### PR TITLE
Add roots to verbs

### DIFF
--- a/he_htb-ud-dev.conllu
+++ b/he_htb-ud-dev.conllu
@@ -74,7 +74,7 @@
 12	טענה	טען	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ט.ע.נ|Tense=Past|Voice=Act	0	root	_	_
 13	כי	כי	SCONJ	SCONJ	_	15	mark	_	_
 14	"	"	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
-15	מביאים	הביא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	12	ccomp	_	_
+15	מביאים	הביא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ב.ו.א|VerbForm=Part|Voice=Act	12	ccomp	_	_
 16	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	15	obj	_	_
 17	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	16	amod	_	_
 18-19	לישראל	_	_	_	_	_	_	_	_
@@ -2312,7 +2312,7 @@
 73	"	"	PUNCT	PUNCT	_	84	punct	_	SpaceAfter=No
 74-75	המגדל	_	_	_	_	_	_	_	_
 74	ה	ה	SCONJ	SCONJ	_	75	mark	_	_
-75	מגדל	גידל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	84	csubj	_	_
+75	מגדל	גידל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ג.ד.ל|VerbForm=Part|Voice=Act	84	csubj	_	_
 76	נחש	נחש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	75	obj	_	_
 77	שפיפון	שפיפון	NOUN	NOUN	Gender=Masc|Number=Sing	76	compound:smixut	_	_
 78-81	בביתו	_	_	_	_	_	_	_	SpaceAfter=No
@@ -2384,7 +2384,7 @@
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	כותרת	כותרת	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
 9	"	"	PUNCT	PUNCT	_	10	punct	_	SpaceAfter=No
-10	יחדל	חדל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	8	appos	_	_
+10	יחדל	חדל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ד.ל|Tense=Fut|Voice=Act	8	appos	_	_
 11	נא	נא	INTJ	INTJ	_	10	discourse	_	_
 12	מילוא	מילוא	NOUN	NOUN	Gender=Masc|Number=Sing	10	nsubj	_	_
 13	להתלבט	התלבט	VERB	VERB	HebBinyan=HITPAEL|Root=ל.ב.ט|VerbForm=Inf	10	xcomp	_	SpaceAfter=No
@@ -2977,7 +2977,7 @@
 8	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
 9	,	,	PUNCT	PUNCT	_	6	punct	_	_
 10	"	"	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
-11	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	3	dep	_	_
+11	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|Root=ד.ב.ר|VerbForm=Part|Voice=Pass	3	dep	_	_
 12	פה	פה	ADV	ADV	_	11	advmod	_	_
 13-14	בתוקפנות	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	14	case	_	_
@@ -3371,7 +3371,7 @@
 17	מלים	מילה	NOUN	NOUN	Gender=Fem|Number=Plur	15	nsubj	_	_
 18	:	:	PUNCT	PUNCT	_	20	punct	_	_
 19	"	"	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
-20	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Voice=Act	17	appos	_	_
+20	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Root=ק.ר.א|Voice=Act	17	appos	_	_
 21	את	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 22	שפתיי	שפתיי	NOUN	NOUN	_	20	obj	_	SpaceAfter=No
 23	,	,	PUNCT	PUNCT	_	20	punct	_	_
@@ -3397,7 +3397,7 @@
 # sent_id = 94
 # text = "קרא את שפתיי..." היא פאראפראזה על סיסמת הבחירות הכוזבת של הנשיא מ8891, "קראו את שפתיי לא יהיו מסים חדשים".
 1	"	"	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
-2	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Voice=Act	8	nsubj:cop	_	_
+2	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Root=ק.ר.א|Voice=Act	8	nsubj:cop	_	_
 3	את	את	ADP	ADP	Case=Acc	4	case:acc	_	_
 4	שפתיי	שפתיי	NOUN	NOUN	_	2	obj	_	SpaceAfter=No
 5	...	...	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
@@ -3421,7 +3421,7 @@
 19	8891	8891	NUM	NUM	_	10	nmod	_	_
 20	,	,	PUNCT	PUNCT	_	10	punct	_	_
 21	"	"	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
-22	קראו	קרא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Voice=Act	10	appos	_	_
+22	קראו	קרא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Root=ק.ר.א|Voice=Act	10	appos	_	_
 23	את	את	ADP	ADP	Case=Acc	24	case:acc	_	_
 24	שפתיי	שפתיי	NOUN	NOUN	_	22	obj	_	_
 25	לא	לא	ADV	ADV	Polarity=Neg	26	advmod	_	_
@@ -5824,7 +5824,7 @@
 12	מחקר	מחקר	NOUN	NOUN	Gender=Masc|Number=Sing	11	compound:smixut	_	SpaceAfter=No
 13	,	,	PUNCT	PUNCT	_	11	punct	_	_
 14	(	(	PUNCT	PUNCT	_	16	punct	_	SpaceAfter=No
-15	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	16	case	_	_
+15	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	16	case	_	_
 16	צוותות	צוות	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	appos	_	_
 17	חשיבה	חשיבה	NOUN	NOUN	Gender=Fem|Number=Sing	16	compound:smixut	_	SpaceAfter=No
 18	)	)	PUNCT	PUNCT	_	16	punct	_	SpaceAfter=No
@@ -8213,7 +8213,7 @@
 25	,	,	PUNCT	PUNCT	_	18	punct	_	_
 26	כדי	כדי	ADP	ADP	_	28	case	_	_
 27	"	"	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
-28	לשרטט	שרטט	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	18	advcl	_	_
+28	לשרטט	שרטט	VERB	VERB	HebBinyan=PIEL|Root=ש.ר.ט.ט|VerbForm=Inf|Voice=Act	18	advcl	_	_
 29	את	את	ADP	ADP	Case=Acc	30	case:acc	_	_
 30	מסלול	מסלול	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	28	obj	_	_
 31-32	המורשת	_	_	_	_	_	_	_	_
@@ -9924,7 +9924,7 @@
 5	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	8	parataxis	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	5	punct	_	_
 7	"	"	PUNCT	PUNCT	_	8	punct	_	SpaceAfter=No
-8	מתרעמים	התרעם	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	0	root	_	_
+8	מתרעמים	התרעם	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ר.ע.מ|VerbForm=Part	0	root	_	_
 9	על	על	ADP	ADP	_	10	case	_	_
 10	עצם	עצם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	8	obl	_	_
 11-12	השאלה	_	_	_	_	_	_	_	_
@@ -15124,7 +15124,7 @@
 25	"	"	PUNCT	PUNCT	_	21	punct	_	SpaceAfter=No
 26	,	,	PUNCT	PUNCT	_	14	punct	_	_
 27	"	"	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
-28	רוצים	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	14	dep	_	_
+28	רוצים	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|Root=ר.צ.י|VerbForm=Part|Voice=Act	14	dep	_	_
 29	נקמה	נקמה	NOUN	NOUN	Gender=Fem|Number=Sing	28	obj	_	SpaceAfter=No
 30	"	"	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 31	.	.	PUNCT	PUNCT	_	14	punct	_	_

--- a/he_htb-ud-dev.conllu
+++ b/he_htb-ud-dev.conllu
@@ -2,7 +2,7 @@
 # text = עשרות אנשים מגיעים מתאילנד לישראל כשהם נרשמים כמתנדבים, אך למעשה משמשים עובדים שכירים זולים.
 1	עשרות	עשרות	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	2	nummod	_	_
 2	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
-3	מגיעים	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+3	מגיעים	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=נ.ג.ע|VerbForm=Part|Voice=Act	0	root	_	_
 4-5	מתאילנד	_	_	_	_	_	_	_	_
 4	מ	מ	ADP	ADP	_	5	case	_	_
 5	תאילנד	תאילנד	PROPN	PROPN	_	3	obl	_	_
@@ -12,14 +12,14 @@
 8-9	כשהם	_	_	_	_	_	_	_	_
 8	כש	כש	SCONJ	SCONJ	Case=Tem	10	mark	_	_
 9	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	10	nsubj	_	_
-10	נרשמים	נרשם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	3	advcl	_	_
+10	נרשמים	נרשם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=ר.ש.מ|VerbForm=Part|Voice=Mid	3	advcl	_	_
 11-12	כמתנדבים	_	_	_	_	_	_	_	SpaceAfter=No
 11	כ	כ	ADP	ADP	_	12	case	_	_
 12	מתנדבים	מתנדב	NOUN	NOUN	Gender=Masc|Number=Plur	10	obl	_	_
 13	,	,	PUNCT	PUNCT	_	10	punct	_	_
 14	אך	אך	CCONJ	CCONJ	_	16	cc	_	_
 15	למעשה	למעשה	ADV	ADV	_	16	advmod	_	_
-16	משמשים	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	10	conj	_	_
+16	משמשים	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ש.מ.ש|VerbForm=Part|Voice=Act	10	conj	_	_
 17	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	16	obj	_	_
 18	שכירים	שכיר	ADJ	ADJ	Gender=Masc|Number=Plur	17	amod	_	_
 19	זולים	זול	ADJ	ADJ	Gender=Masc|Number=Plur	17	amod	_	SpaceAfter=No
@@ -29,7 +29,7 @@
 # text = תופעה זו התבררה אתמול בוועדת העבודה והרווחה של הכנסת, שדנה בנושא העסקת עובדים זרים.
 1	תופעה	תופעה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
 2	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	1	det	_	_
-3	התבררה	התברר	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	התבררה	התברר	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ב.ר.ר|Tense=Past	0	root	_	_
 4	אתמול	אתמול	ADV	ADV	_	3	advmod	_	_
 5-6	בוועדת	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
@@ -48,7 +48,7 @@
 15	,	,	PUNCT	PUNCT	_	6	punct	_	_
 16-17	שדנה	_	_	_	_	_	_	_	_
 16	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
-17	דנה	דן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	acl:relcl	_	_
+17	דנה	דן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ד.ו.נ|Tense=Past|Voice=Act	6	acl:relcl	_	_
 18-19	בנושא	_	_	_	_	_	_	_	_
 18	ב	ב	ADP	ADP	_	19	case	_	_
 19	נושא	נושא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	17	obl	_	_
@@ -71,7 +71,7 @@
 9	מערך	מערך	PROPN	PROPN	_	5	appos	_	SpaceAfter=No
 10	)	)	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	1	punct	_	_
-12	טענה	טען	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+12	טענה	טען	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ט.ע.נ|Tense=Past|Voice=Act	0	root	_	_
 13	כי	כי	SCONJ	SCONJ	_	15	mark	_	_
 14	"	"	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
 15	מביאים	הביא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	12	ccomp	_	_
@@ -91,7 +91,7 @@
 27	רק	רק	ADV	ADV	_	28	advmod	_	_
 28	כדי	כדי	ADP	ADP	_	30	case	_	_
 29	לא	לא	ADV	ADV	Polarity=Neg	30	advmod	_	_
-30	לשלם	שילם	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	15	advcl	_	_
+30	לשלם	שילם	VERB	VERB	HebBinyan=PIEL|Root=ש.ל.מ|VerbForm=Inf|Voice=Act	15	advcl	_	_
 31-32	להם	_	_	_	_	_	_	_	_
 31	ל_	ל	ADP	ADP	_	32	case	_	_
 32	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	30	obl	_	_
@@ -105,11 +105,11 @@
 1	מ	מ	ADP	ADP	_	2	case	_	_
 2	צד	צד	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 3	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	2	amod	_	_
-4	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+4	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.צ.י|VerbForm=Part|Voice=Act	0	root	_	_
 5-6	האוצר	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	אוצר	אוצר	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
-7	להוריד	הוריד	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	4	xcomp	_	_
+7	להוריד	הוריד	VERB	VERB	HebBinyan=HIFIL|Root=י.ר.ד|VerbForm=Inf|Voice=Act	4	xcomp	_	_
 8	את	את	ADP	ADP	Case=Acc	9	case:acc	_	_
 9	שכר	שכר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obj	_	_
 10-11	המינימום	_	_	_	_	_	_	_	SpaceAfter=No
@@ -121,7 +121,7 @@
 14	מ	מ	ADP	ADP	_	15	case	_	_
 15	צד	צד	NOUN	NOUN	Gender=Masc|Number=Sing	17	obl	_	_
 16	שני	שני	NUM	NUM	Gender=Masc|Number=Sing	15	amod	_	_
-17	מתיר	התיר	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	4	conj	_	_
+17	מתיר	התיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=נ.ת.ר|VerbForm=Part	4	conj	_	_
 18	משרד	משרד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	17	nsubj	_	_
 19-20	העבודה	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
@@ -130,7 +130,7 @@
 21	ו	ו	CCONJ	CCONJ	_	23	cc	_	_
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
 23	רווחה	רווחה	NOUN	NOUN	Gender=Fem|Number=Sing	20	conj	_	_
-24	להעסיק	העסיק	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	17	xcomp	_	_
+24	להעסיק	העסיק	VERB	VERB	HebBinyan=HIFIL|Root=ע.ס.ק|VerbForm=Inf|Voice=Act	17	xcomp	_	_
 25	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	24	obj	_	_
 26	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	25	amod	_	_
 27-28	בפחות	_	_	_	_	_	_	_	_
@@ -146,9 +146,9 @@
 # sent_id = 5
 # text = נמיר הודיעה כי תפנה לשרי הפנים והעבודה והרווחה ולמזכיר תנועת המושבים, בתביעה לבטל את הזמנתם של 500 עובדים זרים מתאילנד כמתנדבים כביכול.
 1	נמיר	נמיר	PROPN	PROPN	_	2	nsubj	_	_
-2	הודיעה	הודיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	הודיעה	הודיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ד.ע|Tense=Past|Voice=Act	0	root	_	_
 3	כי	כי	SCONJ	SCONJ	_	4	mark	_	_
-4	תפנה	פנה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Fut	2	ccomp	_	_
+4	תפנה	פנה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.נ.י|Tense=Fut	2	ccomp	_	_
 5-6	לשרי	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	שרי	שר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	obl	_	_
@@ -175,7 +175,7 @@
 22-23	בתביעה	_	_	_	_	_	_	_	_
 22	ב	ב	ADP	ADP	_	23	case	_	_
 23	תביעה	תביעה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
-24	לבטל	ביטל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	23	acl	_	_
+24	לבטל	ביטל	VERB	VERB	HebBinyan=PIEL|Root=ב.ט.ל|VerbForm=Inf|Voice=Act	23	acl	_	_
 25	את	את	ADP	ADP	Case=Acc	26	case:acc	_	_
 26-28	הזמנתם	_	_	_	_	_	_	_	_
 26	הזמנה_	הזמנה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	24	obj	_	_
@@ -197,12 +197,12 @@
 # sent_id = 6
 # text = היא הודיעה כי הוועדה תגבש הצעת חוק בנושא העובדים הזרים, שתכלול איסור על מתן שכר לעובדים מתחת לשכר המינימום ומתן התנאים הסוציאליים המקובלים במקום העבודה.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	הודיעה	הודיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	הודיעה	הודיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ד.ע|Tense=Past|Voice=Act	0	root	_	_
 3	כי	כי	SCONJ	SCONJ	_	6	mark	_	_
 4-5	הוועדה	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	וועדה	ועדה	NOUN	NOUN	Gender=Fem|Number=Sing	6	nsubj	_	_
-6	תגבש	גיבש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	2	ccomp	_	_
+6	תגבש	גיבש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ג.ב.ש|Tense=Fut|Voice=Act	2	ccomp	_	_
 7	הצעת	הצעה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	obj	_	_
 8	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	7	compound:smixut	_	_
 9-10	בנושא	_	_	_	_	_	_	_	_
@@ -217,7 +217,7 @@
 15	,	,	PUNCT	PUNCT	_	7	punct	_	_
 16-17	שתכלול	_	_	_	_	_	_	_	_
 16	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
-17	תכלול	כלל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	7	acl:relcl	_	_
+17	תכלול	כלל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ל.ל|Tense=Fut|Voice=Act	7	acl:relcl	_	_
 18	איסור	איסור	NOUN	NOUN	Gender=Masc|Number=Sing	17	obj	_	_
 19	על	על	ADP	ADP	_	20	case	_	_
 20	מתן	מתן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	18	nmod	_	_
@@ -258,7 +258,7 @@
 1	כמו	כמו	ADP	ADP	_	2	case	_	_
 2	כן	_	PRON	PRON	Person=3|PronType=Dem	4	obl	_	SpaceAfter=No
 3	,	,	PUNCT	PUNCT	_	4	punct	_	_
-4	תציב	הציב	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+4	תציב	הציב	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.צ.ב|Tense=Fut|Voice=Act	0	root	_	_
 5	הצעת	הצעה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	nsubj	_	_
 6-7	החוק	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -275,7 +275,7 @@
 15	מי	מי	ADV	ADV	PronType=Int	8	nmod	_	_
 16-17	שיעסיק	_	_	_	_	_	_	_	_
 16	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
-17	יעסיק	העסיק	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	15	acl:relcl	_	_
+17	יעסיק	העסיק	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ע.ס.ק|Tense=Fut|Voice=Act	15	acl:relcl	_	_
 18	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	17	obj	_	_
 19	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	18	amod	_	_
 20	בלא	בלא	ADP	ADP	_	21	case	_	_
@@ -289,7 +289,7 @@
 3	,	,	PUNCT	PUNCT	_	1	punct	_	_
 4-5	הממונה	_	_	_	_	_	_	_	_
 4	ה	ה	SCONJ	SCONJ	_	5	mark	_	_
-5	ממונה	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	1	acl:relcl	_	_
+5	ממונה	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=מ.נ.י|VerbForm=Part|Voice=Pass	1	acl:relcl	_	_
 6	על	על	ADP	ADP	_	7	case	_	_
 7	מתן	מתן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
 8	היתרי	היתר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	7	compound:smixut	_	_
@@ -304,21 +304,21 @@
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	תעסוקה	תעסוקה	NOUN	NOUN	Gender=Fem|Number=Sing	13	compound:smixut	_	_
 16	,	,	PUNCT	PUNCT	_	17	punct	_	_
-17	מסרה	מסר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+17	מסרה	מסר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.ס.ר|Tense=Past|Voice=Act	0	root	_	_
 18	כי	כי	SCONJ	SCONJ	_	22	mark	_	_
 19	תנועת	תנועה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	22	nsubj	_	_
 20-21	המושבים	_	_	_	_	_	_	_	_
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	מושבים	מושב	NOUN	NOUN	Gender=Masc|Number=Plur	19	compound:smixut	_	_
-22	הפעילה	הפעיל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	17	ccomp	_	_
+22	הפעילה	הפעיל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=פ.ע.ל|Tense=Past|Voice=Act	17	ccomp	_	_
 23	לחץ	לחץ	NOUN	NOUN	Gender=Masc|Number=Sing	22	obj	_	_
 24-25	שיותר	_	_	_	_	_	_	_	_
 24	ש	ש	SCONJ	SCONJ	_	25	mark	_	_
-25	יותר	הותר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	23	acl:relcl	_	_
+25	יותר	הותר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=נ.ת.ר|Tense=Fut	23	acl:relcl	_	_
 26-27	לה	_	_	_	_	_	_	_	_
 26	ל_	ל	ADP	ADP	_	27	case	_	_
 27	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	25	obl	_	_
-28	להביא	הביא	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	25	xcomp	_	_
+28	להביא	הביא	VERB	VERB	HebBinyan=HIFIL|Root=ב.ו.א|VerbForm=Inf|Voice=Act	25	xcomp	_	_
 29	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	28	obj	_	_
 30	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	29	amod	_	_
 31-32	מתאילנד	_	_	_	_	_	_	_	SpaceAfter=No
@@ -329,14 +329,14 @@
 # sent_id = 9
 # text = היא אמרה כי שירות התעסוקה הציע להביא עובדים מדרום לבנון, אך תנועת המושבים סירבה.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 3	כי	כי	SCONJ	SCONJ	_	7	mark	_	_
 4	שירות	שירות	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	nsubj	_	_
 5-6	התעסוקה	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	תעסוקה	תעסוקה	NOUN	NOUN	Gender=Fem|Number=Sing	4	compound:smixut	_	_
-7	הציע	הציע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	ccomp	_	_
-8	להביא	הביא	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	7	xcomp	_	_
+7	הציע	הציע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.צ.ע|Tense=Past|Voice=Act	2	ccomp	_	_
+8	להביא	הביא	VERB	VERB	HebBinyan=HIFIL|Root=ב.ו.א|VerbForm=Inf|Voice=Act	7	xcomp	_	_
 9	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	8	obj	_	_
 10-11	מדרום	_	_	_	_	_	_	_	_
 10	מ	מ	ADP	ADP	_	11	case	_	_
@@ -348,7 +348,7 @@
 16-17	המושבים	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	מושבים	מושב	NOUN	NOUN	Gender=Masc|Number=Plur	15	compound:smixut	_	_
-18	סירבה	סירב	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	7	conj	_	SpaceAfter=No
+18	סירבה	סירב	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ס.ר.ב|Tense=Past|Voice=Act	7	conj	_	SpaceAfter=No
 19	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 10
@@ -364,9 +364,9 @@
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
 9	,	,	PUNCT	PUNCT	_	10	punct	_	_
-10	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+10	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 11	כי	כי	SCONJ	SCONJ	_	24	mark	_	_
-12	ממלא	מילא	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	24	nsubj	_	_
+12	ממלא	מילא	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=מ.ל.א|VerbForm=Part|Voice=Act	24	nsubj	_	_
 13	מקום	מקום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	compound:smixut	_	_
 14	שר	שר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	13	compound:smixut	_	_
 15-16	העבודה	_	_	_	_	_	_	_	_
@@ -380,7 +380,7 @@
 21	דוד	דוד	PROPN	PROPN	_	12	appos	_	_
 22	מגן	מגן	PROPN	PROPN	_	21	flat:name	_	SpaceAfter=No
 23	,	,	PUNCT	PUNCT	_	12	punct	_	_
-24	הקים	הקים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	ccomp	_	_
+24	הקים	הקים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ק.ו.מ|Tense=Past|Voice=Act	10	ccomp	_	_
 25	ועדה	ועדה	NOUN	NOUN	Gender=Fem|Number=Sing	24	obj	_	_
 26	בין	בין	ADV	ADV	Prefix=Yes	28	compound:affix	_	SpaceAfter=No
 27	-	-	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
@@ -388,8 +388,8 @@
 29	,	,	PUNCT	PUNCT	_	25	punct	_	_
 30-31	שהמליצה	_	_	_	_	_	_	_	_
 30	ש	ש	SCONJ	SCONJ	_	31	mark	_	_
-31	המליצה	המליץ	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	25	acl:relcl	_	_
-32	להגדיל	הגדיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	31	xcomp	_	_
+31	המליצה	המליץ	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=מ.ל.צ|Tense=Past|Voice=Act	25	acl:relcl	_	_
+32	להגדיל	הגדיל	VERB	VERB	HebBinyan=HIFIL|Root=ג.ד.ל|VerbForm=Inf|Voice=Act	31	xcomp	_	_
 33-34	באופן	_	_	_	_	_	_	_	_
 33	ב	ב	ADP	ADP	_	34	case	_	_
 34	אופן	אופן	NOUN	NOUN	Gender=Masc|Number=Sing	32	obl	_	_
@@ -412,14 +412,14 @@
 4	(	(	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
 5	מערך	מערך	PROPN	PROPN	_	1	appos	_	SpaceAfter=No
 6	)	)	PUNCT	PUNCT	_	5	punct	_	_
-7	הגיש	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	הגיש	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Act	0	root	_	_
 8	הצעת	הצעה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	obj	_	_
 9	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	_
 10-12	שלפיה	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
 11	לפי_	לפי	ADP	ADP	_	12	case	_	_
 12	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	13	obl	_	_
-13	יוטל	הוטל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	8	acl:relcl	_	_
+13	יוטל	הוטל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=נ.ט.ל|Tense=Fut|Voice=Pass	8	acl:relcl	_	_
 14	היטל	היטל	NOUN	NOUN	Gender=Masc|Number=Sing	13	nsubj	_	_
 15	על	על	ADP	ADP	_	16	case	_	_
 16	מעסיקי	מעסיק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	13	obl	_	_
@@ -427,7 +427,7 @@
 18	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	17	amod	_	SpaceAfter=No
 19	,	,	PUNCT	PUNCT	_	7	punct	_	_
 20	כדי	כדי	ADP	ADP	_	21	case	_	_
-21	למנוע	מנע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	advcl	_	_
+21	למנוע	מנע	VERB	VERB	HebBinyan=PAAL|Root=מ.נ.ע|VerbForm=Inf|Voice=Act	7	advcl	_	_
 22-24	העדפתם	_	_	_	_	_	_	_	_
 22	העדפה_	העדפה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	21	obj	_	_
 23	_של_	של	ADP	ADP	_	24	case:gen	_	_
@@ -442,10 +442,10 @@
 1	חברות	חברה	NOUN	NOUN	Gender=Fem|Number=Plur	6	nsubj	_	_
 2-3	המעסיקות	_	_	_	_	_	_	_	_
 2	ה	ה	SCONJ	SCONJ	_	3	mark	_	_
-3	מעסיקות	העסיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
+3	מעסיקות	העסיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ע.ס.ק|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
 4	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	3	obj	_	_
 5	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	4	amod	_	_
-6	זוכות	זכה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+6	זוכות	זכה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ז.כ.י|VerbForm=Part|Voice=Act	0	root	_	_
 7-8	במכרזים	_	_	_	_	_	_	_	SpaceAfter=No
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	מכרזים	מכרז	NOUN	NOUN	Gender=Masc|Number=Plur	6	obl	_	_
@@ -454,7 +454,7 @@
 11-12	והן	_	_	_	_	_	_	_	_
 11	ו	ו	CCONJ	CCONJ	HebSource=ConvUncertainHead	10	fixed	_	_
 12	הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	13	nsubj	_	_
-13	מציעות	הציע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	6	advcl	_	_
+13	מציעות	הציע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|Root=י.צ.ע|VerbForm=Part|Voice=Act	6	advcl	_	_
 14	שירותים	שירות	NOUN	NOUN	Gender=Masc|Number=Plur	13	obj	_	_
 15	זולים	זול	ADJ	ADJ	Gender=Masc|Number=Plur	14	amod	_	_
 16	יותר	יותר	ADV	ADV	_	15	advmod	_	SpaceAfter=No
@@ -468,13 +468,13 @@
 4	(	(	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
 5	רץ	רצ	PROPN	PROPN	_	1	appos	_	SpaceAfter=No
 6	)	)	PUNCT	PUNCT	_	5	punct	_	_
-7	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 8	כי	כי	SCONJ	SCONJ	_	11	mark	_	_
 9	על	על	ADP	ADP	_	11	case	_	_
 10-11	הוועדה	_	_	_	_	_	_	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	וועדה	ועדה	NOUN	NOUN	Gender=Fem|Number=Sing	7	ccomp	_	_
-12	לפנות	פנה	VERB	VERB	VerbForm=Inf	11	xcomp	_	_
+12	לפנות	פנה	VERB	VERB	HebBinyan=PAAL|Root=פ.נ.י|VerbForm=Inf	11	xcomp	_	_
 13-15	לממשלה	_	_	_	_	_	_	_	_
 13	ל	ל	ADP	ADP	_	15	case	_	_
 14	ה_	ה	DET	DET	PronType=Art	15	det:def	_	_
@@ -482,7 +482,7 @@
 16-17	בדרישה	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	דרישה	דרישה	NOUN	NOUN	Gender=Fem|Number=Sing	12	obl	_	_
-18	לחסל	חיסל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	17	acl	_	_
+18	לחסל	חיסל	VERB	VERB	HebBinyan=PIEL|Root=ח.ס.ל|VerbForm=Inf|Voice=Act	17	acl	_	_
 19	את	את	ADP	ADP	Case=Acc	20	case:acc	_	_
 20	העסקת	העסקה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	18	obj	_	_
 21-22	העובדים	_	_	_	_	_	_	_	_
@@ -502,7 +502,7 @@
 32-33	המוכנים	_	_	_	_	_	_	_	_
 32	ה	ה	SCONJ	SCONJ	_	33	mark	_	_
 33	מוכנים	מוכן	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbType=Mod	34	aux	_	_
-34	לעבוד	עבד	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	31	acl:relcl	_	_
+34	לעבוד	עבד	VERB	VERB	HebBinyan=PAAL|Root=ע.ב.ד|VerbForm=Inf|Voice=Act	31	acl:relcl	_	_
 35-36	בכל	_	_	_	_	_	_	_	_
 35	ב	ב	ADP	ADP	_	37	case	_	_
 36	כל	כול	DET	DET	Definite=Cons	37	det	_	_
@@ -524,7 +524,7 @@
 4	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nmod:poss	_	_
 5	,	,	PUNCT	PUNCT	_	6	punct	_	_
 6	יש	יש	AUX	AUX	VerbType=Mod	7	aux	_	_
-7	לפנות	פנה	VERB	VERB	VerbForm=Inf	0	root	_	_
+7	לפנות	פנה	VERB	VERB	HebBinyan=PAAL|Root=פ.נ.י|VerbForm=Inf	0	root	_	_
 8-9	למשרד	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	משרד	משרד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obl	_	_
@@ -538,7 +538,7 @@
 15-16	בדרישה	_	_	_	_	_	_	_	_
 15	ב	ב	ADP	ADP	_	16	case	_	_
 16	דרישה	דרישה	NOUN	NOUN	Gender=Fem|Number=Sing	7	obl	_	_
-17	לבטל	ביטל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	16	acl	_	_
+17	לבטל	ביטל	VERB	VERB	HebBinyan=PIEL|Root=ב.ט.ל|VerbForm=Inf|Voice=Act	16	acl	_	_
 18	בתוך	בתוך	ADP	ADP	_	19	case	_	_
 19	חודש	חודש	NOUN	NOUN	Gender=Masc|Number=Sing	17	obl	_	_
 20	את	את	ADP	ADP	Case=Acc	21	case:acc	_	_
@@ -551,7 +551,7 @@
 25	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	23	amod	_	_
 26-27	המועסקים	_	_	_	_	_	_	_	_
 26	ה	ה	SCONJ	SCONJ	_	27	mark	_	_
-27	מועסקים	הועסק	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	23	acl:relcl	_	_
+27	מועסקים	הועסק	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ע.ס.ק|VerbForm=Part|Voice=Pass	23	acl:relcl	_	_
 28	כיום	כיום	ADV	ADV	_	27	advmod	_	_
 29	תחת	תחת	ADP	ADP	_	31	case	_	_
 30-31	הכותרת	_	_	_	_	_	_	_	_
@@ -570,7 +570,7 @@
 4	(	(	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
 5	מפם	מפם	PROPN	PROPN	_	1	appos	_	SpaceAfter=No
 6	)	)	PUNCT	PUNCT	_	5	punct	_	_
-7	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 8	כי	כי	SCONJ	SCONJ	_	16	mark	_	_
 9	פרשת	פרשה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	16	nsubj:cop	_	_
 10-11	המתנדבים	_	_	_	_	_	_	_	_
@@ -598,7 +598,7 @@
 1-2	המוח	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	מוח	מוח	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
-3	מתפלץ	התפלץ	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+3	מתפלץ	התפלץ	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=פ.ל.צ|VerbForm=Part	0	root	_	_
 4	לא	לא	ADV	ADV	Polarity=Neg	5	advmod	_	_
 5	רק	רק	ADV	ADV	_	6	advmod	_	_
 6-8	מהתופעה	_	_	_	_	_	_	_	_
@@ -626,7 +626,7 @@
 3-4	היהודי	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	יהודי	יהודי	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-5	ממציא	המציא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	ממציא	המציא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=מ.צ.א|VerbForm=Part|Voice=Act	0	root	_	_
 6-7	לנו	_	_	_	_	_	_	_	_
 6	ל_	ל	ADP	ADP	_	7	case	_	_
 7	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	5	obl	_	_
@@ -638,7 +638,7 @@
 12	,	,	PUNCT	PUNCT	_	11	punct	_	_
 13-14	המשולמים	_	_	_	_	_	_	_	_
 13	ה	ה	SCONJ	SCONJ	_	14	mark	_	_
-14	משולמים	שולם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	11	acl:relcl	_	_
+14	משולמים	שולם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ש.ל.מ|VerbForm=Part|Voice=Pass	11	acl:relcl	_	_
 15	שכר	שכר	NOUN	NOUN	Gender=Masc|Number=Sing	14	obj	_	_
 16	מחפיר	מחפיר	ADJ	ADJ	Gender=Masc|Number=Sing	15	amod	_	SpaceAfter=No
 17	"	"	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
@@ -647,7 +647,7 @@
 # sent_id = 18
 # text = הוא קרא להפסקת התופעה ולמתן תשלומים רטרואקטיוויים לתאילנדים, שישלימו את שכר המינימום.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ר.א|Tense=Past|Voice=Act	0	root	_	_
 3-4	להפסקת	_	_	_	_	_	_	_	_
 3	ל	ל	ADP	ADP	_	4	case	_	_
 4	הפסקת	הפסקה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	2	obl	_	_
@@ -667,7 +667,7 @@
 15	,	,	PUNCT	PUNCT	_	10	punct	_	_
 16-17	שישלימו	_	_	_	_	_	_	_	_
 16	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
-17	ישלימו	השלים	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Fut|Voice=Act	10	acl:relcl	_	_
+17	ישלימו	השלים	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ש.ל.מ|Tense=Fut|Voice=Act	10	acl:relcl	_	_
 18	את	את	ADP	ADP	Case=Acc	19	case:acc	_	_
 19	שכר	שכר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	17	obj	_	_
 20-21	המינימום	_	_	_	_	_	_	_	SpaceAfter=No
@@ -682,7 +682,7 @@
 3-4	התעסוקה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	תעסוקה	תעסוקה	NOUN	NOUN	Gender=Fem|Number=Sing	2	compound:smixut	_	_
-5	מסרה	מסר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	מסרה	מסר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.ס.ר|Tense=Past|Voice=Act	0	root	_	_
 6	אתמול	אתמול	ADV	ADV	_	5	advmod	_	_
 7-8	בתגובה	_	_	_	_	_	_	_	SpaceAfter=No
 7	ב	ב	ADP	ADP	_	8	case	_	_
@@ -692,7 +692,7 @@
 11-12	השירות	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	שירות	שירות	NOUN	NOUN	Gender=Masc|Number=Sing	13	nsubj	_	_
-13	פועל	פעל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	ccomp	_	_
+13	פועל	פעל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=פ.ע.ל|VerbForm=Part|Voice=Act	5	ccomp	_	_
 14-15	לצמצום	_	_	_	_	_	_	_	_
 14	ל	ל	ADP	ADP	_	15	case	_	_
 15	צמצום	צמצום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	13	obl	_	_
@@ -734,7 +734,7 @@
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	אחרונים	אחרון	ADJ	ADJ	Gender=Masc|Number=Plur	7	amod	_	_
 10	,	,	PUNCT	PUNCT	_	11	punct	_	_
-11	צומצם	צומצם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+11	צומצם	צומצם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=צ.מ.צ.מ|Tense=Past|Voice=Pass	0	root	_	_
 12	מספר	מספר	DET	DET	Definite=Cons	14	det	_	_
 13-14	העובדים	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
@@ -762,7 +762,7 @@
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	2	compound:smixut	_	_
 5	לא	לא	ADV	ADV	Polarity=Neg	6	advmod	_	_
-6	תועסק	הועסק	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	0	root	_	_
+6	תועסק	הועסק	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ע.ס.ק|Tense=Fut|Voice=Pass	0	root	_	_
 7-9	בארץ	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -781,17 +781,17 @@
 1-2	הדוברת	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	דוברת	דובר	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 4	כי	כי	SCONJ	SCONJ	_	7	mark	_	_
 5-6	השירות	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	שירות	שירות	NOUN	NOUN	Gender=Masc|Number=Sing	7	nsubj	_	_
-7	קורא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	ccomp	_	_
+7	קורא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ק.ר.א|VerbForm=Part|Voice=Act	3	ccomp	_	_
 8-10	לחקלאים	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	10	case	_	_
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	חקלאים	חקלאי	NOUN	NOUN	Gender=Masc|Number=Plur	7	obl	_	_
-11	לדאוג	דאג	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	xcomp	_	_
+11	לדאוג	דאג	VERB	VERB	HebBinyan=PAAL|Root=ד.א.ג|VerbForm=Inf|Voice=Act	7	xcomp	_	_
 12-13	לעובדים	_	_	_	_	_	_	_	_
 12	ל	ל	ADP	ADP	_	13	case	_	_
 13	עובדים	עובד	NOUN	NOUN	Gender=Masc|Number=Plur	11	obl	_	_
@@ -810,7 +810,7 @@
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	שירות	שירות	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
 4	לא	לא	ADV	ADV	Polarity=Neg	5	advmod	_	_
-5	שינה	שינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	1	conj	_	_
+5	שינה	שינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.נ.י|Tense=Past|Voice=Act	1	conj	_	_
 6	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 7-8	המדיניות	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -828,7 +828,7 @@
 17	להיפך	להיפך	ADV	ADV	_	20	advmod	_	SpaceAfter=No
 18	,	,	PUNCT	PUNCT	_	20	punct	_	_
 19	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nsubj	_	_
-20	הבהיר	הבהיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	conj	_	_
+20	הבהיר	הבהיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ב.ה.ר|Tense=Past|Voice=Act	5	conj	_	_
 21-22	לתנועת	_	_	_	_	_	_	_	_
 21	ל	ל	ADP	ADP	_	22	case	_	_
 22	תנועת	תנועה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	20	obl	_	_
@@ -842,8 +842,8 @@
 28	ישראלי	ישראלי	ADJ	ADJ	Gender=Masc|Number=Sing	27	amod	_	_
 29-30	שיסכים	_	_	_	_	_	_	_	_
 29	ש	ש	SCONJ	SCONJ	_	30	mark	_	_
-30	יסכים	הסכים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	27	acl:relcl	_	_
-31	לעבוד	עבד	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	30	xcomp	_	_
+30	יסכים	הסכים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ס.כ.מ|Tense=Fut|Voice=Act	27	acl:relcl	_	_
+31	לעבוד	עבד	VERB	VERB	HebBinyan=PAAL|Root=ע.ב.ד|VerbForm=Inf|Voice=Act	30	xcomp	_	_
 32-33	בענף	_	_	_	_	_	_	_	_
 32	ב	ב	ADP	ADP	_	33	case	_	_
 33	ענף	ענף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	31	obl	_	_
@@ -851,7 +851,7 @@
 34	ה	ה	DET	DET	PronType=Art	35	det:def	_	_
 35	חקלאות	חקלאות	NOUN	NOUN	Gender=Fem|Number=Sing	33	compound:smixut	_	_
 36	,	,	PUNCT	PUNCT	_	37	punct	_	_
-37	ישובץ	שובץ	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	20	ccomp	_	_
+37	ישובץ	שובץ	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ש.ב.צ|Tense=Fut|Voice=Pass	20	ccomp	_	_
 38-40	לעבודה	_	_	_	_	_	_	_	_
 38	ל	ל	ADP	ADP	_	40	case	_	_
 39	ה_	ה	DET	DET	PronType=Art	40	det:def	_	_
@@ -891,7 +891,7 @@
 24	105	105	NUM	NUM	_	22	nummod	_	SpaceAfter=No
 25	)	)	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
 26	,	,	PUNCT	PUNCT	_	27	punct	_	_
-27	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+27	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ע|Tense=Past|Voice=Act	0	root	_	_
 28-31	לידי	_	_	_	_	_	_	_	_
 28	ל	ל	ADP	ADP	_	29	case	_	_
 29	יד_	יד	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	27	obl	_	_
@@ -909,7 +909,7 @@
 1	למרות	למרות	ADP	ADP	_	3	mark	_	_
 2-3	שחלפו	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	1	fixed	_	_
-3	חלפו	חלף	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	22	advcl	_	_
+3	חלפו	חלף	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ח.ל.פ|Tense=Past|Voice=Act	22	advcl	_	_
 4	מאז	מאז	ADV	ADV	_	3	advmod	_	_
 5	24	24	NUM	NUM	_	6	nummod	_	_
 6	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	SpaceAfter=No
@@ -923,14 +923,14 @@
 12	ימים	יום	NOUN	NOUN	Gender=Masc|Number=Plur	11	compound:smixut	_	_
 13	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	12	det	_	_
 14	אולי	אולי	ADV	ADV	_	15	advmod	_	_
-15	מאפילים	האפיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	3	conj	_	_
+15	מאפילים	האפיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=א.פ.ל|VerbForm=Part|Voice=Act	3	conj	_	_
 16	על	על	ADP	ADP	_	18	case	_	_
 17	כל	כול	DET	DET	Definite=Cons	18	det	_	_
 18	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	15	obl	_	_
 19	אחר	אחר	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	SpaceAfter=No
 20	,	,	PUNCT	PUNCT	_	22	punct	_	_
 21	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	22	nsubj	_	_
-22	מרגיש	הרגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+22	מרגיש	הרגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ר.ג.ש|VerbForm=Part|Voice=Act	0	root	_	_
 23	חובה	חובה	NOUN	NOUN	Gender=Fem|Number=Sing	22	obj	_	_
 24-27	בשמם	_	_	_	_	_	_	_	_
 24	ב	ב	ADP	ADP	_	25	case	_	_
@@ -963,7 +963,7 @@
 44	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	42	acl:relcl	_	_
 45	שם	שם	ADV	ADV	_	44	advmod	_	SpaceAfter=No
 46	,	,	PUNCT	PUNCT	_	42	punct	_	_
-47	להתייחס	התייחס	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	23	acl	_	_
+47	להתייחס	התייחס	VERB	VERB	HebBinyan=HITPAEL|Root=י.ח.ס|VerbForm=Inf	23	acl	_	_
 48-50	למאמר	_	_	_	_	_	_	_	SpaceAfter=No
 48	ל	ל	ADP	ADP	_	50	case	_	_
 49	ה_	ה	DET	DET	PronType=Art	50	det:def	_	_
@@ -978,7 +978,7 @@
 3	מאמר	מאמר	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
 4-5	העוסקים	_	_	_	_	_	_	_	_
 4	ה	ה	SCONJ	SCONJ	_	5	mark	_	_
-5	עוסקים	עסק	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
+5	עוסקים	עסק	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ע.ס.ק|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
 6-8	בקרב	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -992,9 +992,9 @@
 14-15	אליהם	_	_	_	_	_	_	_	_
 14	אל_	אל	ADP	ADP	_	15	case	_	_
 15	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	16	obl	_	_
-16	אתייחס	התייחס	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Sing|Person=1|Tense=Fut	5	conj	_	SpaceAfter=No
+16	אתייחס	התייחס	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Sing|Person=1|Root=י.ח.ס|Tense=Fut	5	conj	_	SpaceAfter=No
 17	,	,	PUNCT	PUNCT	_	18	punct	_	_
-18	מאופיינים	אופיין	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+18	מאופיינים	אופיין	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=א.פ.י.נ|VerbForm=Part|Voice=Pass	0	root	_	_
 19-20	בחוסר	_	_	_	_	_	_	_	_
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	חוסר	חוסר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	18	obl	_	_
@@ -1007,7 +1007,7 @@
 26	,	,	PUNCT	PUNCT	_	18	punct	_	_
 27-28	ומעידים	_	_	_	_	_	_	_	_
 27	ו	ו	CCONJ	CCONJ	_	28	cc	_	_
-28	מעידים	העיד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	18	conj	_	_
+28	מעידים	העיד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ע.ו.ד|VerbForm=Part|Voice=Act	18	conj	_	_
 29	על	על	ADP	ADP	_	31	case	_	_
 30-31	הכותב	_	_	_	_	_	_	_	_
 30	ה	ה	DET	DET	PronType=Art	31	det:def	_	_
@@ -1056,7 +1056,7 @@
 22	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	20	parataxis	_	SpaceAfter=No
 23	"	"	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 24	,	,	PUNCT	PUNCT	_	25	punct	_	_
-25	מרמזת	רימז	VERB	VERB	Gender=Fem|HebBinyan=PIEL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	dep	_	_
+25	מרמזת	רימז	VERB	VERB	Gender=Fem|HebBinyan=PIEL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|Root=ר.מ.ז|VerbForm=Part|Voice=Act	2	dep	_	_
 26	כי	כי	SCONJ	SCONJ	_	27	mark	_	_
 27	ייתכן	ייתכן	AUX	AUX	VerbType=Mod	25	ccomp	_	_
 28-31	שבמנזר	_	_	_	_	_	_	_	_
@@ -1066,7 +1066,7 @@
 31	מנזר	מנזר	NOUN	NOUN	Gender=Masc|Number=Sing	34	obl	_	_
 32	כלל	כלל	ADV	ADV	_	33	advmod	_	_
 33	לא	לא	ADV	ADV	Polarity=Neg	34	advmod	_	_
-34	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	27	advcl	_	_
+34	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=נ.ה.ל|Tense=Past	27	advcl	_	_
 35	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	34	nsubj	_	SpaceAfter=No
 36	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
@@ -1078,10 +1078,10 @@
 3	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	15	obl	_	_
 4-5	המתרשמים	_	_	_	_	_	_	_	_
 4	ה	ה	SCONJ	SCONJ	_	5	mark	_	_
-5	מתרשמים	התרשם	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	3	acl:relcl	_	_
+5	מתרשמים	התרשם	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ר.ש.מ|VerbForm=Part	3	acl:relcl	_	_
 6-7	ומסתפקים	_	_	_	_	_	_	_	_
 6	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
-7	מסתפקים	הסתפק	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	5	conj	_	_
+7	מסתפקים	הסתפק	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ס.פ.ק|VerbForm=Part	5	conj	_	_
 8-9	בקריאת	_	_	_	_	_	_	_	_
 8	ב	ב	ADP	ADP	_	9	case	_	_
 9	קריאת	קריאה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	5	obl	_	_
@@ -1092,11 +1092,11 @@
 13	,	,	PUNCT	PUNCT	_	15	punct	_	_
 14	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	15	nsubj	_	_
 15	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	16	aux	_	_
-16	להבטיח	הבטיח	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+16	להבטיח	הבטיח	VERB	VERB	HebBinyan=HIFIL|Root=ב.ט.ח|VerbForm=Inf|Voice=Act	0	root	_	_
 17-18	שאכן	_	_	_	_	_	_	_	_
 17	ש	ש	SCONJ	SCONJ	_	19	mark	_	_
 18	אכן	אכן	ADV	ADV	_	19	advmod	_	_
-19	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	16	ccomp	_	_
+19	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=נ.ה.ל|Tense=Past	16	ccomp	_	_
 20	שם	שם	ADV	ADV	_	19	advmod	_	_
 21	קרב	קרב	NOUN	NOUN	Gender=Masc|Number=Sing	19	nsubj	_	SpaceAfter=No
 22	,	,	PUNCT	PUNCT	_	19	punct	_	_
@@ -1125,29 +1125,29 @@
 1	ו	ו	CCONJ	CCONJ	_	8	cc	_	_
 2	על	על	ADP	ADP	_	3	case	_	_
 3	כך	כך	PRON	PRON	Person=3|PronType=Dem	4	obl	_	_
-4	תעיד	העיד	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+4	תעיד	העיד	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ע.ו.ד|Tense=Fut|Voice=Act	0	root	_	_
 5-6	ההיסטוריה	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	היסטוריה	היסטוריה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 7	,	,	PUNCT	PUNCT	_	4	punct	_	_
 8-9	ויעידו	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
-9	יעידו	העיד	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Fut|Voice=Act	4	conj	_	_
+9	יעידו	העיד	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ע.ו.ד|Tense=Fut|Voice=Act	4	conj	_	_
 10	עשרות	עשרות	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	12	nummod	_	_
 11-12	הלוחמים	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	לוחמים	לוחם	NOUN	NOUN	Gender=Masc|Number=Plur	9	nsubj	_	_
 13-14	שנשארו	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
-14	נשארו	נשאר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	12	acl:relcl	_	_
+14	נשארו	נשאר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ש.א.ר|Tense=Past|Voice=Mid	12	acl:relcl	_	_
 15-17	בחיים	_	_	_	_	_	_	_	_
 15	ב	ב	ADP	ADP	_	17	case	_	_
 16	ה_	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	חיים	חיים	NOUN	NOUN	Gender=Masc|Number=Plur	14	obl	_	_
 18-19	והצליחו	_	_	_	_	_	_	_	_
 18	ו	ו	CCONJ	CCONJ	_	19	cc	_	_
-19	הצליחו	הצליח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	14	conj	_	_
-20	לבצע	ביצע	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	19	xcomp	_	_
+19	הצליחו	הצליח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=צ.ל.ח|Tense=Past|Voice=Act	14	conj	_	_
+20	לבצע	ביצע	VERB	VERB	HebBinyan=PIEL|Root=ב.צ.ע|VerbForm=Inf|Voice=Act	19	xcomp	_	_
 21	את	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 22-24	משימתם	_	_	_	_	_	_	_	_
 22	משימה_	משימה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	20	obj	_	_
@@ -1179,7 +1179,7 @@
 9	על	על	ADP	ADP	_	10	case	_	_
 10	ירושלים	ירושלים	PROPN	PROPN	_	8	nmod	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	12	punct	_	_
-12	נשארה	נשאר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+12	נשארה	נשאר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.א.ר|Tense=Past|Voice=Mid	0	root	_	_
 13	שכונת	שכונה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	12	nsubj	_	_
 14	קטמון	קטמון	PROPN	PROPN	_	13	compound:smixut	_	_
 15	תקועה	תקוע	ADJ	ADJ	Gender=Fem|Number=Sing	12	xcomp	_	_
@@ -1192,7 +1192,7 @@
 20	מערבית	מערבי	ADJ	ADJ	Gender=Fem|Number=Sing	18	amod	_	_
 21-22	ושימשה	_	_	_	_	_	_	_	_
 21	ו	ו	CCONJ	CCONJ	_	22	cc	_	_
-22	שימשה	שימש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	12	conj	_	_
+22	שימשה	שימש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.מ.ש|Tense=Past|Voice=Act	12	conj	_	_
 23-24	כמרכז	_	_	_	_	_	_	_	_
 23	כ	כ	ADP	ADP	_	24	case	_	_
 24	מרכז	מרכז	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	22	obl	_	_
@@ -1241,7 +1241,7 @@
 26-27	עלינו	_	_	_	_	_	_	_	_
 26	על_	על	ADP	ADP	_	27	case	_	_
 27	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	19	conj	_	_
-28	להשתלט	השתלט	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	27	xcomp	_	_
+28	להשתלט	השתלט	VERB	VERB	HebBinyan=HITPAEL|Root=ש.ל.ט|VerbForm=Inf	27	xcomp	_	_
 29-30	עליו	_	_	_	_	_	_	_	SpaceAfter=No
 29	על_	על	ADP	ADP	_	30	case	_	_
 30	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	28	obl	_	_
@@ -1249,13 +1249,13 @@
 
 # sent_id = 32
 # text = כתוב: "בחוכמה עשה לך מלחמה".
-1	כתוב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
+1	כתוב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ת.ב|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 2	:	:	PUNCT	PUNCT	_	6	punct	_	_
 3	"	"	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 4-5	בחוכמה	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	חוכמה	חוכמה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
-6	עשה	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Voice=Act	1	ccomp	_	_
+6	עשה	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Root=ע.ש.י|Voice=Act	1	ccomp	_	_
 7-8	לך	_	_	_	_	_	_	_	_
 7	ל_	ל	ADP	ADP	_	8	case	_	_
 8	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	6	obl	_	_
@@ -1268,7 +1268,7 @@
 1	אכן	אכן	ADV	ADV	_	4	advmod	_	SpaceAfter=No
 2	,	,	PUNCT	PUNCT	_	4	punct	_	_
 3	כך	כך	ADV	ADV	_	4	advmod	_	_
-4	עשתה	עשה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	עשתה	עשה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	0	root	_	_
 5	חטיבת	חטיבה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	nsubj	_	_
 6	"	"	PUNCT	PUNCT	_	7	punct	_	SpaceAfter=No
 7	הראל	הראל	PROPN	PROPN	_	5	flat:name	_	SpaceAfter=No
@@ -1278,7 +1278,7 @@
 # sent_id = 34
 # text = היא כבשה תחילה את המנזר ואת התנגדות האויב שברה לאחר מכן, בקרב מגננה שהתנהל בתוך המנזר (קרב מגננה מיועד לשבירת כוחות חזקים ממך).
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	כבשה	כבש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	כבשה	כבש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ב.ש|Tense=Past|Voice=Act	0	root	_	_
 3	תחילה	תחילה	ADV	ADV	_	2	advmod	_	_
 4	את	את	ADP	ADP	Case=Acc	6	case:acc	_	_
 5-6	המנזר	_	_	_	_	_	_	_	_
@@ -1291,7 +1291,7 @@
 10-11	האויב	_	_	_	_	_	_	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	אויב	אויב	NOUN	NOUN	Gender=Masc|Number=Sing	9	compound:smixut	_	_
-12	שברה	שבר	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	2	conj	_	_
+12	שברה	שבר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.ב.ר|Tense=Past	2	conj	_	_
 13	לאחר	לאחר	ADP	ADP	_	15	case	_	_
 14-15	מכן	_	_	_	_	_	_	_	SpaceAfter=No
 14	מ	מן	ADP	ADP	_	15	case	_	_
@@ -1303,7 +1303,7 @@
 19	מגננה	מגננה	NOUN	NOUN	Gender=Fem|Number=Sing	18	compound:smixut	_	_
 20-21	שהתנהל	_	_	_	_	_	_	_	_
 20	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
-21	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	18	acl:relcl	_	_
+21	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=נ.ה.ל|Tense=Past	18	acl:relcl	_	_
 22	בתוך	בתוך	ADP	ADP	_	24	case	_	_
 23-24	המנזר	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
@@ -1311,7 +1311,7 @@
 25	(	(	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 26	קרב	קרב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	28	nsubj	_	_
 27	מגננה	מגננה	NOUN	NOUN	Gender=Fem|Number=Sing	26	compound:smixut	_	_
-28	מיועד	יועד	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	18	appos	_	_
+28	מיועד	יועד	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=י.ע.ד|VerbForm=Part|Voice=Pass	18	appos	_	_
 29-30	לשבירת	_	_	_	_	_	_	_	_
 29	ל	ל	ADP	ADP	_	30	case	_	_
 30	שבירת	שבירה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	28	obl	_	_
@@ -1329,27 +1329,27 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	אויב	אויב	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 3	אמנם	אמנם	ADV	ADV	_	4	advmod	_	_
-4	נשבר	נשבר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
+4	נשבר	נשבר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.ב.ר|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
 5	;	;	PUNCT	PUNCT	_	11	cc	_	_
 6	קרב	קרב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	nsubj	_	_
 7-8	המגננה	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	מגננה	מגננה	NOUN	NOUN	Gender=Fem|Number=Sing	6	compound:smixut	_	_
-9	הפך	הפך	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	11	aux	_	_
+9	הפך	הפך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ה.פ.כ|Tense=Past	11	aux	_	_
 10-11	לניצחון	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	11	case	_	_
 11	ניצחון	ניצחון	NOUN	NOUN	Gender=Masc|Number=Sing	4	conj	_	_
 12	מוחץ	מוחץ	ADJ	ADJ	Gender=Masc|Number=Sing	11	amod	_	SpaceAfter=No
 13	;	;	PUNCT	PUNCT	_	15	cc	_	_
 14	קטמון	קטמון	PROPN	PROPN	_	15	nsubj	_	_
-15	נפלה	נפל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	conj	_	_
+15	נפלה	נפל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.פ.ל|Tense=Past|Voice=Act	4	conj	_	_
 16-17	וירושלים	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
 17	ירושלים	ירושלים	PROPN	PROPN	_	20	nsubj	_	_
 18-19	המערבית	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	מערבית	מערבי	ADJ	ADJ	Gender=Fem|Number=Sing	17	amod	_	_
-20	אוחדה	אוחד	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	4	conj	_	SpaceAfter=No
+20	אוחדה	אוחד	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Root=א.ח.ד|Tense=Past|Voice=Pass	4	conj	_	SpaceAfter=No
 21	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 36
@@ -1360,7 +1360,7 @@
 3	,	,	PUNCT	PUNCT	_	2	punct	_	_
 4-5	המצטט	_	_	_	_	_	_	_	_
 4	ה	ה	SCONJ	SCONJ	_	5	mark	_	_
-5	מצטט	ציטט	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	acl:relcl	_	_
+5	מצטט	ציטט	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=צ.ט.ט|VerbForm=Part|Voice=Act	2	acl:relcl	_	_
 6-9	ממחקרו	_	_	_	_	_	_	_	_
 6	מ	מ	ADP	ADP	_	7	case	_	_
 7	מחקר_	מחקר	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
@@ -1375,7 +1375,7 @@
 16	לא	לא	ADV	ADV	Polarity=Neg	18	advmod	_	_
 17	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	18	cop	_	_
 18	צריך	צריך	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	19	aux	_	_
-19	לכבוש	כבש	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	appos	_	_
+19	לכבוש	כבש	VERB	VERB	HebBinyan=PAAL|Root=כ.ב.ש|VerbForm=Inf|Voice=Act	7	appos	_	_
 20	את	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 21-22	המנזר	_	_	_	_	_	_	_	SpaceAfter=No
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
@@ -1383,7 +1383,7 @@
 23	...	...	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 24	"	"	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 25	,	,	PUNCT	PUNCT	_	26	punct	_	_
-26	מצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+26	מצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=צ.ב.י|VerbForm=Part|Voice=Act	0	root	_	_
 27	על	על	ADP	ADP	_	28	case	_	_
 28	חוסר	חוסר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	26	obl	_	_
 29	הבנה	הבנה	NOUN	NOUN	Gender=Fem|Number=Sing	28	compound:smixut	_	_
@@ -1406,7 +1406,7 @@
 4-5	שצה"ל	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
 5	צה"ל	צה"ל	PROPN	PROPN	Abbr=Yes	6	nsubj	_	_
-6	אימץ	אימץ	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	1	acl:relcl	_	_
+6	אימץ	אימץ	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=א.מ.צ|Tense=Past|Voice=Act	1	acl:relcl	_	_
 7-8	כתוצאה	_	_	_	_	_	_	_	_
 7	כ	כ	ADP	ADP	_	8	case	_	_
 8	תוצאה	תוצאה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
@@ -1425,7 +1425,7 @@
 # sent_id = 38
 # text = היא מבוססת על אותו קרב המגננה שבו אירעו מעשי גבורה עילאיים, ועל קבלת החלטות קשות בתנאי קרב.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	מבוססת	_	VERB	VERB	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+2	מבוססת	_	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ס.ס|VerbForm=Part	0	root	_	_
 3	על	על	ADP	ADP	_	5	case	_	_
 4	אותו	אותו	PRON	PRON	Definite=Def|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	det	_	_
 5	קרב	קרב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	obl	_	_
@@ -1436,7 +1436,7 @@
 8	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
 9	ב_	ב	ADP	ADP	_	10	case	_	_
 10	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	obl	_	_
-11	אירעו	אירע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	5	acl:relcl	_	_
+11	אירעו	אירע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=א.ר.ע|Tense=Past|Voice=Act	5	acl:relcl	_	_
 12	מעשי	מעשה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	nsubj	_	_
 13	גבורה	גבורה	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	_
 14	עילאיים	עילאי	ADJ	ADJ	Gender=Masc|Number=Plur	12	amod	_	SpaceAfter=No
@@ -1461,7 +1461,7 @@
 3	ו	ו	CCONJ	CCONJ	_	4	cc	_	_
 4	עלילה	עלילה	NOUN	NOUN	Gender=Fem|Number=Sing	1	conj	_	_
 5	זדונית	זדוני	ADJ	ADJ	Gender=Fem|Number=Sing	4	amod	_	_
-6	באים	בא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+6	באים	בא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ב.ו.א|VerbForm=Part|Voice=Act	0	root	_	_
 7-8	לביטוי	_	_	_	_	_	_	_	_
 7	ל	ל	ADP	ADP	_	8	case	_	_
 8	ביטוי	ביטוי	NOUN	NOUN	Gender=Masc|Number=Sing	6	obl	_	_
@@ -1473,7 +1473,7 @@
 12	מאמר	מאמר	NOUN	NOUN	Gender=Masc|Number=Sing	10	compound:smixut	_	_
 13-14	הדן	_	_	_	_	_	_	_	_
 13	ה	ה	SCONJ	SCONJ	_	14	mark	_	_
-14	דן	דן	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	10	acl:relcl	_	_
+14	דן	דן	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ד.ו.נ|VerbForm=Part|Voice=Act	10	acl:relcl	_	_
 15-16	בנושא	_	_	_	_	_	_	_	_
 15	ב	ב	ADP	ADP	_	16	case	_	_
 16	נושא	נושא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	obl	_	_
@@ -1491,7 +1491,7 @@
 2	ישראלי	ישראלי	NOUN	NOUN	Gender=Masc|Number=Sing	17	nsubj	_	_
 3-4	המנוסה	_	_	_	_	_	_	_	_
 3	ה	ה	SCONJ	SCONJ	_	4	mark	_	_
-4	מנוסה	נוסה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	2	acl:relcl	_	_
+4	מנוסה	נוסה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=נ.ס.י|VerbForm=Part|Voice=Pass	2	acl:relcl	_	_
 5-6	בקרב	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	קרב	קרב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
@@ -1507,7 +1507,7 @@
 14	סן	סן	PROPN	PROPN	_	13	compound:smixut	_	_
 15	סימון	סימון	PROPN	PROPN	_	14	flat:name	_	SpaceAfter=No
 16	)	)	PUNCT	PUNCT	_	13	punct	_	_
-17	יודע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
+17	יודע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 18	,	,	PUNCT	PUNCT	_	17	punct	_	_
 19	כי	כי	SCONJ	SCONJ	_	28	mark	_	_
 20	תוך	תוך	ADP	ADP	_	22	case	_	_
@@ -1519,14 +1519,14 @@
 25	חשכה	חשכה	NOUN	NOUN	Gender=Fem|Number=Sing	22	nmod	_	_
 26	קודם	קודם	ADV	ADV	_	28	advmod	_	_
 27	כל	כול	DET	DET	Definite=Cons	26	fixed	_	_
-28	יורים	ירה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	17	ccomp	_	_
+28	יורים	ירה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=י.ר.י|VerbForm=Part|Voice=Act	17	ccomp	_	_
 29-30	בכל	_	_	_	_	_	_	_	_
 29	ב	ב	ADP	ADP	_	31	case	_	_
 30	כל	כול	DET	DET	Definite=Cons	31	det	_	_
 31	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	28	obl	_	_
 32-33	שנע	_	_	_	_	_	_	_	_
 32	ש	ש	SCONJ	SCONJ	_	33	mark	_	_
-33	נע	נע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	31	acl:relcl	_	_
+33	נע	נע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ו.ע|VerbForm=Part|Voice=Act	31	acl:relcl	_	_
 34-36	ממולך	_	_	_	_	_	_	_	SpaceAfter=No
 34	מ	מ	ADP	ADP	_	36	case	_	_
 35	מולך	מול	ADP	ADP	_	34	fixed	_	_
@@ -1540,7 +1540,7 @@
 2	אכן	אכן	ADV	ADV	_	5	advmod	_	_
 3	,	,	PUNCT	PUNCT	_	5	punct	_	_
 4	כך	כך	ADV	ADV	_	5	advmod	_	_
-5	קרה	קרה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+5	קרה	קרה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ר.י|Tense=Past	0	root	_	_
 6-8	בפריצה	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -1558,7 +1558,7 @@
 # sent_id = 42
 # text = לא נהרגו "נזירות", אלא נשים ערביות, כנראה משרתות במנזר.
 1	לא	לא	ADV	ADV	Polarity=Neg	2	advmod	_	_
-2	נהרגו	נהרג	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+2	נהרגו	נהרג	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ה.ר.ג|Tense=Past|Voice=Mid	0	root	_	_
 3	"	"	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 4	נזירות	נזירה	NOUN	NOUN	Gender=Fem|Number=Plur	2	nsubj	_	SpaceAfter=No
 5	"	"	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
@@ -1584,7 +1584,7 @@
 # text = איש לא התכוון לכך.
 1	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	התכוון	התכוון	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	התכוון	התכוון	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=כ.ו.נ|Tense=Past	0	root	_	_
 4-5	לכך	_	_	_	_	_	_	_	SpaceAfter=No
 4	ל	ל	ADP	ADP	_	5	case	_	_
 5	כך	כך	PRON	PRON	Person=3|PronType=Dem	3	obl	_	_
@@ -1604,14 +1604,14 @@
 8	עת	עת	NOUN	NOUN	Gender=Fem|Number=Sing	16	obl	_	_
 9-10	שנורתה	_	_	_	_	_	_	_	SpaceAfter=No
 9	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
-10	נורתה	נורה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	8	acl:relcl	_	_
+10	נורתה	נורה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.ר.י|Tense=Past|Voice=Mid	8	acl:relcl	_	_
 11	,	,	PUNCT	PUNCT	_	16	punct	_	_
 12	(	(	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 13-14	הנזירה	_	_	_	_	_	_	_	SpaceAfter=No
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	נזירה	נזירה	NOUN	NOUN	Gender=Fem|Number=Sing	16	nsubj	_	_
 15	)	)	PUNCT	PUNCT	_	14	punct	_	_
-16	עסקה	עסק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	1	ccomp	_	_
+16	עסקה	עסק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ס.ק|Tense=Past|Voice=Act	1	ccomp	_	_
 17-18	בטיפול	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	טיפול	טיפול	NOUN	NOUN	Gender=Masc|Number=Sing	16	obl	_	_
@@ -1634,7 +1634,7 @@
 3-4	המאמר	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	מאמר	מאמר	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
-5	קובע	קבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
+5	קובע	קבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ק.ב.ע|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	5	punct	_	_
 7	פסקה	פסק	NOUN	NOUN	_	5	dep	_	_
 8	קודם	קודם	ADV	ADV	_	7	advmod	_	_
@@ -1694,7 +1694,7 @@
 # sent_id = 49
 # text = לא היה כאן רצח נזירות, אלא ניסיון לרצח טוהר הנשק של הפלמ"ח בטוהר עט הסופרים של הכותב.
 1	לא	לא	ADV	ADV	Polarity=Neg	2	advmod	_	_
-2	היה	היה	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+2	היה	היה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 3	כאן	כאן	ADV	ADV	_	2	advmod	_	_
 4	רצח	רצח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	נזירות	נזירה	NOUN	NOUN	Gender=Fem|Number=Plur	4	compound:smixut	_	SpaceAfter=No
@@ -1732,7 +1732,7 @@
 2	ידיעה	ידיעה	NOUN	NOUN	Gender=Fem|Number=Sing	39	nsubj	_	_
 3-4	שפורסמה	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	פורסמה	פורסם	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	2	acl:relcl	_	_
+4	פורסמה	פורסם	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Root=פ.ר.ס.מ|Tense=Past|Voice=Pass	2	acl:relcl	_	_
 5	תחת	תחת	ADP	ADP	_	7	case	_	_
 6-7	הכותרת	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -1757,7 +1757,7 @@
 21	ל	ל	ADP	ADP	_	22	case	_	_
 22	ירושלים	ירושלים	PROPN	PROPN	_	20	nmod	_	_
 23	;	;	PUNCT	PUNCT	_	24	punct	_	_
-24	טוענים	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	7	appos	_	SpaceAfter=No
+24	טוענים	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ט.ע.נ|VerbForm=Part|Voice=Act	7	appos	_	SpaceAfter=No
 25	:	:	PUNCT	PUNCT	_	24	punct	_	_
 26	הפגנה	הפגנה	NOUN	NOUN	Gender=Fem|Number=Sing	24	obj	_	_
 27	פוליטית	פוליטי	ADJ	ADJ	Gender=Fem|Number=Sing	26	amod	_	SpaceAfter=No
@@ -1773,7 +1773,7 @@
 36	0192	0192	NUM	NUM	_	33	nummod	_	SpaceAfter=No
 37	)	)	PUNCT	PUNCT	_	33	punct	_	SpaceAfter=No
 38	,	,	PUNCT	PUNCT	_	39	punct	_	_
-39	הטרידה	הטריד	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+39	הטרידה	הטריד	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ט.ר.ד|Tense=Past|Voice=Act	0	root	_	_
 40-41	אותי	_	_	_	_	_	_	_	_
 40	את_	את	ADP	ADP	Case=Acc	41	case:acc	_	_
 41	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	39	obj	_	_
@@ -1787,7 +1787,7 @@
 3	,	,	PUNCT	PUNCT	_	1	punct	_	_
 4-5	שמסרה	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	מסרה	מסר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	1	acl:relcl	_	_
+5	מסרה	מסר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.ס.ר|Tense=Past|Voice=Act	1	acl:relcl	_	_
 6	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 7-8	הידיעה	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -1798,9 +1798,9 @@
 11	הורים	הורה	NOUN	NOUN	Gender=Masc|Number=Plur	8	nmod	_	_
 12	(	(	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 13	אין	_	ADV	ADV	Polarity=Neg	14	advmod	_	_
-14	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	8	appos	_	_
+14	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	8	appos	_	_
 15	אם	אם	SCONJ	SCONJ	_	16	mark	_	_
-16	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	14	ccomp	_	_
+16	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ד.ב.ר|VerbForm=Part|Voice=Pass	14	ccomp	_	_
 17-18	בהורה	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	הורה	הורה	NOUN	NOUN	Gender=Masc|Number=Sing	16	obl	_	_
@@ -1814,7 +1814,7 @@
 25	מסוימת	מסוים	ADJ	ADJ	Gender=Fem|Number=Sing	23	amod	_	SpaceAfter=No
 26	)	)	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 27	,	,	PUNCT	PUNCT	_	28	punct	_	_
-28	כתבה	כתב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+28	כתבה	כתב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ת.ב|Tense=Past|Voice=Act	0	root	_	_
 29	כי	כי	SCONJ	SCONJ	_	59	mark	_	_
 30	"	"	PUNCT	PUNCT	_	59	punct	_	SpaceAfter=No
 31	אחד	אחד	NUM	NUM	Definite=Cons|Gender=Masc|Number=Sing	33	nummod	_	_
@@ -1824,7 +1824,7 @@
 34	,	,	PUNCT	PUNCT	_	33	punct	_	_
 35-36	שהחזיר	_	_	_	_	_	_	_	_
 35	ש	ש	SCONJ	SCONJ	_	36	mark	_	_
-36	החזיר	החזיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	33	acl:relcl	_	_
+36	החזיר	החזיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Past|Voice=Act	33	acl:relcl	_	_
 37-39	למנהלת	_	_	_	_	_	_	_	_
 37	ל	ל	ADP	ADP	_	39	case	_	_
 38	ה_	ה	DET	DET	PronType=Art	39	det:def	_	_
@@ -1840,7 +1840,7 @@
 45	ש	ש	SCONJ	SCONJ	_	48	mark	_	_
 46	ב_	ב	ADP	ADP	_	47	case	_	_
 47	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	48	obl	_	_
-48	הביע	הביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	42	acl:relcl	_	_
+48	הביע	הביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ב.ע|Tense=Past|Voice=Act	42	acl:relcl	_	_
 49	התנגדות	התנגדות	NOUN	NOUN	Gender=Fem|Number=Sing	48	obj	_	_
 50-51	להשתתפות	_	_	_	_	_	_	_	_
 50	ל	ל	ADP	ADP	_	51	case	_	_
@@ -1854,7 +1854,7 @@
 56	ה_	ה	DET	DET	PronType=Art	57	det:def	_	_
 57	טיול	טיול	NOUN	NOUN	Gender=Masc|Number=Sing	51	nmod	_	_
 58	,	,	PUNCT	PUNCT	_	59	punct	_	_
-59	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	28	ccomp	_	_
+59	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ט.ע.נ|Tense=Past|Voice=Act	28	ccomp	_	_
 60	כי	כי	SCONJ	SCONJ	_	63	mark	_	_
 61	"	"	PUNCT	PUNCT	_	63	punct	_	SpaceAfter=No
 62	זהו	זהו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	63	nsubj	_	_
@@ -1865,7 +1865,7 @@
 66	ילד_	ילד	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	69	nsubj	_	_
 67	_של_	של	ADP	ADP	_	68	case:gen	_	_
 68	_אנחנו	הוא	PRON	PRON	Case=Gen|Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	66	nmod:poss	_	_
-69	משמשים	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	63	advcl	_	_
+69	משמשים	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ש.מ.ש|VerbForm=Part|Voice=Act	63	advcl	_	_
 70	אמצעי	אמצעי	NOUN	NOUN	Gender=Masc|Number=Sing	69	obj	_	_
 71	חי	חי	ADJ	ADJ	Gender=Masc|Number=Sing	70	amod	_	_
 72-73	להפגנות	_	_	_	_	_	_	_	SpaceAfter=No
@@ -1885,17 +1885,17 @@
 6-7	עלי	_	_	_	_	_	_	_	_
 6	על_	על	ADP	ADP	_	7	case	_	_
 7	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	0	root	_	_
-8	לציין	ציין	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	7	xcomp	_	_
+8	לציין	ציין	VERB	VERB	HebBinyan=PIEL|Root=צ.י.נ|VerbForm=Inf|Voice=Act	7	xcomp	_	_
 9	כי	כי	SCONJ	SCONJ	_	11	mark	_	_
 10	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	11	nsubj	_	_
-11	נמנה	נמנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	8	ccomp	_	_
+11	נמנה	נמנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=מ.נ.י|VerbForm=Part|Voice=Mid	8	ccomp	_	_
 12	על	על	ADP	ADP	_	14	case	_	_
 13-14	ההורים	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	הורים	הורה	NOUN	NOUN	Gender=Masc|Number=Plur	11	obl	_	_
 15-16	שהביעו	_	_	_	_	_	_	_	_
 15	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
-16	הביעו	הביע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	14	acl:relcl	_	_
+16	הביעו	הביע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=נ.ב.ע|Tense=Past|Voice=Act	14	acl:relcl	_	_
 17	את	את	ADP	ADP	Case=Acc	18	case:acc	_	_
 18-20	הסכמתם	_	_	_	_	_	_	_	_
 18	הסכמה_	הסכמה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	16	obj	_	_
@@ -1936,10 +1936,10 @@
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 2	גם	גם	ADV	ADV	_	3	advmod	_	_
 3	מוכן	מוכן	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	4	aux	_	_
-4	להסתכן	הסתכן	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	0	root	_	_
+4	להסתכן	הסתכן	VERB	VERB	HebBinyan=HITPAEL|Root=ס.כ.נ|VerbForm=Inf	0	root	_	_
 5-6	ולשער	_	_	_	_	_	_	_	_
 5	ו	ו	CCONJ	CCONJ	_	6	cc	_	_
-6	לשער	שיער	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	4	conj	_	_
+6	לשער	שיער	VERB	VERB	HebBinyan=PIEL|Root=ש.ע.ר|VerbForm=Inf|Voice=Act	4	conj	_	_
 7	כי	כי	SCONJ	SCONJ	_	21	mark	_	_
 8-9	ההורה	_	_	_	_	_	_	_	SpaceAfter=No
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -1952,13 +1952,13 @@
 14	הורים	הורה	NOUN	NOUN	Gender=Masc|Number=Plur	12	compound:smixut	_	_
 15-16	שהתנגדה	_	_	_	_	_	_	_	_
 15	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
-16	התנגדה	התנגד	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	12	acl:relcl	_	_
+16	התנגדה	התנגד	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=נ.ג.ד|Tense=Past	12	acl:relcl	_	_
 17-19	לטיול	_	_	_	_	_	_	_	SpaceAfter=No
 17	ל	ל	ADP	ADP	_	19	case	_	_
 18	ה_	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	טיול	טיול	NOUN	NOUN	Gender=Masc|Number=Sing	16	obl	_	_
 20	,	,	PUNCT	PUNCT	_	21	punct	_	_
-21	מסתתרים	הסתתר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	6	ccomp	_	_
+21	מסתתרים	הסתתר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ס.ת.ר|VerbForm=Part	6	ccomp	_	_
 22	תחת	תחת	ADP	ADP	_	24	case	_	_
 23-24	המעטה	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
@@ -1971,8 +1971,8 @@
 29	ו	ו	CCONJ	CCONJ	_	32	cc	_	_
 30	למעשה	למעשה	ADV	ADV	_	32	advmod	_	_
 31	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	32	nsubj	_	_
-32	פוחדים	פחד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	21	conj	_	_
-33	לשלוח	שלח	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	32	xcomp	_	_
+32	פוחדים	פחד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=פ.ח.ד|VerbForm=Part|Voice=Act	21	conj	_	_
+33	לשלוח	שלח	VERB	VERB	HebBinyan=PAAL|Root=ש.ל.ח|VerbForm=Inf|Voice=Act	32	xcomp	_	_
 34	את	את	ADP	ADP	Case=Acc	35	case:acc	_	_
 35-37	ילדיהם	_	_	_	_	_	_	_	_
 35	ילד_	ילד	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	33	obj	_	_
@@ -1981,7 +1981,7 @@
 38	שמא	שמא	SCONJ	SCONJ	_	41	mark	_	_
 39	איזה	איזה	DET	DET	Definite=Cons	40	det	_	_
 40	ערבי	ערבי	NOUN	NOUN	Gender=Masc|Number=Sing	41	nsubj	_	_
-41	ינעץ	נעץ	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	33	advcl	_	_
+41	ינעץ	נעץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ע.צ|Tense=Fut	33	advcl	_	_
 42-43	בהם	_	_	_	_	_	_	_	_
 42	ב_	ב	ADP	ADP	_	43	case	_	_
 43	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	41	obl	_	_
@@ -1999,9 +1999,9 @@
 3	,	,	PUNCT	PUNCT	_	2	punct	_	_
 4-5	ורוצה	_	_	_	_	_	_	_	SpaceAfter=No
 4	ו	ו	CCONJ	CCONJ	_	5	cc	_	_
-5	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	conj	_	_
+5	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.צ.י|VerbForm=Part|Voice=Act	2	conj	_	_
 6	,	,	PUNCT	PUNCT	_	2	punct	_	_
-7	לשלוח	שלח	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+7	לשלוח	שלח	VERB	VERB	HebBinyan=PAAL|Root=ש.ל.ח|VerbForm=Inf|Voice=Act	0	root	_	_
 8	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 9-10	הילד	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -2022,7 +2022,7 @@
 21	ממתקים	ממתק	NOUN	NOUN	Gender=Masc|Number=Plur	20	compound:smixut	_	SpaceAfter=No
 22	,	,	PUNCT	PUNCT	_	7	punct	_	_
 23	כדי	כדי	ADP	ADP	_	24	case	_	_
-24	להביע	הביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	7	advcl	_	_
+24	להביע	הביע	VERB	VERB	HebBinyan=HIFIL|Root=נ.ב.ע|VerbForm=Inf|Voice=Act	7	advcl	_	_
 25	הוקרה	הוקרה	NOUN	NOUN	Gender=Fem|Number=Sing	24	obj	_	_
 26-27	ועידוד	_	_	_	_	_	_	_	_
 26	ו	ו	CCONJ	CCONJ	_	27	cc	_	_
@@ -2037,7 +2037,7 @@
 34	,	,	PUNCT	PUNCT	_	30	punct	_	_
 35-36	שחטף	_	_	_	_	_	_	_	_
 35	ש	ש	SCONJ	SCONJ	_	36	mark	_	_
-36	חטף	חטף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	30	acl:relcl	_	_
+36	חטף	חטף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ט.פ|Tense=Past|Voice=Act	30	acl:relcl	_	_
 37	סכין	סכין	NOUN	NOUN	Gender=Fem,Masc|Number=Sing	36	obj	_	_
 38-40	בראש	_	_	_	_	_	_	_	_
 38	ב	ב	ADP	ADP	_	40	case	_	_
@@ -2049,7 +2049,7 @@
 44	שפל	שפל	ADJ	ADJ	Gender=Masc|Number=Sing	43	amod	_	_
 45-46	שדקר	_	_	_	_	_	_	_	_
 45	ש	ש	SCONJ	SCONJ	_	46	mark	_	_
-46	דקר	דקר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	43	acl:relcl	_	_
+46	דקר	דקר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ד.ק.ר|Tense=Past|Voice=Act	43	acl:relcl	_	_
 47-49	למוות	_	_	_	_	_	_	_	_
 47	ל	ל	ADP	ADP	_	49	case	_	_
 48	ה_	ה	DET	DET	PronType=Art	49	det:def	_	_
@@ -2065,7 +2065,7 @@
 # sent_id = 56
 # text = אני רוצה שהילד שלי יסתכל בעיניים של הילד הפגוע ויגיד לו: "אתה לא לבדך בירושלים, כי גם אנחנו הגרים בנווה-מונסון, אתך בלב איתן ביחד".
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	dep	_	_
-2	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.צ.י|VerbForm=Part|Voice=Act	0	root	_	_
 3-5	שהילד	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -2073,7 +2073,7 @@
 6-7	שלי	_	_	_	_	_	_	_	_
 6	של_	של	ADP	ADP	Case=Gen	7	case:gen	_	_
 7	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	5	nmod:poss	_	_
-8	יסתכל	הסתכל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	2	ccomp	_	_
+8	יסתכל	הסתכל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ס.כ.ל|Tense=Fut	2	ccomp	_	_
 9-11	בעיניים	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
@@ -2087,7 +2087,7 @@
 16	פגוע	פגוע	ADJ	ADJ	Gender=Masc|Number=Sing	14	amod	_	_
 17-18	ויגיד	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
-18	יגיד	הגיד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	8	conj	_	_
+18	יגיד	הגיד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ד|Tense=Fut|Voice=Act	8	conj	_	_
 19-20	לו	_	_	_	_	_	_	_	SpaceAfter=No
 19	ל_	ל	ADP	ADP	_	20	case	_	_
 20	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	obl	_	_
@@ -2105,7 +2105,7 @@
 31	אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	40	nsubj	_	_
 32-33	הגרים	_	_	_	_	_	_	_	_
 32	ה	ה	SCONJ	SCONJ	_	33	mark	_	_
-33	גרים	גר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	31	acl:relcl	_	_
+33	גרים	גר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ג.ו.ר|VerbForm=Part|Voice=Act	31	acl:relcl	_	_
 34-35	בנווה	_	_	_	_	_	_	_	SpaceAfter=No
 34	ב	ב	ADP	ADP	_	35	case	_	_
 35	נווה	נווה	PROPN	PROPN	_	33	obl	_	_
@@ -2127,7 +2127,7 @@
 # text = אני מוכן להעיד כי גם אבי ז"ל, שלקח אותי באוטובוס לירושלים בשנת תרצ"ח כאשר הערבים ירו על כביש באב אל-ואד, אמר לי: "אלי! אם תשמע יריות תתכופף, אבל אל תפחד".
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
 2	מוכן	מוכן	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	3	aux	_	_
-3	להעיד	העיד	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+3	להעיד	העיד	VERB	VERB	HebBinyan=HIFIL|Root=ע.ו.ד|VerbForm=Inf|Voice=Act	0	root	_	_
 4	כי	כי	SCONJ	SCONJ	_	33	mark	_	_
 5	גם	גם	ADV	ADV	_	6	det	_	_
 6-8	אבי	_	_	_	_	_	_	_	_
@@ -2138,7 +2138,7 @@
 10	,	,	PUNCT	PUNCT	_	6	punct	_	_
 11-12	שלקח	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-12	לקח	לקח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	acl:relcl	_	_
+12	לקח	לקח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ל.ק.ח|Tense=Past|Voice=Act	6	acl:relcl	_	_
 13-14	אותי	_	_	_	_	_	_	_	_
 13	את_	את	ADP	ADP	Case=Acc	14	case:acc	_	_
 14	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	12	obj	_	_
@@ -2156,7 +2156,7 @@
 23-24	הערבים	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	ערבים	ערבי	NOUN	NOUN	Gender=Masc|Number=Plur	25	nsubj	_	_
-25	ירו	ירה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	12	advcl	_	_
+25	ירו	ירה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.ר.י|Tense=Past|Voice=Act	12	advcl	_	_
 26	על	על	ADP	ADP	_	27	case	_	_
 27	כביש	כביש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	25	obl	_	_
 28	באב	באב	PROPN	PROPN	_	27	compound:smixut	_	_
@@ -2164,7 +2164,7 @@
 30	-	-	PUNCT	PUNCT	_	28	flat:name	_	SpaceAfter=No
 31	ואד	ואד	PROPN	PROPN	_	28	flat:name	_	SpaceAfter=No
 32	,	,	PUNCT	PUNCT	_	33	punct	_	_
-33	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	ccomp	_	_
+33	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	3	ccomp	_	_
 34-35	לי	_	_	_	_	_	_	_	SpaceAfter=No
 34	ל_	ל	ADP	ADP	_	35	case	_	_
 35	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	33	obl	_	_
@@ -2173,13 +2173,13 @@
 38	אלי	אלי	PROPN	PROPN	_	43	obl	_	SpaceAfter=No
 39	!	!	PUNCT	PUNCT	_	43	punct	_	_
 40	אם	אם	SCONJ	SCONJ	_	41	mark	_	_
-41	תשמע	שמע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=2|Tense=Fut|Voice=Act	43	advcl	_	_
+41	תשמע	שמע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=2|Root=ש.מ.ע|Tense=Fut|Voice=Act	43	advcl	_	_
 42	יריות	ירייה	NOUN	NOUN	Gender=Fem|Number=Plur	41	obj	_	_
-43	תתכופף	התכופף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=2|Tense=Fut	33	ccomp	_	SpaceAfter=No
+43	תתכופף	התכופף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=2|Root=כ.פ.פ|Tense=Fut	33	ccomp	_	SpaceAfter=No
 44	,	,	PUNCT	PUNCT	_	43	punct	_	_
 45	אבל	אבל	CCONJ	CCONJ	_	47	cc	_	_
 46	אל	_	ADV	ADV	_	47	advmod	_	_
-47	תפחד	פחד	VERB	VERB	Gender=Masc|Number=Sing|Person=2|Tense=Fut	43	conj	_	SpaceAfter=No
+47	תפחד	פחד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=2|Root=פ.ח.ד|Tense=Fut	43	conj	_	SpaceAfter=No
 48	"	"	PUNCT	PUNCT	_	43	punct	_	SpaceAfter=No
 49	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
@@ -2189,7 +2189,7 @@
 1	ו	ו	CCONJ	CCONJ	_	0	root	_	_
 2	לכן	לכן	ADV	ADV	_	4	advmod	_	_
 3	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
-4	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	1	conj	_	_
+4	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	1	conj	_	_
 5-6	לכל	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	7	case	_	_
 6	כל	כול	DET	DET	Definite=Cons	7	det	_	_
@@ -2197,19 +2197,19 @@
 8	ישראל	ישראל	PROPN	PROPN	_	7	compound:smixut	_	SpaceAfter=No
 9	:	:	PUNCT	PUNCT	_	11	punct	_	_
 10	אל	_	ADV	ADV	_	11	advmod	_	_
-11	תפחדו	פחד	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=2|Tense=Fut	4	ccomp	_	SpaceAfter=No
+11	תפחדו	פחד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=2|Root=פ.ח.ד|Tense=Fut	4	ccomp	_	SpaceAfter=No
 12	!	!	PUNCT	PUNCT	_	11	punct	_	_
-13	סעו	נסע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Voice=Act	11	parataxis	_	_
+13	סעו	נסע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Root=נ.ס.ע|Voice=Act	11	parataxis	_	_
 14-15	לירושלים	_	_	_	_	_	_	_	SpaceAfter=No
 14	ל	ל	ADP	ADP	_	15	case	_	_
 15	ירושלים	ירושלים	PROPN	PROPN	HebSource=ConvUncertainHead	13	dep	_	_
 16	,	,	PUNCT	PUNCT	HebSource=ConvUncertainHead	13	dep	_	_
 17	אפילו	אפילו	ADV	ADV	_	19	advmod	_	_
 18	אם	אם	SCONJ	SCONJ	_	19	mark	_	_
-19	יורים	ירה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	13	dep	_	_
+19	יורים	ירה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|Root=י.ר.י|VerbForm=Part|Voice=Act	13	dep	_	_
 20	או	או	CCONJ	CCONJ	_	22	cc	_	_
 21	אם	אם	SCONJ	SCONJ	_	22	mark	_	_
-22	מתעופפים	התעופף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	19	conj	_	_
+22	מתעופפים	התעופף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ע.ו.פ|VerbForm=Part	19	conj	_	_
 23	שם	שם	ADV	ADV	_	22	advmod	_	_
 24	סכינים	סכין	NOUN	NOUN	Gender=Fem,Masc|Number=Plur	22	nsubj	_	SpaceAfter=No
 25	.	.	PUNCT	PUNCT	_	1	punct	_	_
@@ -2224,7 +2224,7 @@
 4	כבד	כבד	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
 5-6	שהנחית	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	הנחית	הנחית	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	acl:relcl	_	_
+6	הנחית	הנחית	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ח.ת|Tense=Past|Voice=Act	2	acl:relcl	_	_
 7-8	הפועל	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	פועל	פועל	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
@@ -2260,7 +2260,7 @@
 32-33	המרכול	_	_	_	_	_	_	_	_
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	מרכול	מרכול	NOUN	NOUN	Gender=Masc|Number=Sing	31	compound:smixut	_	_
-34	תקעה	תקע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	25	acl:relcl	_	_
+34	תקעה	תקע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ת.ק.ע|Tense=Past|Voice=Act	25	acl:relcl	_	_
 35-36	באחד	_	_	_	_	_	_	_	_
 35	ב	ב	ADP	ADP	_	38	case	_	_
 36	אחד	אחד	NUM	NUM	Definite=Cons|Gender=Masc|Number=Sing	38	nummod	_	_
@@ -2297,7 +2297,7 @@
 61	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	62	nsubj	_	_
 62	ערבי	ערבי	NOUN	NOUN	Gender=Masc|Number=Sing	56	appos	_	SpaceAfter=No
 63	,	,	PUNCT	PUNCT	_	62	punct	_	_
-64	מעלה	העלה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+64	מעלה	העלה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ע.ל.י|VerbForm=Part|Voice=Act	0	root	_	_
 65-66	מנבכי	_	_	_	_	_	_	_	_
 65	מ	מ	ADP	ADP	_	66	case	_	_
 66	נבכי	נבך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	64	obl	_	_
@@ -2322,18 +2322,18 @@
 81	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	79	nmod:poss	_	_
 82	,	,	PUNCT	PUNCT	_	84	punct	_	_
 83	אל	_	ADV	ADV	_	84	advmod	_	_
-84	יופתע	הופתע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	71	appos	_	_
+84	יופתע	הופתע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=פ.ת.ע|Tense=Fut|Voice=Pass	71	appos	_	_
 85	אם	אם	SCONJ	SCONJ	_	86	mark	_	_
-86	ימצא	מצא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	84	advcl	_	_
+86	ימצא	מצא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.צ.א|Tense=Fut|Voice=Act	84	advcl	_	_
 87	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	86	obj	_	_
-88	מוכש	הוכש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	86	advmod	_	SpaceAfter=No
+88	מוכש	הוכש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=נ.כ.ש|VerbForm=Part|Voice=Pass	86	advmod	_	SpaceAfter=No
 89	"	"	PUNCT	PUNCT	_	84	punct	_	SpaceAfter=No
 90	.	.	PUNCT	PUNCT	_	64	punct	_	_
 
 # sent_id = 60
 # text = אני כותב זאת בצער וברגשי אשם; פעם חשבתי אחרת (על הערבים, לא על הנחשים).
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
-2	כותב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	כותב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ת.ב|VerbForm=Part|Voice=Act	0	root	_	_
 3	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	obj	_	_
 4-5	בצער	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
@@ -2345,7 +2345,7 @@
 9	אשם	אשם	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	SpaceAfter=No
 10	;	;	PUNCT	PUNCT	_	12	cc	_	_
 11	פעם	פעם	ADV	ADV	_	12	advmod	_	_
-12	חשבתי	חשב	VERB	VERB	Gender=Fem,Masc|Number=Sing|Person=1|Tense=Past	2	conj	_	_
+12	חשבתי	חשב	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Sing|Person=1|Root=ח.ש.ב|Tense=Past	2	conj	_	_
 13	אחרת	אחרת	ADV	ADV	_	12	advmod	_	_
 14	(	(	PUNCT	PUNCT	_	17	punct	_	SpaceAfter=No
 15	על	על	ADP	ADP	_	17	case	_	_
@@ -2363,7 +2363,7 @@
 
 # sent_id = 61
 # text = מסתבר שהייתי תמים.
-1	מסתבר	הסתבר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+1	מסתבר	הסתבר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ס.ב.ר|VerbForm=Part	0	root	_	_
 2-3	שהייתי	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
 3	הייתי	היה	AUX	AUX	Gender=Fem,Masc|Number=Sing|Person=1|Polarity=Pos|Tense=Past|VerbType=Cop	4	cop	_	_
@@ -2378,7 +2378,7 @@
 3	מערכת	מערכת	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 4-5	שהתפרסם	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	התפרסם	התפרסם	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	1	acl:relcl	_	_
+5	התפרסם	התפרסם	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=פ.ר.ס.מ|Tense=Past	1	acl:relcl	_	_
 6	תחת	תחת	ADP	ADP	_	8	case	_	_
 7-8	הכותרת	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -2387,7 +2387,7 @@
 10	יחדל	חדל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	8	appos	_	_
 11	נא	נא	INTJ	INTJ	_	10	discourse	_	_
 12	מילוא	מילוא	NOUN	NOUN	Gender=Masc|Number=Sing	10	nsubj	_	_
-13	להתלבט	התלבט	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	10	xcomp	_	SpaceAfter=No
+13	להתלבט	התלבט	VERB	VERB	HebBinyan=HITPAEL|Root=ל.ב.ט|VerbForm=Inf	10	xcomp	_	SpaceAfter=No
 14	"	"	PUNCT	PUNCT	_	10	punct	_	_
 15	(	(	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 16	"	"	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
@@ -2399,8 +2399,8 @@
 21	111	111	NUM	NUM	_	18	nummod	_	SpaceAfter=No
 22	)	)	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 23	,	,	PUNCT	PUNCT	_	24	punct	_	_
-24	תובע	תבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
-25	למצות	מיצה	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	24	xcomp	_	_
+24	תובע	תבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ת.ב.ע|VerbForm=Part|Voice=Act	0	root	_	_
+25	למצות	מיצה	VERB	VERB	HebBinyan=PIEL|Root=מ.צ.י|VerbForm=Inf|Voice=Act	24	xcomp	_	_
 26	את	את	ADP	ADP	Case=Acc	28	case:acc	_	_
 27-28	הדין	_	_	_	_	_	_	_	_
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
@@ -2451,7 +2451,7 @@
 12	,	,	PUNCT	PUNCT	_	2	punct	_	_
 13-14	שנגרם	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
-14	נגרם	נגרם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	2	acl:relcl	_	_
+14	נגרם	נגרם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ג.ר.מ|Tense=Past|Voice=Mid	2	acl:relcl	_	_
 15	רק	רק	ADV	ADV	_	16	advmod	_	_
 16	בגלל	בגלל	ADP	ADP	_	18	case	_	_
 17-18	העובדה	_	_	_	_	_	_	_	_
@@ -2460,7 +2460,7 @@
 19-20	שהוא	_	_	_	_	_	_	_	_
 19	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
 20	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	nsubj	_	_
-21	סמך	סמך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	18	acl:relcl	_	_
+21	סמך	סמך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ס.מ.כ|Tense=Past|Voice=Act	18	acl:relcl	_	_
 22	יותר	יותר	ADV	ADV	_	21	advmod	_	_
 23	מדי	מדי	ADV	ADV	HebSource=ConvUncertainHead	22	fixed	_	_
 24	על	על	ADP	ADP	_	25	case	_	_
@@ -2479,7 +2479,7 @@
 2	כל	כול	DET	DET	Definite=Cons	3	det	_	_
 3	נושא	נושא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	nsubj	_	_
 4	משרה	משרה	NOUN	NOUN	Gender=Fem|Number=Sing	3	compound:smixut	_	_
-5	יפוטר	פוטר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	13	advcl	_	_
+5	יפוטר	פוטר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=פ.ט.ר|Tense=Fut|Voice=Pass	13	advcl	_	_
 6	מיד	מייד	ADV	ADV	_	7	advmod	_	_
 7	עם	עם	ADP	ADP	_	9	case	_	_
 8-9	השגיאה	_	_	_	_	_	_	_	_
@@ -2489,7 +2489,7 @@
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	9	amod	_	_
 12	,	,	PUNCT	PUNCT	_	13	punct	_	_
-13	תסבול	סבל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+13	תסבול	סבל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ס.ב.ל|Tense=Fut|Voice=Act	0	root	_	_
 14-15	המדינה	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	מדינה	מדינה	NOUN	NOUN	Gender=Fem|Number=Sing	13	nsubj	_	_
@@ -2497,7 +2497,7 @@
 16	מ	מ	ADP	ADP	_	17	case	_	_
 17	סבב	סבב	NOUN	NOUN	Gender=Masc|Number=Sing	13	obl	_	_
 18	בלתי	בלתי	ADV	ADV	Prefix=Yes	19	compound:affix	_	_
-19	פוסק	פסק	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	17	amod	_	_
+19	פוסק	פסק	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=פ.ס.ק|VerbForm=Part|Voice=Act	17	amod	_	_
 20	של	של	ADP	ADP	Case=Gen	21	case:gen	_	_
 21	בעלי	בעל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	17	nmod	_	_
 22	תפקידים	תפקיד	NOUN	NOUN	Gender=Masc|Number=Plur	21	compound:smixut	_	_
@@ -2513,7 +2513,7 @@
 
 # sent_id = 65
 # text = מתקבל הרושם שהיחידים במדינה הזו שאינם צריכים לחשוש מתוצאות מעשיהם הם הפוליטיקאים.
-1	מתקבל	התקבל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+1	מתקבל	התקבל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ק.ב.ל|VerbForm=Part	0	root	_	_
 2-3	הרושם	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	רושם	רושם	NOUN	NOUN	Gender=Masc|Number=Sing	1	nsubj	_	_
@@ -2532,7 +2532,7 @@
 12	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
 13	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	14	advmod	_	_
 14	צריכים	צריך	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbType=Mod	15	aux	_	_
-15	לחשוש	חשש	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	6	acl:relcl	_	_
+15	לחשוש	חשש	VERB	VERB	HebBinyan=PAAL|Root=ח.ש.ש|VerbForm=Inf|Voice=Act	6	acl:relcl	_	_
 16-17	מתוצאות	_	_	_	_	_	_	_	_
 16	מ	מ	ADP	ADP	_	17	case	_	_
 17	תוצאות	תוצאה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	15	obl	_	_
@@ -2550,7 +2550,7 @@
 # text = אלה לא נופלים כתוצאה משגיאות או ממחדלים, או אפילו מהתנהגות פסולה, אלא רק בשל משחקי כוח פוליטיים.
 1	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	נופלים	נפל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+3	נופלים	נפל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=נ.פ.ל|VerbForm=Part|Voice=Act	0	root	_	_
 4-5	כתוצאה	_	_	_	_	_	_	_	_
 4	כ	כ	ADP	ADP	_	5	case	_	_
 5	תוצאה	תוצאה	NOUN	NOUN	Gender=Fem|Number=Sing	3	obl	_	_
@@ -2601,7 +2601,7 @@
 17	מצד	מצד	ADP	ADP	_	18	case	_	_
 18	ועדת	ועדה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	11	conj	_	_
 19	חקירה	חקירה	NOUN	NOUN	Gender=Fem|Number=Sing	18	compound:smixut	_	_
-20	נופלת	נפל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+20	נופלת	נפל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.פ.ל|VerbForm=Part|Voice=Act	0	root	_	_
 21	תמיד	תמיד	ADV	ADV	_	20	advmod	_	_
 22	על	על	ADP	ADP	_	23	case	_	_
 23	אוזניים	אוזן	NOUN	NOUN	Gender=Fem|Number=Plur	20	obl	_	_
@@ -2611,7 +2611,7 @@
 27-28	כשאפשר	_	_	_	_	_	_	_	_
 27	כש	כש	SCONJ	SCONJ	Case=Tem	28	mark	_	_
 28	אפשר	אפשר	AUX	AUX	VerbType=Mod	29	aux	_	_
-29	להטיל	הטיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	39	advcl	_	_
+29	להטיל	הטיל	VERB	VERB	HebBinyan=HIFIL|Root=נ.ט.ל|VerbForm=Inf|Voice=Act	39	advcl	_	_
 30	את	את	ADP	ADP	Case=Acc	32	case:acc	_	_
 31-32	האשמה	_	_	_	_	_	_	_	_
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
@@ -2622,7 +2622,7 @@
 36	או	או	CCONJ	CCONJ	_	37	cc	_	_
 37	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	35	conj	_	SpaceAfter=No
 38	,	,	PUNCT	PUNCT	_	39	punct	_	_
-39	מוטל	הוטל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	20	conj	_	_
+39	מוטל	הוטל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=נ.ט.ל|VerbForm=Part|Voice=Pass	20	conj	_	_
 40-42	גורלם	_	_	_	_	_	_	_	_
 40	גורל_	גורל	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	39	nsubj	_	_
 41	_של_	של	ADP	ADP	_	42	case:gen	_	_
@@ -2639,7 +2639,7 @@
 # sent_id = 68
 # text = אני תמה על "הארץ" שהזדרז לשחק לידיהם של הפוליטיקאים, המעוניינים להיפטר מהמפכ"ל הנוכחי.
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	dep	_	_
-2	תמה	_	VERB	VERB	VerbForm=Part	0	root	_	_
+2	תמה	_	VERB	VERB	HebBinyan=PAAL|Root=ת.מ.י|VerbForm=Part	0	root	_	_
 3	על	על	ADP	ADP	_	6	case	_	_
 4	"	"	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 5-6	הארץ	_	_	_	_	_	_	_	SpaceAfter=No
@@ -2648,8 +2648,8 @@
 7	"	"	PUNCT	PUNCT	_	6	punct	_	_
 8-9	שהזדרז	_	_	_	_	_	_	_	_
 8	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
-9	הזדרז	הזדרז	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	6	acl:relcl	_	_
-10	לשחק	שיחק	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	9	xcomp	_	_
+9	הזדרז	הזדרז	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ז.ר.ז|Tense=Past	6	acl:relcl	_	_
+10	לשחק	שיחק	VERB	VERB	HebBinyan=PIEL|Root=ש.ח.ק|VerbForm=Inf|Voice=Act	9	xcomp	_	_
 11-14	לידיהם	_	_	_	_	_	_	_	_
 11	ל	ל	ADP	ADP	_	12	case	_	_
 12	יד_	יד	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	10	obl	_	_
@@ -2663,7 +2663,7 @@
 19-20	המעוניינים	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	mark	_	_
 20	מעוניינים	_	AUX	AUX	VerbType=Mod	21	aux	_	_
-21	להיפטר	נפטר	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	17	acl:relcl	_	_
+21	להיפטר	נפטר	VERB	VERB	HebBinyan=NIFAL|Root=פ.ט.ר|VerbForm=Inf|Voice=Mid	17	acl:relcl	_	_
 22-24	מהמפכ"ל	_	_	_	_	_	_	_	_
 22	מ	מ	ADP	ADP	_	24	case	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
@@ -2679,7 +2679,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	עיתונים	עיתון	NOUN	NOUN	Gender=Masc|Number=Plur	4	obl	_	_
 3	רבים	רב	ADJ	ADJ	Gender=Masc|Number=Plur	2	amod	_	_
-4	פורסם	פורסם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	פורסם	פורסם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=פ.ר.ס.מ|Tense=Past|Voice=Pass	0	root	_	_
 5-7	מכתבה	_	_	_	_	_	_	_	_
 5	מכתב_	מכתב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
@@ -2707,7 +2707,7 @@
 24	כותרת	כותרת	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
 25	"	"	PUNCT	PUNCT	_	27	punct	_	SpaceAfter=No
 26	אל	_	ADV	ADV	_	27	advmod	_	_
-27	תיגעו	נגע	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=2|Tense=Fut	24	appos	_	_
+27	תיגעו	נגע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=2|Root=נ.ג.ע|Tense=Fut	24	appos	_	_
 28-30	במשכנתא	_	_	_	_	_	_	_	SpaceAfter=No
 28	ב	ב	ADP	ADP	_	30	case	_	_
 29	ה_	ה	DET	DET	PronType=Art	30	det:def	_	_
@@ -2722,7 +2722,7 @@
 2	רצון_	רצון	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 3	_של_	של	ADP	ADP	_	4	case:gen	_	_
 4	_אני	הוא	PRON	PRON	Case=Gen|Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	nmod:poss	_	_
-5	להדגיש	הדגיש	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
+5	להדגיש	הדגיש	VERB	VERB	HebBinyan=HIFIL|Root=ד.ג.ש|VerbForm=Inf|Voice=Act	2	xcomp	_	_
 6	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	5	obj	_	_
 7	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	6	nummod	_	_
 8-11	בדבריה	_	_	_	_	_	_	_	SpaceAfter=No
@@ -2739,7 +2739,7 @@
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	משכנתאות	משכנתא	NOUN	NOUN	Gender=Fem|Number=Plur	16	compound:smixut	_	_
 19	,	,	PUNCT	PUNCT	_	20	punct	_	_
-20	נקלענו	נקלע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=1|Tense=Past|Voice=Mid	6	appos	_	_
+20	נקלענו	נקלע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=1|Root=ק.ל.ע|Tense=Past|Voice=Mid	6	appos	_	_
 21-24	למצבנו	_	_	_	_	_	_	_	_
 21	ל	ל	ADP	ADP	_	22	case	_	_
 22	מצב_	מצב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	20	obl	_	_
@@ -2774,16 +2774,16 @@
 4	,	,	PUNCT	PUNCT	_	1	punct	_	_
 5-6	התואמות	_	_	_	_	_	_	_	_
 5	ה	ה	SCONJ	SCONJ	_	6	mark	_	_
-6	תואמות	תאם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
+6	תואמות	תאם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ת.א.מ|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
 7	במדויק	במדויק	ADV	ADV	_	6	advmod	_	_
 8	את	את	ADP	ADP	Case=Acc	9	case:acc	_	_
 9	מה	מה	ADV	ADV	PronType=Int	6	obj	_	_
 10-12	שהחתום	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
 11	ה	ה	DET	DET	PronType=Art	12	mark	_	_
-12	חתום	חתם	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	14	csubj	_	_
+12	חתום	חתם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ח.ת.מ|VerbForm=Part	14	csubj	_	_
 13	מטה	מטה	ADV	ADV	_	12	advmod	_	_
-14	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	9	acl:relcl	_	_
+14	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ט.ע.נ|Tense=Past|Voice=Act	9	acl:relcl	_	_
 15	במשך	במשך	ADP	ADP	_	16	case	_	_
 16	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	14	obl	_	_
 17	רבות	רב	ADJ	ADJ	Gender=Fem|Number=Plur	16	amod	_	SpaceAfter=No
@@ -2798,7 +2798,7 @@
 4	ריבית	ריבית	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
 5-6	שסיבכה	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	סיבכה	סיבך	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	acl:relcl	_	_
+6	סיבכה	סיבך	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ס.ב.כ|Tense=Past|Voice=Act	4	acl:relcl	_	_
 7	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 8	מקבלי	מקבל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	6	obj	_	_
 9-10	המשכנתאות	_	_	_	_	_	_	_	_
@@ -2885,7 +2885,7 @@
 4-5	באוקטובר	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	אוקטובר	אוקטובר	PROPN	PROPN	_	3	obl	_	_
-6	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ע|Tense=Past|Voice=Act	0	root	_	_
 7	אל	אל	ADP	ADP	_	9	case	_	_
 8-9	העיר	_	_	_	_	_	_	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -2918,7 +2918,7 @@
 1	כאן	כאן	ADV	ADV	_	4	advmod	_	_
 2	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 3	גם	גם	ADV	ADV	_	4	advmod	_	_
-4	נתקל	נתקל	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+4	נתקל	נתקל	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ת.ק.ל|Tense=Past|Voice=Mid	0	root	_	_
 5-7	בהפגנה	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -2941,13 +2941,13 @@
 # text = "לא נשפוך דם למען נפט", קראו לעברו כמה צעירים באסיפת בחירות לטובת מועמד רפובליקאי.
 1	"	"	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	נשפוך	שפך	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Fut|Voice=Act	9	obl	_	_
+3	נשפוך	שפך	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=ש.פ.כ|Tense=Fut|Voice=Act	9	obl	_	_
 4	דם	דם	NOUN	NOUN	Gender=Masc|Number=Sing	3	obj	_	_
 5	למען	למען	ADP	ADP	_	6	case	_	_
 6	נפט	נפט	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
 7	"	"	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	9	punct	_	_
-9	קראו	קרא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+9	קראו	קרא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ק.ר.א|Tense=Past|Voice=Act	0	root	_	_
 10-11	לעברו	_	_	_	_	_	_	_	_
 10	לעבר_	לעבר	ADP	ADP	_	11	case	_	_
 11	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	obl	_	_
@@ -2971,7 +2971,7 @@
 3	נפט	נפט	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 4	"	"	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	6	punct	_	_
-6	כעס	כעס	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	parataxis	_	_
+6	כעס	כעס	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ע.ס|Tense=Past|Voice=Act	3	parataxis	_	_
 7-8	הנשיא	_	_	_	_	_	_	_	SpaceAfter=No
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
@@ -2998,7 +2998,7 @@
 
 # sent_id = 80
 # text = אומרים עליה, שיש בה יותר ארגונים פציפיסטיים לקילומטר מרובע מאשר בכל מדינה אחרת של ארה"ב.
-1	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+1	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 2-3	עליה	_	_	_	_	_	_	_	SpaceAfter=No
 2	על_	על	ADP	ADP	_	3	case	_	_
 3	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	1	obl	_	_
@@ -3030,7 +3030,7 @@
 # text = פציפיזם אינו מוגבל באיובה לסטודנטים רדיקליים, אפשר למצוא אותו גם בין חקלאים ופועלי חרושת.
 1	פציפיזם	פציפיזם	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
 2	אינו	אינו	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	3	advmod	_	_
-3	מוגבל	הוגבל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+3	מוגבל	הוגבל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ג.ב.ל|VerbForm=Part|Voice=Pass	0	root	_	_
 4-5	באיובה	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	איובה	איובה	PROPN	PROPN	_	3	obl	_	_
@@ -3040,7 +3040,7 @@
 8	רדיקליים	רדיקלי	ADJ	ADJ	Gender=Masc|Number=Plur	7	amod	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	3	punct	_	_
 10	אפשר	אפשר	AUX	AUX	VerbType=Mod	11	aux	_	_
-11	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	parataxis	_	_
+11	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|Root=מ.צ.א|VerbForm=Inf|Voice=Act	3	parataxis	_	_
 12-13	אותו	_	_	_	_	_	_	_	_
 12	את_	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 13	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	obj	_	_
@@ -3073,7 +3073,7 @@
 13	_של_	של	ADP	ADP	_	14	case:gen	_	_
 14	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	12	nmod:poss	_	_
 15	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
-16	מייצאת	ייצא	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	conj	_	_
+16	מייצאת	ייצא	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=י.צ.א|VerbForm=Part|Voice=Act	4	conj	_	_
 17-18	אותם	_	_	_	_	_	_	_	_
 17	את_	את	ADP	ADP	Case=Acc	18	case:acc	_	_
 18	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	16	obj	_	_
@@ -3093,7 +3093,7 @@
 1-2	ב0891	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	0891	0891	NUM	NUM	_	3	obl	_	_
-3	נקלעה	נקלע	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+3	נקלעה	נקלע	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ק.ל.ע|Tense=Past|Voice=Mid	0	root	_	_
 4	איובה	איובה	PROPN	PROPN	_	3	nsubj	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	3	punct	_	_
 6	יחד	יחד	ADV	ADV	_	8	case	_	_
@@ -3119,8 +3119,8 @@
 22	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	25	nsubj	_	_
 23	גימי	גימי	PROPN	PROPN	_	22	flat:name	_	_
 24	קרטר	קרטר	PROPN	PROPN	_	22	flat:name	_	_
-25	החליט	החליט	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	parataxis	_	_
-26	להטיל	הטיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	25	xcomp	_	_
+25	החליט	החליט	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ל.ט|Tense=Past|Voice=Act	3	parataxis	_	_
+26	להטיל	הטיל	VERB	VERB	HebBinyan=HIFIL|Root=נ.ט.ל|VerbForm=Inf|Voice=Act	25	xcomp	_	_
 27	חרם	חרם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	26	obj	_	_
 28	דגנים	דגן	NOUN	NOUN	Gender=Masc|Number=Plur	27	compound:smixut	_	_
 29	על	על	ADP	ADP	_	31	case	_	_
@@ -3141,7 +3141,7 @@
 # sent_id = 84
 # text = איובה שילמה את המחיר עד אמצע שנות ה80.
 1	איובה	איובה	PROPN	PROPN	_	2	nsubj	_	_
-2	שילמה	שילם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	שילמה	שילם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.ל.מ|Tense=Past|Voice=Act	0	root	_	_
 3	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 4-5	המחיר	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -3161,7 +3161,7 @@
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
 3	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	1	nmod:poss	_	_
 4	היתה	היה	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	5	cop	_	_
-5	שקועה	שקוע	VERB	VERB	VerbForm=Part	0	root	_	_
+5	שקועה	שקוע	VERB	VERB	HebBinyan=PAAL|Root=ש.ק.ע|VerbForm=Part	0	root	_	_
 6-7	במיתון	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	מיתון	מיתון	NOUN	NOUN	Gender=Masc|Number=Sing	5	obl	_	_
@@ -3182,7 +3182,7 @@
 18-19	בארה"ב	_	_	_	_	_	_	_	_
 18	ב	ב	ADP	ADP	_	19	case	_	_
 19	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	15	nmod	_	_
-20	נהנו	נהנה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	11	acl:relcl	_	_
+20	נהנו	נהנה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ה.נ.י|Tense=Past|Voice=Mid	11	acl:relcl	_	_
 21-22	משגשוג	_	_	_	_	_	_	_	_
 21	מ	מ	ADP	ADP	_	22	case	_	_
 22	שגשוג	שגשוג	NOUN	NOUN	Gender=Masc|Number=Sing	20	obl	_	_
@@ -3196,7 +3196,7 @@
 2	רק	רק	ADV	ADV	_	3	advmod	_	_
 3	מניעים	מניע	NOUN	NOUN	Gender=Masc|Number=Plur	5	nsubj	_	_
 4	אלטרואיסטיים	אלטרואיסטי	ADJ	ADJ	Gender=Masc|Number=Plur	3	amod	_	_
-5	מעוררים	עורר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	מעוררים	עורר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ע.ו.ר|VerbForm=Part|Voice=Act	0	root	_	_
 6	איפוא	אפוא	ADV	ADV	_	5	advmod	_	_
 7-8	באיובה	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
@@ -3216,7 +3216,7 @@
 # text = כאן אין אוהבים ביותר את הרעיון של מלחמה במפרץ הפרסי.
 1	כאן	כאן	ADV	ADV	_	3	advmod	_	_
 2	אין	_	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	אוהבים	אהב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+3	אוהבים	אהב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=א.ה.ב|VerbForm=Part|Voice=Act	0	root	_	_
 4	ביותר	ביותר	ADV	ADV	_	3	advmod	_	_
 5	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 6-7	הרעיון	_	_	_	_	_	_	_	_
@@ -3243,8 +3243,8 @@
 5	שבוע	שבוע	NOUN	NOUN	Gender=Masc|Number=Sing	1	nmod	_	_
 6-7	שעבר	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
-7	עבר	עבר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	5	acl:relcl	_	_
-8	מרח	מרח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	עבר	עבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past	5	acl:relcl	_	_
+8	מרח	מרח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.ר.ח|Tense=Past|Voice=Act	0	root	_	_
 9-10	העיתון	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	עיתון	עיתון	NOUN	NOUN	Gender=Masc|Number=Sing	8	nsubj	_	_
@@ -3282,7 +3282,7 @@
 # text = ", אמרה הכותרת באנגלית, "שלום עכשיו".
 1	"	"	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 2	,	,	PUNCT	PUNCT	_	3	punct	_	_
-3	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 4-5	הכותרת	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	כותרת	כותרת	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
@@ -3305,7 +3305,7 @@
 4-5	האדומות	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	אדומות	אדום	ADJ	ADJ	Gender=Fem|Number=Plur	3	amod	_	_
-6	הציב	הציב	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	הציב	הציב	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.צ.ב|Tense=Past|Voice=Act	0	root	_	_
 7-8	העיתון	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	עיתון	עיתון	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
@@ -3327,7 +3327,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	יום	יום	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 3	אחר	אחר	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-4	פירסם	פרסם	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	פירסם	פרסם	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=פ.ר.ס.מ|Tense=Past|Voice=Act	0	root	_	_
 5-6	העיתון	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	עיתון	עיתון	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
@@ -3348,7 +3348,7 @@
 
 # sent_id = 92
 # text = נראה בה מלאך המוות חבוש כאפייה, ומפיו בוקעות המלים: "קרא את שפתיי, גורג לא תהיה עוד וייטנאם".
-1	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+1	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ר.א.י|Tense=Past|Voice=Mid	0	root	_	_
 2-3	בה	_	_	_	_	_	_	_	_
 2	ב_	ב	ADP	ADP	_	3	case	_	_
 3	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	1	obl	_	_
@@ -3365,7 +3365,7 @@
 12	פה_	פה	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	15	obl	_	_
 13	_של_	של	ADP	ADP	_	14	case:gen	_	_
 14	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nmod:poss	_	_
-15	בוקעות	בקע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	1	conj	_	_
+15	בוקעות	בקע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ב.ק.ע|VerbForm=Part|Voice=Act	1	conj	_	_
 16-17	המלים	_	_	_	_	_	_	_	SpaceAfter=No
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	מלים	מילה	NOUN	NOUN	Gender=Fem|Number=Plur	15	nsubj	_	_
@@ -3377,7 +3377,7 @@
 23	,	,	PUNCT	PUNCT	_	20	punct	_	_
 24	גורג	גורג	PROPN	PROPN	_	20	obl	_	_
 25	לא	לא	ADV	ADV	Polarity=Neg	26	advmod	_	_
-26	תהיה	היה	VERB	VERB	Gender=Fem|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	20	parataxis	_	_
+26	תהיה	היה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	20	parataxis	_	_
 27	עוד	עוד	ADV	ADV	_	28	det	_	_
 28	וייטנאם	וייטנאם	PROPN	PROPN	_	26	nsubj	_	SpaceAfter=No
 29	"	"	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
@@ -3425,7 +3425,7 @@
 23	את	את	ADP	ADP	Case=Acc	24	case:acc	_	_
 24	שפתיי	שפתיי	NOUN	NOUN	_	22	obj	_	_
 25	לא	לא	ADV	ADV	Polarity=Neg	26	advmod	_	_
-26	יהיו	היה	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Fut	22	parataxis	_	_
+26	יהיו	היה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	22	parataxis	_	_
 27	מסים	מס	NOUN	NOUN	Gender=Masc|Number=Plur	26	nsubj	_	_
 28	חדשים	חדש	ADJ	ADJ	Gender=Masc|Number=Plur	27	amod	_	SpaceAfter=No
 29	"	"	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
@@ -3451,7 +3451,7 @@
 12	דמוקרטי	דמוקרטי	ADJ	ADJ	Gender=Masc|Number=Sing	10	amod	_	_
 13-14	שהעמיד	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
-14	העמיד	העמיד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	acl:relcl	_	_
+14	העמיד	העמיד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ע.מ.ד|Tense=Past|Voice=Act	10	acl:relcl	_	_
 15	את	את	ADP	ADP	Case=Acc	16	case:acc	_	_
 16	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	14	obj	_	_
 17	השבוע	השבוע	ADV	ADV	_	14	advmod	_	_
@@ -3460,7 +3460,7 @@
 19	בחירה	בחירה	NOUN	NOUN	Gender=Fem|Number=Sing	14	obl	_	_
 20	חוזרת	חוזר	ADJ	ADJ	Gender=Fem|Number=Sing	19	amod	_	SpaceAfter=No
 21	,	,	PUNCT	PUNCT	_	22	punct	_	_
-22	הסביר	הסביר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+22	הסביר	הסביר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ס.ב.ר|Tense=Past|Voice=Act	0	root	_	_
 23-24	לי	_	_	_	_	_	_	_	_
 23	ל_	ל	ADP	ADP	_	24	case	_	_
 24	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	22	obl	_	_
@@ -3470,11 +3470,11 @@
 27	אחד	אחד	NUM	NUM	Definite=Cons|Gender=Masc|Number=Sing	29	nummod	_	_
 28-29	הנוכחים	_	_	_	_	_	_	_	_
 28	ה	ה	DET	DET	PronType=Art	29	det:def	_	_
-29	נוכחים	נוכח	VERB	VERB	Gender=Masc|Number=Plur|Person=1,2,3|VerbForm=Part	22	nsubj	_	_
+29	נוכחים	נוכח	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=י.כ.ח|VerbForm=Part	22	nsubj	_	_
 30	כיצד	כיצד	ADV	ADV	PronType=Int	31	advmod	_	_
 31	יכולה	יכול	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	33	aux	_	_
 32	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	31	nsubj	_	_
-33	ליישב	יישב	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	22	obl	_	_
+33	ליישב	יישב	VERB	VERB	HebBinyan=PIEL|Root=י.ש.ב|VerbForm=Inf|Voice=Act	22	obl	_	_
 34	את	את	ADP	ADP	Case=Acc	35	case:acc	_	_
 35	סכסוך	סכסוך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	33	obj	_	_
 36-37	המפרץ	_	_	_	_	_	_	_	_
@@ -3487,7 +3487,7 @@
 41	"	"	PUNCT	PUNCT	_	44	punct	_	SpaceAfter=No
 42	אם	אם	SCONJ	SCONJ	_	44	mark	_	_
 43	רק	רק	ADV	ADV	_	44	advmod	_	_
-44	תביא	הביא	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	31	advcl	_	_
+44	תביא	הביא	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ב.ו.א|Tense=Fut|Voice=Act	31	advcl	_	_
 45	את	את	ADP	ADP	Case=Acc	47	case:acc	_	_
 46-47	העניין	_	_	_	_	_	_	_	_
 46	ה	ה	DET	DET	PronType=Art	47	det:def	_	_
@@ -3510,7 +3510,7 @@
 
 # sent_id = 96
 # text = התבוננתי בבן שיחי בהפתעה ניכרת.
-1	התבוננתי	התבונן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Sing|Person=1|Tense=Past	0	root	_	_
+1	התבוננתי	התבונן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Sing|Person=1|Root=ב.ו.נ|Tense=Past	0	root	_	_
 2-3	בבן	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
 3	בן	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	obl	_	_
@@ -3544,7 +3544,7 @@
 13	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	9	obl	_	_
 14	,	,	PUNCT	PUNCT	_	16	punct	_	_
 15	לא	לא	ADV	ADV	Polarity=Neg	16	advmod	_	_
-16	שמעתי	שמע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Sing|Person=1|Tense=Past|Voice=Act	0	root	_	_
+16	שמעתי	שמע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Sing|Person=1|Root=ש.מ.ע|Tense=Past|Voice=Act	0	root	_	_
 17	כבר	כבר	ADV	ADV	_	19	det	_	_
 18	הרבה	הרבה	DET	DET	Definite=Cons	19	det	_	_
 19	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	16	dep	_	SpaceAfter=No
@@ -3564,12 +3564,12 @@
 7	של	של	ADP	ADP	Case=Gen	8	case:gen	_	_
 8	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	4	nmod:poss	_	_
 9	קל	קל	AUX	AUX	Gender=Masc|Number=Sing|Tense=Past|VerbType=Mod	10	aux	_	_
-10	להאמין	האמין	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+10	להאמין	האמין	VERB	VERB	HebBinyan=HIFIL|Root=א.מ.נ|VerbForm=Inf|Voice=Act	0	root	_	_
 11-13	שהעולם	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	עולם	עולם	NOUN	NOUN	Gender=Masc|Number=Sing	14	nsubj	_	_
-14	נברא	נברא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	10	ccomp	_	_
+14	נברא	נברא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ב.ר.א|Tense=Past|Voice=Mid	10	ccomp	_	_
 15-16	בצלם	_	_	_	_	_	_	_	_
 15	ב	ב	ADP	ADP	_	16	case	_	_
 16	צלם	צלם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	obl	_	_
@@ -3599,16 +3599,16 @@
 35	ש	ש	SCONJ	SCONJ	_	43	mark	_	_
 36	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	43	nsubj	_	_
 37	,	,	PUNCT	PUNCT	_	39	punct	_	_
-38	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	39	case	_	_
+38	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	39	case	_	_
 39	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	36	appos	_	SpaceAfter=No
 40	,	,	PUNCT	PUNCT	_	39	punct	_	_
 41	מעולם	מעולם	ADV	ADV	_	43	advmod	_	_
 42	לא	לא	ADV	ADV	HebSource=ConvUncertainHead|Polarity=Neg	41	fixed	_	_
-43	לקח	לקח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	34	acl:relcl	_	_
+43	לקח	לקח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ל.ק.ח|Tense=Past|Voice=Act	34	acl:relcl	_	_
 44-45	ברצינות	_	_	_	_	_	_	_	_
 44	ב	ב	ADP	ADP	_	45	case	_	_
 45	רצינות	רצינות	NOUN	NOUN	Gender=Fem|Number=Sing	43	obl	_	_
-46	תעשה	עשה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	14	conj	_	_
+46	תעשה	עשה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Fut|Voice=Act	14	conj	_	_
 47	רושם	רושם	NOUN	NOUN	Gender=Masc|Number=Sing	46	obj	_	_
 48	מיידי	מיידי	ADJ	ADJ	Gender=Masc|Number=Sing	47	amod	_	_
 49	על	על	ADP	ADP	_	50	case	_	_
@@ -3662,15 +3662,15 @@
 16	,	,	PUNCT	PUNCT	_	19	punct	_	_
 17	אמנם	אמנם	ADV	ADV	_	19	advmod	_	_
 18	לא	לא	ADV	ADV	Polarity=Neg	19	advmod	_	_
-19	יכלו	יכל	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut	0	root	_	_
-20	להסכים	הסכים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	19	xcomp	_	_
+19	יכלו	יכל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.כ.ל|Tense=Fut	0	root	_	_
+20	להסכים	הסכים	VERB	VERB	HebBinyan=HIFIL|Root=ס.כ.מ|VerbForm=Inf|Voice=Act	19	xcomp	_	_
 21	על	על	ADP	ADP	_	23	case	_	_
 22	שום	שום	DET	DET	Definite=Cons	23	det	_	_
 23	עניין	עניין	NOUN	NOUN	Gender=Masc|Number=Sing	20	obl	_	SpaceAfter=No
 24	,	,	PUNCT	PUNCT	_	19	punct	_	_
 25	אבל	אבל	CCONJ	CCONJ	_	26	cc	_	_
-26	נטו	נטה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	19	conj	_	_
-27	להסכים	הסכים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	26	xcomp	_	_
+26	נטו	נטה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=נ.ט.י|Tense=Past|Voice=Act	19	conj	_	_
+27	להסכים	הסכים	VERB	VERB	HebBinyan=HIFIL|Root=ס.כ.מ|VerbForm=Inf|Voice=Act	26	xcomp	_	_
 28	על	על	ADP	ADP	_	30	case	_	_
 29-30	המפרץ	_	_	_	_	_	_	_	_
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
@@ -3683,7 +3683,7 @@
 # sent_id = 101
 # text = שניהם תומכים בנשיא, ושניהם מאמינים בצורך בזהירות.
 1	שניהם	שניים	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	2	nsubj	_	_
-2	תומכים	תמך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	תומכים	תמך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ת.מ.כ|VerbForm=Part|Voice=Act	0	root	_	_
 3-5	בנשיא	_	_	_	_	_	_	_	SpaceAfter=No
 3	ב	ב	ADP	ADP	_	5	case	_	_
 4	ה_	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -3692,7 +3692,7 @@
 7-8	ושניהם	_	_	_	_	_	_	_	_
 7	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
 8	שניהם	שניים	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	9	nsubj	_	_
-9	מאמינים	האמין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	conj	_	_
+9	מאמינים	האמין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=א.מ.נ|VerbForm=Part|Voice=Act	2	conj	_	_
 10-12	בצורך	_	_	_	_	_	_	_	_
 10	ב	ב	ADP	ADP	_	12	case	_	_
 11	ה_	ה	DET	DET	PronType=Art	12	det:def	_	_
@@ -3718,20 +3718,20 @@
 9	אנטי	אנטי	ADV	ADV	HebSource=ConvUncertainHead|Prefix=Yes	11	compound:affix	_	SpaceAfter=No
 10	-	-	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
 11	קומוניסט	קומוניסט	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
-12	נלהב	נלהב	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	11	amod	_	SpaceAfter=No
+12	נלהב	נלהב	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ל.ה.ב|VerbForm=Part|Voice=Mid	11	amod	_	SpaceAfter=No
 13	,	,	PUNCT	PUNCT	_	11	punct	_	_
 14-15	והארקין	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
 15	הארקין	הארקין	PROPN	PROPN	_	17	nsubj	_	_
 16	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	17	cop	_	_
 17	יונה	יון	NOUN	NOUN	Gender=Fem|Number=Sing	11	conj	_	_
-18	נלהבת	נלהב	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	17	amod	_	SpaceAfter=No
+18	נלהבת	נלהב	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ל.ה.ב|VerbForm=Part|Voice=Mid	17	amod	_	SpaceAfter=No
 19	.	.	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 103
 # text = טוקי תמך בכל סעיף הוצאות צבאיות אפשרי, וחייב את המאבק להפלת ממשלת ניקרגואה; הארקין רצה קיצוצים ניכרים בתקציב הביטחון, ועמד בראש המאבק בסנאט נגד הסיוע לקונטראס.
 1	טוקי	טוקי	PROPN	PROPN	_	2	nsubj	_	_
-2	תמך	תמך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	תמך	תמך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ת.מ.כ|Tense=Past|Voice=Act	0	root	_	_
 3-4	בכל	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	5	case	_	_
 4	כל	כול	DET	DET	Definite=Cons	5	det	_	_
@@ -3742,7 +3742,7 @@
 9	,	,	PUNCT	PUNCT	_	2	punct	_	_
 10-11	וחייב	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
-11	חייב	חייב	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+11	חייב	חייב	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ח.ו.ב|Tense=Past|Voice=Act	2	conj	_	_
 12	את	את	ADP	ADP	Case=Acc	14	case:acc	_	_
 13-14	המאבק	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
@@ -3754,7 +3754,7 @@
 18	ניקרגואה	ניקרגוואה	PROPN	PROPN	_	17	compound:smixut	_	SpaceAfter=No
 19	;	;	PUNCT	PUNCT	_	21	cc	_	_
 20	הארקין	הארקין	PROPN	PROPN	_	21	nsubj	_	_
-21	רצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+21	רצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ר.צ.י|Tense=Past|Voice=Act	2	conj	_	_
 22	קיצוצים	קיצוץ	NOUN	NOUN	Gender=Masc|Number=Plur	21	obj	_	_
 23	ניכרים	ניכר	ADJ	ADJ	Gender=Masc|Number=Plur	22	amod	_	_
 24-25	בתקציב	_	_	_	_	_	_	_	_
@@ -3766,7 +3766,7 @@
 28	,	,	PUNCT	PUNCT	_	21	punct	_	_
 29-30	ועמד	_	_	_	_	_	_	_	_
 29	ו	ו	CCONJ	CCONJ	_	30	cc	_	_
-30	עמד	עמד	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	21	conj	_	_
+30	עמד	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.מ.ד|Tense=Past	21	conj	_	_
 31-32	בראש	_	_	_	_	_	_	_	_
 31	ב	ב	ADP	ADP	_	32	case	_	_
 32	ראש	ראש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	30	obl	_	_
@@ -3826,7 +3826,7 @@
 9-10	השטח	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	שטח	שטח	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	_
-11	חוזרת	חזר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	conj	_	_
+11	חוזרת	חזר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ח.ז.ר|VerbForm=Part|Voice=Act	4	conj	_	_
 12	גם	גם	ADV	ADV	_	13	det	_	_
 13	מידה	מידה	NOUN	NOUN	Gender=Fem|Number=Sing	11	nsubj	_	_
 14	הגונה	הגון	ADJ	ADJ	Gender=Fem|Number=Sing	13	amod	_	_
@@ -3858,7 +3858,7 @@
 4-5	הבחירות	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	3	compound:smixut	_	_
-6	הקרין	הקרין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	הקרין	הקרין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ק.ר.נ|Tense=Past|Voice=Act	0	root	_	_
 7-9	מטהו	_	_	_	_	_	_	_	_
 7	מטה_	מטה	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	_של_	של	ADP	ADP	_	9	case:gen	_	_
@@ -3906,7 +3906,7 @@
 13	ל	ל	ADP	ADP	_	14	case	_	_
 14	סיוע	סיוע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	nmod	_	_
 15	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	14	compound:smixut	_	_
-16	מעמידה	העמיד	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+16	מעמידה	העמיד	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ע.מ.ד|VerbForm=Part|Voice=Act	0	root	_	_
 17	את	את	ADP	ADP	Case=Acc	19	case:acc	_	_
 18-19	המתנגד	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
@@ -3921,7 +3921,7 @@
 25	גם	גם	ADV	ADV	_	28	advmod	_	_
 26	אם	אם	SCONJ	SCONJ	_	28	mark	_	_
 27	אינה	אינו	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	28	advmod	_	_
-28	מוסבת	הוסב	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	16	advcl	_	_
+28	מוסבת	הוסב	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ס.ב.ב|VerbForm=Part|Voice=Pass	16	advcl	_	_
 29	ספציפית	ספציפית	ADV	ADV	_	28	advmod	_	_
 30	על	על	ADP	ADP	_	31	case	_	_
 31	ישראל	ישראל	PROPN	PROPN	_	28	obl	_	SpaceAfter=No
@@ -3933,13 +3933,13 @@
 2	פרו	פרו	ADV	ADV	Prefix=Yes	4	compound:affix	_	SpaceAfter=No
 3	-	-	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 4	ישראליים	ישראלי	ADJ	ADJ	Gender=Masc|Number=Plur	1	amod	_	_
-5	עודדו	עודד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	עודדו	עודד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ע.ד.ד|Tense=Past|Voice=Act	0	root	_	_
 6	מאז	מאז	ADV	ADV	_	5	advmod	_	_
 7-8	ומעולם	_	_	_	_	_	_	_	_
 7	ו	ו	CCONJ	CCONJ	_	8	cc	_	_
 8	מעולם	מעולם	ADV	ADV	_	6	conj	_	_
 9	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	5	obj	_	_
-10	לתרום	תרם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
+10	לתרום	תרם	VERB	VERB	HebBinyan=PAAL|Root=ת.ר.מ|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 11	כספים	כסף	NOUN	NOUN	Gender=Masc|Number=Plur	10	obj	_	_
 12-13	למועמדים	_	_	_	_	_	_	_	SpaceAfter=No
 12	ל	ל	ADP	ADP	_	13	case	_	_
@@ -3947,7 +3947,7 @@
 14	,	,	PUNCT	PUNCT	_	13	punct	_	_
 15-16	הנאבקים	_	_	_	_	_	_	_	_
 15	ה	ה	SCONJ	SCONJ	_	16	mark	_	_
-16	נאבקים	נאבק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	13	acl:relcl	_	_
+16	נאבקים	נאבק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=א.ב.ק|VerbForm=Part|Voice=Mid	13	acl:relcl	_	_
 17	נגד	נגד	ADP	ADP	_	18	case	_	_
 18	מתנגדי	מתנגד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	16	obl	_	_
 19	סיוע	סיוע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	18	compound:smixut	_	_
@@ -4005,7 +4005,7 @@
 5	איובה	איובה	PROPN	PROPN	_	2	nmod	_	_
 6	,	,	PUNCT	PUNCT	_	8	punct	_	_
 7	הארקין	הארקין	PROPN	PROPN	_	8	nsubj	_	_
-8	קיבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+8	קיבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Past|Voice=Act	0	root	_	_
 9	002	002	NUM	NUM	_	10	nummod	_	_
 10	אלף	אלף	NUM	NUM	Gender=Masc|Number=Sing	11	nummod	_	_
 11	דולר	דולר	NOUN	NOUN	Gender=Masc|Number=Sing	8	obj	_	_
@@ -4027,7 +4027,7 @@
 # sent_id = 111
 # text = טוקי קיבל רק 52 אלף.
 1	טוקי	טוקי	PROPN	PROPN	_	2	nsubj	_	_
-2	קיבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	קיבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Past|Voice=Act	0	root	_	_
 3	רק	רק	ADV	ADV	_	5	det	_	_
 4	52	52	NUM	NUM	_	5	nummod	_	_
 5	אלף	אלף	NUM	NUM	Gender=Masc|Number=Sing	2	obj	_	SpaceAfter=No
@@ -4038,7 +4038,7 @@
 1-2	ב48	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	48	48	NUM	NUM	_	3	obl	_	_
-3	תיאר	תיאר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	תיאר	תיאר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ת.א.ר|Tense=Past|Voice=Act	0	root	_	_
 4	מנכ"ל	מנכ"ל	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	3	nsubj	_	_
 5	אייפא"ק	אייפא"ק	PROPN	PROPN	Abbr=Yes	4	compound:smixut	_	_
 6	טום	טום	PROPN	PROPN	_	4	appos	_	_
@@ -4057,7 +4057,7 @@
 17	,	,	PUNCT	PUNCT	_	16	punct	_	_
 18-19	שנבחרו	_	_	_	_	_	_	_	_
 18	ש	ש	SCONJ	SCONJ	_	19	mark	_	_
-19	נבחרו	נבחר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	16	acl:relcl	_	_
+19	נבחרו	נבחר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ב.ח.ר|Tense=Past|Voice=Mid	16	acl:relcl	_	_
 20	בזכות	בזכות	ADP	ADP	_	22	case	_	_
 21	"	"	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
 22	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	19	obl	_	_
@@ -4080,7 +4080,7 @@
 10	ספק	ספק	NOUN	NOUN	Gender=Masc|Number=Sing	9	nsubj	_	_
 11-12	שיימנע	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-12	יימנע	נמנע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	10	acl:relcl	_	_
+12	יימנע	נמנע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.נ.ע|Tense=Fut|Voice=Mid	10	acl:relcl	_	_
 13-14	ממנה	_	_	_	_	_	_	_	_
 13	מן_	מן	ADP	ADP	_	14	case	_	_
 14	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	12	obl	_	_
@@ -4104,7 +4104,7 @@
 13-14	בוואשינגטון	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	וואשינגטון	ואשינגטון	PROPN	PROPN	_	9	nmod	_	_
-15	חככו	חכך	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	0	root	_	_
+15	חככו	חכך	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ח.כ.כ|Tense=Past	0	root	_	_
 16	השבוע	השבוע	ADV	ADV	_	15	advmod	_	_
 17	את	את	ADP	ADP	Case=Acc	18	case:acc	_	_
 18-20	ידיהם	_	_	_	_	_	_	_	_
@@ -4125,13 +4125,13 @@
 29-30	שהארקין	_	_	_	_	_	_	_	_
 29	ש	ש	SCONJ	SCONJ	_	31	mark	_	_
 30	הארקין	הארקין	PROPN	PROPN	_	31	nsubj	_	_
-31	גבר	גבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	27	acl:relcl	_	_
+31	גבר	גבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ג.ב.ר|Tense=Past|Voice=Act	27	acl:relcl	_	_
 32	על	על	ADP	ADP	_	33	case	_	_
 33	טוקי	טוקי	PROPN	PROPN	_	31	obl	_	_
 34-35	בהפרש	_	_	_	_	_	_	_	_
 34	ב	ב	ADP	ADP	_	35	case	_	_
 35	הפרש	הפרש	NOUN	NOUN	Gender=Masc|Number=Sing	31	obl	_	_
-36	משכנע	שכנע	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	35	amod	_	_
+36	משכנע	שכנע	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ש.כ.נ.ע|VerbForm=Part|Voice=Act	35	amod	_	_
 37	של	של	ADP	ADP	Case=Gen	39	case:gen	_	_
 38	10	10	NUM	NUM	_	39	nummod	_	SpaceAfter=No
 39	%	%	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	35	nmod	_	SpaceAfter=No
@@ -4155,7 +4155,7 @@
 10	איובה	איובה	PROPN	PROPN	_	9	compound:smixut	_	_
 11-12	הנבחר	_	_	_	_	_	_	_	_
 11	ה	ה	SCONJ	SCONJ	_	12	mark	_	_
-12	נבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	3	acl:relcl	_	_
+12	נבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ב.ח.ר|VerbForm=Part|Voice=Mid	3	acl:relcl	_	_
 13-14	לתקופת	_	_	_	_	_	_	_	_
 13	ל	ל	ADP	ADP	_	14	case	_	_
 14	תקופת	תקופה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	12	obl	_	_
@@ -4167,7 +4167,7 @@
 # text = הוא גם יודע, שבלי תרומות מחוץ לגבולות מדינתו הקטנה, יתקשה לאסוף די כסף לניהול מערכת הבחירות הטלוויזיונית היקרה, שבלעדיה אין פוליטיקאים אמריקאיים מסוגלים לנצח.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	גם	גם	ADV	ADV	_	3	advmod	_	_
-3	יודע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
+3	יודע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	3	punct	_	_
 5-6	שבלי	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
@@ -4187,8 +4187,8 @@
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	קטנה	קטן	ADJ	ADJ	Gender=Fem|Number=Sing	12	amod	_	_
 17	,	,	PUNCT	PUNCT	_	18	punct	_	_
-18	יתקשה	התקשה	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	3	ccomp	_	_
-19	לאסוף	אסף	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	18	xcomp	_	_
+18	יתקשה	התקשה	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ק.ש.י|Tense=Fut	3	ccomp	_	_
+19	לאסוף	אסף	VERB	VERB	HebBinyan=PAAL|Root=א.ס.פ|VerbForm=Inf|Voice=Act	18	xcomp	_	_
 20	די	די	DET	DET	Definite=Cons	21	det	_	_
 21	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	19	obj	_	_
 22-23	לניהול	_	_	_	_	_	_	_	_
@@ -4213,7 +4213,7 @@
 36	פוליטיקאים	פוליטיקאי	NOUN	NOUN	Gender=Masc|Number=Plur	38	nsubj	_	_
 37	אמריקאיים	אמריקני	ADJ	ADJ	Gender=Masc|Number=Plur	36	amod	_	_
 38	מסוגלים	מסוגל	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbType=Mod	39	aux	_	_
-39	לנצח	ניצח	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	24	acl:relcl	_	SpaceAfter=No
+39	לנצח	ניצח	VERB	VERB	HebBinyan=PIEL|Root=נ.צ.ח|VerbForm=Inf|Voice=Act	24	acl:relcl	_	SpaceAfter=No
 40	.	.	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 117
@@ -4224,7 +4224,7 @@
 4	,	,	PUNCT	PUNCT	_	1	punct	_	_
 5-6	שיצביע	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	יצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	1	ccomp	_	_
+6	יצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ב.ע|Tense=Fut|Voice=Act	1	ccomp	_	_
 7	גם	גם	ADV	ADV	_	8	advmod	_	_
 8-10	בעתיד	_	_	_	_	_	_	_	_
 8	ב	ב	ADP	ADP	_	10	case	_	_
@@ -4248,20 +4248,20 @@
 5-6	החקלאיים	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	חקלאיים	חקלאי	ADJ	ADJ	Gender=Masc|Number=Plur	4	amod	_	_
-7	הציעה	הציע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	הציעה	הציע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.צ.ע|Tense=Past|Voice=Act	0	root	_	_
 8	אתמול	אתמול	ADV	ADV	_	7	advmod	_	_
 9-11	שהממשלה	_	_	_	_	_	_	_	_
 9	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	ממשלה	ממשלה	NOUN	NOUN	Gender=Fem|Number=Sing	12	nsubj	_	_
-12	תשלם	שילם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	7	ccomp	_	_
+12	תשלם	שילם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.ל.מ|Tense=Fut|Voice=Act	7	ccomp	_	_
 13	מענק	מענק	NOUN	NOUN	Gender=Masc|Number=Sing	12	obj	_	_
 14	חודשי	חודשי	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	_
 15	של	של	ADP	ADP	Case=Gen	17	case:gen	_	_
 16	500	500	NUM	NUM	_	17	nummod	_	_
 17	ש"ח	ש"ח	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 18	,	,	PUNCT	PUNCT	_	13	punct	_	_
-19	נוסף	נוסף	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	22	case	_	_
+19	נוסף	נוסף	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=י.ס.פ|VerbForm=Part	22	case	_	_
 20-22	לשכר	_	_	_	_	_	_	_	_
 20	ל	ל	ADP	ADP	_	19	fixed	_	_
 21	ה_	ה	DET	DET	PronType=Art	22	det:def	_	_
@@ -4276,7 +4276,7 @@
 28	ישראלי	ישראלי	NOUN	NOUN	Gender=Masc|Number=Sing	12	obl	_	_
 29-30	שיעבוד	_	_	_	_	_	_	_	_
 29	ש	ש	SCONJ	SCONJ	_	30	mark	_	_
-30	יעבוד	עבד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	28	acl:relcl	_	_
+30	יעבוד	עבד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ב.ד|Tense=Fut|Voice=Act	28	acl:relcl	_	_
 31-32	בקטיף	_	_	_	_	_	_	_	_
 31	ב	ב	ADP	ADP	_	32	case	_	_
 32	קטיף	קטיף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	30	obl	_	_
@@ -4303,12 +4303,12 @@
 8	חיים	חיים	PROPN	PROPN	_	1	appos	_	_
 9	אביבי	אביבי	PROPN	PROPN	_	8	flat:name	_	SpaceAfter=No
 10	,	,	PUNCT	PUNCT	_	11	punct	_	_
-11	מסר	מסר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+11	מסר	מסר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.ס.ר|Tense=Past|Voice=Act	0	root	_	_
 12-14	שההצעה	_	_	_	_	_	_	_	_
 12	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	הצעה	הצעה	NOUN	NOUN	Gender=Fem|Number=Sing	15	nsubj	_	_
-15	הועלתה	הועלה	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	11	ccomp	_	_
+15	הועלתה	הועלה	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ע.ל.י|Tense=Past|Voice=Pass	11	ccomp	_	_
 16	לנוכח	לנוכח	ADP	ADP	_	18	case	_	_
 17-18	המחסור	_	_	_	_	_	_	_	_
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
@@ -4319,12 +4319,12 @@
 21	קטיף	קטיף	NOUN	NOUN	Gender=Masc|Number=Sing	20	compound:smixut	_	_
 22-23	המורגש	_	_	_	_	_	_	_	_
 22	ה	ה	SCONJ	SCONJ	_	23	mark	_	_
-23	מורגש	הורגש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	18	acl:relcl	_	_
+23	מורגש	הורגש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ר.ג.ש|VerbForm=Part|Voice=Pass	18	acl:relcl	_	_
 24	כבר	כבר	ADV	ADV	HebSource=ConvUncertainHead	25	advmod	_	_
 25	כעת	כעת	ADV	ADV	_	23	advmod	_	_
 26-27	ויוחרף	_	_	_	_	_	_	_	_
 26	ו	ו	CCONJ	CCONJ	_	27	cc	_	_
-27	יוחרף	הוחרף	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	23	conj	_	_
+27	יוחרף	הוחרף	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ח.ר.פ|Tense=Fut|Voice=Pass	23	conj	_	_
 28-30	בחודש	_	_	_	_	_	_	_	_
 28	ב	ב	ADP	ADP	_	30	case	_	_
 29	ה_	ה	DET	DET	PronType=Art	30	det:def	_	_
@@ -4360,11 +4360,11 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	מעסיקים	מעסיק	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	_
 3	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	4	advmod	_	_
-4	מצפים	ציפה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+4	מצפים	ציפה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=צ.פ.י|VerbForm=Part|Voice=Act	0	root	_	_
 5-6	שיצליחו	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	יצליחו	הצליח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Fut|Voice=Act	4	ccomp	_	_
-7	למשוך	משך	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
+6	יצליחו	הצליח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=צ.ל.ח|Tense=Fut|Voice=Act	4	ccomp	_	_
+7	למשוך	משך	VERB	VERB	HebBinyan=PAAL|Root=מ.ש.כ|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 8	מספר	מספר	NOUN	NOUN	Gender=Masc|Number=Sing	7	obj	_	_
 9	ניכר	ניכר	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
 10	של	של	ADP	ADP	Case=Gen	11	case:gen	_	_
@@ -4384,7 +4384,7 @@
 21	נמוך	נמוך	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	_
 22-23	המשולם	_	_	_	_	_	_	_	_
 22	ה	ה	SCONJ	SCONJ	_	23	mark	_	_
-23	משולם	שולם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	19	acl:relcl	_	_
+23	משולם	שולם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ש.ל.מ|VerbForm=Part|Voice=Pass	19	acl:relcl	_	_
 24-25	לעבודה	_	_	_	_	_	_	_	_
 24	ל	ל	ADP	ADP	_	25	case	_	_
 25	עבודה	עבודה	NOUN	NOUN	Gender=Fem|Number=Sing	23	obl	_	_
@@ -4410,7 +4410,7 @@
 4-5	הבא	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	בא	בא	ADJ	ADJ	Gender=Masc|Number=Sing	3	amod	_	_
-6	ידון	דן	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	0	root	_	_
+6	ידון	דן	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ד.ו.נ|Tense=Fut	0	root	_	_
 7	מנכ"ל	מנכ"ל	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	התאחדות	התאחדות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	compound:smixut	_	_
 9-10	האיכרים	_	_	_	_	_	_	_	SpaceAfter=No
@@ -4436,16 +4436,16 @@
 26-27	ההתאחדות	_	_	_	_	_	_	_	_
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	התאחדות	התאחדות	NOUN	NOUN	Gender=Fem|Number=Sing	25	compound:smixut	_	_
-28	לשכנע	שכנע	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	25	acl	_	_
+28	לשכנע	שכנע	VERB	VERB	HebBinyan=PIEL|Root=ש.כ.נ.ע|VerbForm=Inf|Voice=Act	25	acl	_	_
 29	עולים	עולה	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Plur	28	dep	_	_
 30	חדשים	חדש	ADJ	ADJ	Gender=Masc|Number=Plur	29	amod	_	_
 31-32	הלומדים	_	_	_	_	_	_	_	_
 31	ה	ה	SCONJ	SCONJ	_	32	mark	_	_
-32	לומדים	למד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	29	acl:relcl	_	_
+32	לומדים	למד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ל.מ.ד|VerbForm=Part|Voice=Act	29	acl:relcl	_	_
 33-34	באולפנים	_	_	_	_	_	_	_	_
 33	ב	ב	ADP	ADP	_	34	case	_	_
 34	אולפנים	אולפן	NOUN	NOUN	Gender=Masc|Number=Plur	32	obl	_	_
-35	לעבוד	עבד	VERB	VERB	HebBinyan=PAAL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	28	dep	_	_
+35	לעבוד	עבד	VERB	VERB	HebBinyan=PAAL|HebSource=ConvUncertainHead|Root=ע.ב.ד|VerbForm=Inf|Voice=Act	28	dep	_	_
 36-38	בקטיף	_	_	_	_	_	_	_	SpaceAfter=No
 36	ב	ב	ADP	ADP	_	38	case	_	_
 37	ה_	ה	DET	DET	PronType=Art	38	det:def	_	_
@@ -4455,12 +4455,12 @@
 # sent_id = 122
 # text = רייזמן מציע שהממשלה תסבסד מחצית מעלות העסקתם של העולים בקטיף.
 1	רייזמן	רייזמן	PROPN	PROPN	_	2	nsubj	_	_
-2	מציע	הציע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	מציע	הציע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=י.צ.ע|VerbForm=Part|Voice=Act	0	root	_	_
 3-5	שהממשלה	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	ממשלה	ממשלה	NOUN	NOUN	Gender=Fem|Number=Sing	6	nsubj	_	_
-6	תסבסד	סבסד	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	2	ccomp	_	_
+6	תסבסד	סבסד	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ס.ב.ס.ד|Tense=Fut|Voice=Act	2	ccomp	_	_
 7	מחצית	_	DET	DET	Definite=Cons	9	det	_	_
 8-9	מעלות	_	_	_	_	_	_	_	_
 8	מ	מ	ADP	ADP	_	9	case	_	_
@@ -4489,7 +4489,7 @@
 5-6	החקלאיים	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	חקלאיים	חקלאי	ADJ	ADJ	Gender=Masc|Number=Plur	4	amod	_	_
-7	אישרה	אישר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	אישרה	אישר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=א.ש.ר|Tense=Past|Voice=Act	0	root	_	_
 8	אתמול	אתמול	ADV	ADV	_	7	advmod	_	_
 9	נקיטת	נקיטה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	obj	_	_
 10	עיצומים	עיצומים	NOUN	NOUN	Gender=Masc|Number=Plur	9	compound:smixut	_	_
@@ -4503,7 +4503,7 @@
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	בא	בא	ADJ	ADJ	Gender=Masc|Number=Sing	15	amod	_	_
 18	לא	לא	ADV	ADV	Polarity=Neg	19	advmod	_	_
-19	יושג	הושג	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	7	advcl	_	_
+19	יושג	הושג	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=נ.שׂ.ג|Tense=Fut|Voice=Pass	7	advcl	_	_
 20	הסכם	הסכם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	19	nsubj	_	_
 21	שכר	שכר	NOUN	NOUN	Gender=Masc|Number=Sing	20	compound:smixut	_	_
 22-24	לשנתיים	_	_	_	_	_	_	_	_
@@ -4519,7 +4519,7 @@
 29	מסגרת_	מסגרת	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	32	obl	_	_
 30	_של_	של	ADP	ADP	_	31	case:gen	_	_
 31	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	29	nmod:poss	_	_
-32	יועלה	הועלה	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	20	acl	_	_
+32	יועלה	הועלה	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ע.ל.י|Tense=Fut|Voice=Pass	20	acl	_	_
 33	שכר	שכר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	32	nsubj	_	_
 34-35	העובדים	_	_	_	_	_	_	_	_
 34	ה	ה	DET	DET	PronType=Art	35	det:def	_	_
@@ -4536,7 +4536,7 @@
 2-3	השכר	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	שכר	שכר	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
-4	פג	פג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	פג	פג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ו.ג|Tense=Past|Voice=Act	0	root	_	_
 5-6	באפריל	_	_	_	_	_	_	_	SpaceAfter=No
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	אפריל	אפריל	PROPN	PROPN	_	4	obl	_	_
@@ -4554,7 +4554,7 @@
 7	אריה	אריה	PROPN	PROPN	_	1	appos	_	_
 8	גרוסבורד	גרוסבורד	PROPN	PROPN	_	7	flat:name	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	10	punct	_	_
-10	נהרג	נהרג	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+10	נהרג	נהרג	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ה.ר.ג|Tense=Past|Voice=Mid	0	root	_	_
 11-12	ביום	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	יום	יום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	10	obl	_	_
@@ -4575,7 +4575,7 @@
 # sent_id = 126
 # text = גרוסבורד נהג לבדו במכונית, בדרכו מהעיר מיניאפוליס באינדיאנה לנמל התעופה שלה.
 1	גרוסבורד	גרוסבורד	PROPN	PROPN	_	2	nsubj	_	_
-2	נהג	נהג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	נהג	נהג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ה.ג|Tense=Past|Voice=Act	0	root	_	_
 3	לבדו	לבד	ADV	ADV	_	2	advmod	_	_
 4-6	במכונית	_	_	_	_	_	_	_	SpaceAfter=No
 4	ב	ב	ADP	ADP	_	6	case	_	_
@@ -4609,7 +4609,7 @@
 # sent_id = 127
 # text = משאית פגעה במכוניתו, והוא נהרג במקום.
 1	משאית	משאית	NOUN	NOUN	Gender=Fem|Number=Sing	2	nsubj	_	_
-2	פגעה	פגע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	פגעה	פגע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ג.ע|Tense=Past|Voice=Act	0	root	_	_
 3-6	במכוניתו	_	_	_	_	_	_	_	SpaceAfter=No
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	מכונית_	מכונית	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	2	obl	_	_
@@ -4619,7 +4619,7 @@
 8-9	והוא	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	10	cc	_	_
 9	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	_	_
-10	נהרג	נהרג	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	2	conj	_	_
+10	נהרג	נהרג	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ה.ר.ג|Tense=Past|Voice=Mid	2	conj	_	_
 11-13	במקום	_	_	_	_	_	_	_	SpaceAfter=No
 11	ב	ב	ADP	ADP	_	13	case	_	_
 12	ה_	ה	DET	DET	PronType=Art	13	det:def	_	_
@@ -4632,7 +4632,7 @@
 2	גרוסבורד	גרוסבורד	PROPN	PROPN	_	1	flat:name	_	_
 3	אמור	אמור	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	5	aux	_	_
 4	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	3	cop	_	_
-5	לטוס	טס	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+5	לטוס	טס	VERB	VERB	HebBinyan=PAAL|Root=ט.ו.ס|VerbForm=Inf|Voice=Act	0	root	_	_
 6-7	ממיניאפוליס	_	_	_	_	_	_	_	_
 6	מ	מ	ADP	ADP	_	7	case	_	_
 7	מיניאפוליס	מיניאפוליס	PROPN	PROPN	_	5	obl	_	_
@@ -4656,7 +4656,7 @@
 1	שם	שם	ADV	ADV	_	3	advmod	_	_
 2	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	3	cop	_	_
 3	אמור	אמור	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	4	aux	_	_
-4	להיפגש	נפגש	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	0	root	_	_
+4	להיפגש	נפגש	VERB	VERB	HebBinyan=NIFAL|Root=פ.ג.ש|VerbForm=Inf|Voice=Mid	0	root	_	_
 5	עם	עם	ADP	ADP	_	6	case	_	_
 6-8	אשתו	_	_	_	_	_	_	_	SpaceAfter=No
 6	איש_	איש	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	4	obl	_	_
@@ -4665,7 +4665,7 @@
 9	,	,	PUNCT	PUNCT	_	6	punct	_	_
 10-11	שעשתה	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	עשתה	עשה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	acl:relcl	_	_
+11	עשתה	עשה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	6	acl:relcl	_	_
 12-13	בבוסטון	_	_	_	_	_	_	_	SpaceAfter=No
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	בוסטון	בוסטון	PROPN	PROPN	_	11	obl	_	_
@@ -4678,8 +4678,8 @@
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	זוג	זוג	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
 4	גרוסבורד	גרוסבורד	PROPN	PROPN	_	1	flat:name	_	_
-5	תוכננו	תוכנן	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
-6	לשוב	שב	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
+5	תוכננו	תוכנן	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=ת.כ.נ.נ|Tense=Past|Voice=Pass	0	root	_	_
+6	לשוב	שב	VERB	VERB	HebBinyan=PAAL|Root=ש.ו.ב|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 7	היום	היום	ADV	ADV	_	6	advmod	_	_
 8	אחרי	אחרי	ADP	ADP	_	11	case	_	SpaceAfter=No
 9	-	-	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
@@ -4700,7 +4700,7 @@
 4	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nmod:poss	_	_
 5	של	של	ADP	ADP	Case=Gen	6	case:gen	_	_
 6	גרוסבורד	גרוסבורד	PROPN	PROPN	_	2	nmod:poss	_	_
-7	נודע	נודע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+7	נודע	נודע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.ד.ע|Tense=Past|Voice=Mid	0	root	_	_
 8	רק	רק	ADV	ADV	_	9	advmod	_	_
 9	אתמול	אתמול	ADV	ADV	_	7	advmod	_	_
 10-12	בצהריים	_	_	_	_	_	_	_	_
@@ -4724,7 +4724,7 @@
 3	,	,	PUNCT	PUNCT	_	2	punct	_	_
 4-5	שטיפלו	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	טיפלו	טיפל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	2	acl:relcl	_	_
+5	טיפלו	טיפל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ט.פ.ל|Tense=Past|Voice=Act	2	acl:relcl	_	_
 6-8	בדבר	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -4735,7 +4735,7 @@
 11	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
 12	,	,	PUNCT	PUNCT	_	14	punct	_	_
 13	לא	לא	ADV	ADV	Polarity=Neg	14	advmod	_	_
-14	קישרו	קישר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+14	קישרו	קישר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ק.ש.ר|Tense=Past|Voice=Act	0	root	_	_
 15	את	את	ADP	ADP	Case=Acc	16	case:acc	_	_
 16-18	שמו	_	_	_	_	_	_	_	_
 16	שם_	שם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	14	obj	_	_
@@ -4752,7 +4752,7 @@
 # text = משטרת מיניאפוליס מצאה במכוניתו את מזוודותיו עם תגי הזיהוי.
 1	משטרת	משטרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	nsubj	_	_
 2	מיניאפוליס	מיניאפוליס	PROPN	PROPN	_	1	compound:smixut	_	_
-3	מצאה	מצא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	מצאה	מצא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.צ.א|Tense=Past|Voice=Act	0	root	_	_
 4-7	במכוניתו	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	מכונית_	מכונית	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	3	obl	_	_
@@ -4775,7 +4775,7 @@
 1-2	המשטרה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	דיווחה	דיווח	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	דיווחה	דיווח	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ד.ו.ח|Tense=Past|Voice=Act	0	root	_	_
 4-5	למחלקת	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	5	case	_	_
 5	מחלקת	מחלקה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	obl	_	_
@@ -4788,7 +4788,7 @@
 10	,	,	PUNCT	PUNCT	_	5	punct	_	_
 11-12	שהעבירה	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-12	העבירה	העביר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	acl:relcl	_	_
+12	העבירה	העביר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past|Voice=Act	5	acl:relcl	_	_
 13	את	את	ADP	ADP	Case=Acc	15	case:acc	_	_
 14-15	המידע	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
@@ -4806,7 +4806,7 @@
 23	,	,	PUNCT	PUNCT	_	18	punct	_	_
 24-25	המטפלת	_	_	_	_	_	_	_	_
 24	ה	ה	SCONJ	SCONJ	_	25	mark	_	_
-25	מטפלת	טיפל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	18	acl:relcl	_	_
+25	מטפלת	טיפל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ט.פ.ל|VerbForm=Part|Voice=Act	18	acl:relcl	_	_
 26-27	באזור	_	_	_	_	_	_	_	_
 26	ב	ב	ADP	ADP	_	27	case	_	_
 27	אזור	אזור	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	25	obl	_	_
@@ -4821,7 +4821,7 @@
 3-4	בשיקאגו	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	שיקאגו	שיקאגו	PROPN	PROPN	_	2	nmod	_	_
-5	הבריקה	הבריק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	הבריקה	הבריק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ב.ר.ק|Tense=Past|Voice=Act	0	root	_	_
 6-7	לירושלים	_	_	_	_	_	_	_	SpaceAfter=No
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	ירושלים	ירושלים	PROPN	PROPN	_	5	obl	_	_
@@ -4838,9 +4838,9 @@
 5-6	בירושלים	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	ירושלים	ירושלים	PROPN	PROPN	_	2	nmod	_	_
-7	נשלח	נשלח	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+7	נשלח	נשלח	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.ל.ח|Tense=Past|Voice=Mid	0	root	_	_
 8	שליח	שליח	NOUN	NOUN	Gender=Masc|Number=Sing	7	nsubj	_	_
-9	להודיע	הודיע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	7	xcomp	_	_
+9	להודיע	הודיע	VERB	VERB	HebBinyan=HIFIL|Root=י.ד.ע|VerbForm=Inf|Voice=Act	7	xcomp	_	_
 10	על	על	ADP	ADP	_	11	case	_	_
 11	דבר	דבר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	9	obl	_	_
 12-13	המוות	_	_	_	_	_	_	_	_
@@ -4855,7 +4855,7 @@
 18	,	,	PUNCT	PUNCT	_	7	punct	_	_
 19	אולם	אולם	CCONJ	CCONJ	_	21	cc	_	_
 20	לא	לא	ADV	ADV	Polarity=Neg	21	advmod	_	_
-21	היה	היה	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	7	conj	_	_
+21	היה	היה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	7	conj	_	_
 22	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	21	nsubj	_	_
 23-26	בדירתו	_	_	_	_	_	_	_	SpaceAfter=No
 23	ב	ב	ADP	ADP	_	24	case	_	_
@@ -4870,7 +4870,7 @@
 2	אחר	אחר	ADP	ADP	_	4	case	_	SpaceAfter=No
 3	-	-	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 4	כך	כך	PRON	PRON	Person=3|PronType=Dem	5	obl	_	_
-5	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+5	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.צ.א|Tense=Past|Voice=Mid	0	root	_	_
 6	כרטיס	כרטיס	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	ביקור	ביקור	NOUN	NOUN	Gender=Masc|Number=Sing	6	compound:smixut	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	5	punct	_	_
@@ -4903,7 +4903,7 @@
 3-4	החוץ	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
-5	התקשרו	התקשר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
+5	התקשרו	התקשר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=ק.ש.ר|Tense=Past	0	root	_	_
 6	אתמול	אתמול	ADV	ADV	_	5	advmod	_	_
 7-9	למפעל	_	_	_	_	_	_	_	SpaceAfter=No
 7	ל	ל	ADP	ADP	_	9	case	_	_
@@ -4914,9 +4914,9 @@
 11	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 12	רק	רק	ADV	ADV	_	13	advmod	_	_
 13	אז	אז	ADV	ADV	_	14	advmod	_	_
-14	התברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	5	conj	_	_
+14	התברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=פ.ל.ל|Tense=Past	5	conj	_	_
 15	כי	כי	SCONJ	SCONJ	_	16	mark	_	_
-16	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	14	ccomp	_	_
+16	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ד.ב.ר|VerbForm=Part|Voice=Pass	14	ccomp	_	_
 17-18	ביו"ר	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	יו"ר	יו"ר	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	16	obl	_	_
@@ -4939,7 +4939,7 @@
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
 8	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nmod:poss	_	_
 9	,	,	PUNCT	PUNCT	_	1	punct	_	_
-10	השאיר	השאיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+10	השאיר	השאיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ש.א.ר|Tense=Past|Voice=Act	0	root	_	_
 11-12	אחריו	_	_	_	_	_	_	_	_
 11	אחרי_	אחרי	ADP	ADP	_	12	case	_	_
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obl	_	_
@@ -4960,7 +4960,7 @@
 # text = עדיין לא נקבע מועד להלווייתו.
 1	עדיין	עדיין	ADV	ADV	_	2	advmod	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+3	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ק.ב.ע|Tense=Past|Voice=Mid	0	root	_	_
 4	מועד	מועד	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
 5-8	להלווייתו	_	_	_	_	_	_	_	SpaceAfter=No
 5	ל	ל	ADP	ADP	_	6	case	_	_
@@ -4990,7 +4990,7 @@
 13	בצלם	בצלם	PROPN	PROPN	_	1	appos	_	SpaceAfter=No
 14	"	"	PUNCT	PUNCT	_	13	punct	_	SpaceAfter=No
 15	,	,	PUNCT	PUNCT	_	16	punct	_	_
-16	מפרסם	פרסם	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+16	מפרסם	פרסם	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=פ.ר.ס.מ|VerbForm=Part|Voice=Act	0	root	_	_
 17-18	מפעם	_	_	_	_	_	_	_	_
 17	מ	מ	ADP	ADP	_	16	advmod	_	_
 18	פעם	פעם	ADV	ADV	_	17	fixed	_	_
@@ -5007,7 +5007,7 @@
 27	על	על	ADP	ADP	_	29	case	_	_
 28-29	הנעשה	_	_	_	_	_	_	_	_
 28	ה	ה	SCONJ	SCONJ	_	29	mark	_	_
-29	נעשה	נעשה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	26	nmod	_	_
+29	נעשה	נעשה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ע.ש.י|VerbForm=Part|Voice=Mid	26	nmod	_	_
 30-32	בשטחים	_	_	_	_	_	_	_	_
 30	ב	ב	ADP	ADP	_	32	case	_	_
 31	ה_	ה	DET	DET	PronType=Art	32	det:def	_	_
@@ -5046,8 +5046,8 @@
 1	"	"	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 2	בצלם	בצלם	PROPN	PROPN	_	4	nsubj	_	SpaceAfter=No
 3	"	"	PUNCT	PUNCT	_	2	punct	_	_
-4	נוהג	נהג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
-5	להפיץ	הפיץ	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	4	xcomp	_	_
+4	נוהג	נהג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ה.ג|VerbForm=Part|Voice=Act	0	root	_	_
+5	להפיץ	הפיץ	VERB	VERB	HebBinyan=HIFIL|Root=פ.ו.צ|VerbForm=Inf|Voice=Act	4	xcomp	_	_
 6	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 7	דפי	דף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	obj	_	_
 8-9	המידע	_	_	_	_	_	_	_	_
@@ -5081,7 +5081,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	ימים	יום	NOUN	NOUN	Gender=Masc|Number=Plur	4	obl	_	_
 3	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	2	det	_	_
-4	התקבל	התקבל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+4	התקבל	התקבל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Past	0	root	_	_
 5-6	במשרדי	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	משרדי	משרד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	obl	_	_
@@ -5123,7 +5123,7 @@
 # sent_id = 145
 # text = רצ"ב מוחזר אליכם החומר שנשלח אלי.
 1	רצ"ב	רצ"ב	ADV	ADV	Abbr=Yes	2	advmod	_	_
-2	מוחזר	הוחזר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+2	מוחזר	הוחזר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ח.ז.ר|VerbForm=Part|Voice=Pass	0	root	_	_
 3-4	אליכם	_	_	_	_	_	_	_	_
 3	אל_	אל	ADP	ADP	_	4	case	_	_
 4	_אתם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=2|PronType=Prs	2	obl	_	_
@@ -5132,7 +5132,7 @@
 6	חומר	חומר	NOUN	NOUN	Gender=Masc|Number=Sing	2	nsubj	_	_
 7-8	שנשלח	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
-8	נשלח	נשלח	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	6	acl:relcl	_	_
+8	נשלח	נשלח	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.ל.ח|Tense=Past|Voice=Mid	6	acl:relcl	_	_
 9-10	אלי	_	_	_	_	_	_	_	SpaceAfter=No
 9	אל_	אל	ADP	ADP	_	10	case	_	_
 10	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	8	obl	_	_
@@ -5144,7 +5144,7 @@
 1	כמו_	כמו	ADP	ADP	_	2	case	_	_
 2	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	obl	_	_
 3	אתם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=2|PronType=Prs	4	nsubj	_	_
-4	שולחים	שלח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+4	שולחים	שלח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ש.ל.ח|VerbForm=Part|Voice=Act	0	root	_	_
 5-6	אלי	_	_	_	_	_	_	_	_
 5	אל_	אל	ADP	ADP	_	6	case	_	_
 6	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	4	obl	_	_
@@ -5153,7 +5153,7 @@
 9-10	והוא	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
 10	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
-11	נזרק	נזרק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	conj	_	_
+11	נזרק	נזרק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ז.ר.ק|Tense=Past|Voice=Mid	4	conj	_	_
 12	ישר	ישר	ADV	ADV	_	11	advmod	_	_
 13-15	לפח	_	_	_	_	_	_	_	SpaceAfter=No
 13	ל	ל	ADP	ADP	_	15	case	_	_
@@ -5164,10 +5164,10 @@
 # sent_id = 147
 # text = אבקשכם לשלוח אלי חומר זה.
 1-3	אבקשכם	_	_	_	_	_	_	_	_
-1	אבקשכם	_	VERB	VERB	_	0	root	_	_
+1	אבקשכם	_	VERB	VERB	HebBinyan=PIEL|Root=ב.ק.ש	0	root	_	_
 2	את	את	ADP	ADP	Case=Acc	3	case	_	_
 3	_אתם	הוא	PRON	PRON	Case=Acc|Gender=Masc|Number=Plur|Person=2|PronType=Prs	1	obj	_	_
-4	לשלוח	שלח	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	1	xcomp	_	_
+4	לשלוח	שלח	VERB	VERB	HebBinyan=PAAL|Root=ש.ל.ח|VerbForm=Inf|Voice=Act	1	xcomp	_	_
 5-6	אלי	_	_	_	_	_	_	_	_
 5	אל_	אל	ADP	ADP	_	6	case	_	_
 6	_אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	4	obl	_	_
@@ -5182,7 +5182,7 @@
 2	עבודה_	עבודה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3	_של_	של	ADP	ADP	_	4	case:gen	_	_
 4	_אני	הוא	PRON	PRON	Case=Gen|Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	nmod:poss	_	_
-5	מיועד	יועד	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+5	מיועד	יועד	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=י.ע.ד|VerbForm=Part|Voice=Pass	0	root	_	_
 6-7	לקבלת	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	קבלת	קבלה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	5	obl	_	_
@@ -5222,7 +5222,7 @@
 3	מי	מי	ADV	ADV	PronType=Int	0	root	_	_
 4-5	שיספר	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	יספר	סיפר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	3	acl:relcl	_	_
+5	יספר	סיפר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ס.פ.ר|Tense=Fut	3	acl:relcl	_	_
 6	פעם	פעם	ADV	ADV	_	5	advmod	_	_
 7	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 8-10	סיפורה	_	_	_	_	_	_	_	_
@@ -5261,7 +5261,7 @@
 5	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
 6	עיריית	עירייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	8	nsubj	_	_
 7	ירושלים	ירושלים	PROPN	PROPN	_	6	flat:name	_	_
-8	שלחה	שלח	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	2	acl:relcl	_	_
+8	שלחה	שלח	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.ל.ח|Tense=Past	2	acl:relcl	_	_
 9-10	בימים	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	ימים	יום	NOUN	NOUN	Gender=Masc|Number=Plur	8	obl	_	_
@@ -5270,7 +5270,7 @@
 12	ל	ל	ADP	ADP	_	14	case	_	_
 13	ה_	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	תושבים	תושב	NOUN	NOUN	Gender=Masc|Number=Plur	8	obl	_	_
-15	הודפסה	הודפס	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+15	הודפסה	הודפס	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ד.פ.ס|Tense=Past|Voice=Pass	0	root	_	_
 16	הנחיה	הנחיה	NOUN	NOUN	Gender=Fem|Number=Sing	15	nsubj	_	_
 17-18	בזו	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	20	case	_	_
@@ -5294,7 +5294,7 @@
 32	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	30	compound:smixut	_	_
 33	,	,	PUNCT	PUNCT	_	35	punct	_	_
 34	אנא	אנא	ADV	ADV	_	35	advmod	_	_
-35	דאג	דאג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Voice=Act	16	appos	_	_
+35	דאג	דאג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Root=ד.א.ג|Voice=Act	16	appos	_	_
 36-37	לנעילת	_	_	_	_	_	_	_	_
 36	ל	ל	ADP	ADP	_	37	case	_	_
 37	נעילת	נעילה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	35	obl	_	_
@@ -5307,14 +5307,14 @@
 42	גג	גג	NOUN	NOUN	Gender=Masc|Number=Sing	39	nmod	_	_
 43	,	,	PUNCT	PUNCT	_	35	punct	_	_
 44	כדי	כדי	ADP	ADP	_	45	case	_	_
-45	למנוע	מנע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	35	advcl	_	_
+45	למנוע	מנע	VERB	VERB	HebBinyan=PAAL|Root=מ.נ.ע|VerbForm=Inf|Voice=Act	35	advcl	_	_
 46-47	מאנשים	_	_	_	_	_	_	_	_
 46	מ	מ	ADP	ADP	_	47	case	_	_
 47	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	45	obl	_	_
 48	זרים	זר	ADJ	ADJ	Gender=Masc|Number=Plur	47	amod	_	_
-49	לזהם	זיהם	VERB	VERB	HebBinyan=PIEL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	45	dep	_	_
+49	לזהם	זיהם	VERB	VERB	HebBinyan=PIEL|HebSource=ConvUncertainHead|Root=ז.ה.מ|VerbForm=Inf|Voice=Act	45	dep	_	_
 50	או	או	CCONJ	CCONJ	_	51	cc	_	_
-51	להרעיל	הרעיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	49	conj	_	_
+51	להרעיל	הרעיל	VERB	VERB	HebBinyan=HIFIL|Root=ר.ע.ל|VerbForm=Inf|Voice=Act	49	conj	_	_
 52	את	את	ADP	ADP	Case=Acc	53	case:acc	_	_
 53	מי	מים	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	49	obj	_	_
 54-55	השתייה	_	_	_	_	_	_	_	SpaceAfter=No
@@ -5338,7 +5338,7 @@
 1-2	העלים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	עלים	עלה	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
-3	מזהיבים	הזהיב	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
+3	מזהיבים	הזהיב	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ז.ה.ב|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 154
@@ -5350,7 +5350,7 @@
 4	של	של	ADP	ADP	Case=Gen	5	case:gen	_	_
 5	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	1	nmod:poss	_	_
 6	נוספת	נוסף	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
-7	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+7	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ר.א.י|VerbForm=Part|Voice=Mid	0	root	_	_
 8	במעורפל	במעורפל	ADV	ADV	_	7	advmod	_	_
 9-11	באופק	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	11	case	_	_
@@ -5361,7 +5361,7 @@
 13	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
 14	עדיין	עדיין	ADV	ADV	_	15	advmod	_	_
 15	לא	לא	ADV	ADV	Polarity=Neg	16	advmod	_	_
-16	זכית	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=2|Tense=Past|Voice=Act	7	conj	_	_
+16	זכית	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=2|Root=ז.כ.י|Tense=Past|Voice=Act	7	conj	_	_
 17-18	במענק	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	מענק	מענק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	obl	_	_
@@ -5386,7 +5386,7 @@
 2	רשימת	רשימה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3-4	הזוכים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
-4	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	compound:smixut	_	_
+4	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ז.כ.י|VerbForm=Part|Voice=Act	2	compound:smixut	_	_
 5	השנה	השנה	ADV	ADV	_	1	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	8	punct	_	_
 7	כמו	כמו	ADP	ADP	_	8	case	_	_
@@ -5397,7 +5397,7 @@
 11	ב_	ב	ADP	ADP	_	12	case	_	_
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obl	_	_
 13	כדי	כדי	ADP	ADP	_	14	case	_	_
-14	לגרום	גרם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	10	advcl	_	_
+14	לגרום	גרם	VERB	VERB	HebBinyan=PAAL|Root=ג.ר.מ|VerbForm=Inf|Voice=Act	10	advcl	_	_
 15-16	לסופרים	_	_	_	_	_	_	_	SpaceAfter=No
 15	ל	ל	ADP	ADP	_	16	case	_	_
 16	סופרים	סופר	NOUN	NOUN	Gender=Masc|Number=Plur	14	obl	_	_
@@ -5427,7 +5427,7 @@
 34-35	כולה	_	_	_	_	_	_	_	_
 34	כולה	כול	NOUN	NOUN	Gender=Masc|Number=Sing	31	amod	_	_
 35	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	34	nmod:poss	_	_
-36	לצפות	צפה	VERB	VERB	HebSource=ConvUncertainHead|VerbForm=Inf	14	dep	_	_
+36	לצפות	צפה	VERB	VERB	HebBinyan=PAAL|HebSource=ConvUncertainHead|Root=צ.פ.י|VerbForm=Inf	14	dep	_	_
 37-38	לרשימת	_	_	_	_	_	_	_	_
 37	ל	ל	ADP	ADP	_	38	case	_	_
 38	רשימת	רשימה	NOUN	NOUN	Definite=Cons|Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	36	dep	_	_
@@ -5444,7 +5444,7 @@
 46	לב_	לב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	49	obl	_	_
 47	_של_	של	ADP	ADP	_	48	case:gen	_	_
 48	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	46	nmod:poss	_	_
-49	מקננת	קינן	VERB	VERB	Gender=Fem|HebBinyan=PIEL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	36	dep	_	_
+49	מקננת	קינן	VERB	VERB	Gender=Fem|HebBinyan=PIEL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|Root=ק.נ.נ|VerbForm=Part|Voice=Act	36	dep	_	_
 50-51	התקווה	_	_	_	_	_	_	_	_
 50	ה	ה	DET	DET	PronType=Art	51	det:def	_	_
 51	תקווה	תקווה	NOUN	NOUN	Gender=Fem|Number=Sing	49	nsubj	_	_
@@ -5453,7 +5453,7 @@
 53	אולי	אולי	ADV	ADV	_	56	advmod	_	_
 54	גם	גם	ADV	ADV	_	55	det	_	_
 55	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	56	nsubj	_	_
-56	ייכללו	נכלל	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Fut|Voice=Mid	51	acl:relcl	_	_
+56	ייכללו	נכלל	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=כ.ל.ל|Tense=Fut|Voice=Mid	51	acl:relcl	_	_
 57-58	בה	_	_	_	_	_	_	_	SpaceAfter=No
 57	ב_	ב	ADP	ADP	_	58	case	_	_
 58	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	56	obl	_	_
@@ -5470,14 +5470,14 @@
 6	63	63	NUM	NUM	_	8	nummod	_	_
 7-8	הזוכים	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
-8	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	21	nsubj	_	_
+8	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ז.כ.י|VerbForm=Part|Voice=Act	21	nsubj	_	_
 9	אם	אם	SCONJ	SCONJ	_	10	case	_	_
-10	לשפוט	שפט	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	21	parataxis	_	_
+10	לשפוט	שפט	VERB	VERB	HebBinyan=PAAL|Root=ש.פ.ט|VerbForm=Inf|Voice=Act	21	parataxis	_	_
 11	על	על	ADP	ADP	_	13	case	_	_
 12	פי	פה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	fixed	_	_
 13-14	הכתוב	_	_	_	_	_	_	_	_
 13	ה	ה	SCONJ	SCONJ	_	10	obl	_	_
-14	כתוב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	13	dep	_	_
+14	כתוב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|Root=כ.ת.ב|VerbForm=Part|Voice=Act	13	dep	_	_
 15-16	עליהם	_	_	_	_	_	_	_	_
 15	על_	על	ADP	ADP	_	16	case	_	_
 16	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	14	obl	_	_
@@ -5486,7 +5486,7 @@
 18	ה_	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	עיתונות	עיתונות	NOUN	NOUN	Gender=Fem|Number=Sing	14	obl	_	_
 20	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	21	advmod	_	_
-21	נראים	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+21	נראים	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=ר.א.י|VerbForm=Part|Voice=Mid	0	root	_	_
 22	מיוחדים	מיוחד	ADJ	ADJ	Gender=Masc|HebSource=ConvUncertainLabel|Number=Plur	21	xcomp	_	_
 23	כל	כול	DET	DET	Definite=Cons	22	advmod	_	_
 24	כך	כך	ADV	ADV	_	23	fixed	_	SpaceAfter=No
@@ -5501,7 +5501,7 @@
 5	בדיקה	בדיקה	NOUN	NOUN	Gender=Fem|Number=Sing	8	obl	_	_
 6	קפדנית	קפדני	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	SpaceAfter=No
 7	,	,	PUNCT	PUNCT	_	8	punct	_	_
-8	מתברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+8	מתברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ב.ר.ר|VerbForm=Part	0	root	_	_
 9-10	שזה	_	_	_	_	_	_	_	_
 9	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
 10	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	12	nsubj	_	_
@@ -5515,7 +5515,7 @@
 
 # sent_id = 159
 # text = קחו למשל את מריה ואראלה.
-1	קחו	לקח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Voice=Act	0	root	_	_
+1	קחו	לקח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Root=ל.ק.ח|Voice=Act	0	root	_	_
 2	למשל	למשל	ADV	ADV	_	1	advmod	_	_
 3	את	את	ADP	ADP	Case=Acc	4	case:acc	_	_
 4	מריה	מריה	PROPN	PROPN	_	1	obj	_	_
@@ -5528,10 +5528,10 @@
 1	ב	ב	ADP	ADP	_	4	advmod	_	_
 2	תחילה	תחילה	NOUN	NOUN	Gender=Fem|Number=Sing	1	fixed	_	_
 3	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
-4	מצטיירת	הצטייר	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+4	מצטיירת	הצטייר	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=צ.י.ר|VerbForm=Part	0	root	_	_
 5	כמו	כמו	ADP	ADP	_	7	case	_	_
 6	כל	כול	DET	DET	Definite=Cons	7	det	_	_
-7	מארגנת	ארגן	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	obl	_	_
+7	מארגנת	ארגן	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=א.ר.ג.נ|VerbForm=Part|Voice=Act	4	obl	_	_
 8	קהילתית	קהילתי	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	_
 9	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	SpaceAfter=No
 10	.	.	PUNCT	PUNCT	_	4	punct	_	_
@@ -5545,13 +5545,13 @@
 4-5	מקרוב	_	_	_	_	_	_	_	_
 4	מ	מ	ADP	ADP	_	5	case	_	_
 5	קרוב	קרוב	ADJ	ADJ	Gender=Masc|Number=Sing	3	nmod	_	_
-6	מתברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+6	מתברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ב.ר.ר|VerbForm=Part	0	root	_	_
 7-8	שהיא	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
 8	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	9	nsubj	_	_
-9	נמנתה	נמנה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	6	ccomp	_	_
+9	נמנתה	נמנה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.נ.י|Tense=Past|Voice=Mid	6	ccomp	_	_
 10	עם	עם	ADP	ADP	_	11	case	_	_
-11	מקימי	הקים	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	9	obl	_	_
+11	מקימי	הקים	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ק.ו.מ|VerbForm=Part|Voice=Act	9	obl	_	_
 12	גנאדאס	גנאדאס	PROPN	PROPN	_	11	compound:smixut	_	_
 13	דל	דל	PROPN	PROPN	_	12	flat:name	_	_
 14	ואיה	ואיה	PROPN	PROPN	_	12	flat:name	_	SpaceAfter=No
@@ -5580,7 +5580,7 @@
 1	האם	האם	ADV	ADV	PronType=Int	3	mark:q	_	_
 2	אתם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=2|PronType=Prs	3	nsubj	_	_
 3	יכולים	יכול	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbForm=Part|VerbType=Mod	4	aux	_	_
-4	להתעלות	התעלה	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	0	root	_	_
+4	להתעלות	התעלה	VERB	VERB	HebBinyan=HITPAEL|Root=ע.ל.י|VerbForm=Inf	0	root	_	_
 5	על	על	ADP	ADP	_	6	case	_	_
 6	כך	כך	PRON	PRON	Person=3|PronType=Dem	4	obl	_	SpaceAfter=No
 7	?	?	PUNCT	PUNCT	_	3	punct	_	_
@@ -5589,11 +5589,11 @@
 # text = וישנם גם הזוכים המיוחדים במובן היותר שנוי במחלוקת של המלה.
 1-2	וישנם	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	2	cc	_	_
-2	ישנם	יש	VERB	VERB	HebExistential=True	0	root	_	_
+2	ישנם	יש	VERB	VERB	HebBinyan=_|HebExistential=True|Root=_	0	root	_	_
 3	גם	גם	ADV	ADV	_	5	det	_	_
 4-5	הזוכים	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
-5	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	nsubj	_	_
+5	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ז.כ.י|VerbForm=Part|Voice=Act	2	nsubj	_	_
 6-7	המיוחדים	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	מיוחדים	מיוחד	ADJ	ADJ	Gender=Masc|Number=Plur	5	amod	_	_
@@ -5622,12 +5622,12 @@
 3	מענקי	מענק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	6	nsubj	_	_
 4	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	compound:smixut	_	_
 5	מקארתור	מקארתור	PROPN	PROPN	_	4	flat:name	_	_
-6	נועדו	נועד	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	22	advcl	_	_
-7	לשחרר	שחרר	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
+6	נועדו	נועד	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=י.ע.ד|Tense=Past|Voice=Mid	22	advcl	_	_
+7	לשחרר	שחרר	VERB	VERB	HebBinyan=PIEL|Root=ש.ח.ר.ר|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 8	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 9-10	המוכשרים	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
-10	מוכשרים	הוכשר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	7	obj	_	_
+10	מוכשרים	הוכשר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=כ.ש.ר|VerbForm=Part|Voice=Pass	7	obj	_	_
 11-12	מנטל	_	_	_	_	_	_	_	_
 11	מ	מ	ADP	ADP	_	12	case	_	_
 12	נטל	נטל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obl	_	_
@@ -5642,7 +5642,7 @@
 19	,	,	PUNCT	PUNCT	_	22	punct	_	_
 20	כמה	כמה	DET	DET	Definite=Cons	21	det	_	_
 21	מענקים	מענק	NOUN	NOUN	Gender=Masc|Number=Plur	22	nsubj	_	_
-22	מגיעים	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+22	מגיעים	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=נ.ג.ע|VerbForm=Part|Voice=Act	0	root	_	_
 23	תמיד	תמיד	ADV	ADV	_	22	advmod	_	_
 24-25	לאנשים	_	_	_	_	_	_	_	_
 24	ל	ל	ADP	ADP	_	25	case	_	_
@@ -5651,9 +5651,9 @@
 26	ש	ש	SCONJ	SCONJ	_	29	mark	_	_
 27	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	29	advmod	_	_
 28	בדיוק	בדיוק	ADV	ADV	_	29	advmod	_	_
-29	נאבקים	נאבק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	25	acl:relcl	_	_
+29	נאבקים	נאבק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=א.ב.ק|VerbForm=Part|Voice=Mid	25	acl:relcl	_	_
 30	כדי	כדי	ADP	ADP	_	31	case	_	_
-31	לזכות	זכה	VERB	VERB	VerbForm=Inf	29	advcl	_	_
+31	לזכות	זכה	VERB	VERB	HebBinyan=PAAL|Root=ז.כ.י|VerbForm=Inf	29	advcl	_	_
 32-33	בהכרה	_	_	_	_	_	_	_	_
 32	ב	ב	ADP	ADP	_	33	case	_	_
 33	הכרה	הכרה	NOUN	NOUN	Gender=Fem|Number=Sing	31	obl	_	_
@@ -5687,7 +5687,7 @@
 3	כל	כול	DET	DET	Definite=Cons	2	fixed	_	_
 4	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	fixed	_	_
 5	אתם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=2|PronType=Prs	6	nsubj	_	_
-6	רוצים	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	19	advcl	_	_
+6	רוצים	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ר.צ.י|VerbForm=Part|Voice=Act	19	advcl	_	_
 7	סבסוד	סבסוד	NOUN	NOUN	Gender=Masc|Number=Sing	6	obj	_	_
 8-11	למחשבותיכם	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	9	case	_	_
@@ -5704,7 +5704,7 @@
 18-19	עליכם	_	_	_	_	_	_	_	_
 18	על_	על	ADP	ADP	_	19	case	_	_
 19	_אתם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=2|PronType=Prs	0	root	_	_
-20	להשיג	השיג	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	19	xcomp	_	_
+20	להשיג	השיג	VERB	VERB	HebBinyan=HIFIL|Root=נ.שׂ.ג|VerbForm=Inf|Voice=Act	19	xcomp	_	_
 21-22	אותו	_	_	_	_	_	_	_	_
 21	את_	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 22	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	obj	_	_
@@ -5716,7 +5716,7 @@
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	מיושנת	מיושן	ADJ	ADJ	Gender=Fem|Number=Sing	25	amod	_	_
 28	:	:	PUNCT	PUNCT	_	25	punct	_	_
-29	לפנות	פנה	VERB	VERB	VerbForm=Inf	25	acl	_	_
+29	לפנות	פנה	VERB	VERB	HebBinyan=PAAL|Root=פ.נ.י|VerbForm=Inf	25	acl	_	_
 30-32	לקרן	_	_	_	_	_	_	_	SpaceAfter=No
 30	ל	ל	ADP	ADP	_	32	case	_	_
 31	ה_	ה	DET	DET	PronType=Art	32	det:def	_	_
@@ -5724,7 +5724,7 @@
 33	,	,	PUNCT	PUNCT	_	29	punct	_	_
 34-35	ולשכנע	_	_	_	_	_	_	_	_
 34	ו	ו	CCONJ	CCONJ	_	35	cc	_	_
-35	לשכנע	שכנע	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	29	conj	_	_
+35	לשכנע	שכנע	VERB	VERB	HebBinyan=PIEL|Root=ש.כ.נ.ע|VerbForm=Inf|Voice=Act	29	conj	_	_
 36	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	35	obj	_	_
 37	בעלי	בעל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	36	acl	_	_
 38	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	37	compound:smixut	_	_
@@ -5753,7 +5753,7 @@
 2	מספר	מספר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	1	nmod	_	_
 3	1	1	NUM	NUM	_	2	nummod	_	SpaceAfter=No
 4	:	:	PUNCT	PUNCT	_	5	punct	_	_
-5	הצטרפו	הצטרף	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Mood=Imp|Number=Plur|Person=2	0	root	_	_
+5	הצטרפו	הצטרף	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Mood=Imp|Number=Plur|Person=2|Root=צ.ר.פ	0	root	_	_
 6-7	לגופים	_	_	_	_	_	_	_	SpaceAfter=No
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	גופים	גוף	NOUN	NOUN	Gender=Masc|Number=Plur	5	obl	_	_
@@ -5775,11 +5775,11 @@
 9	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
 10	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	12	nsubj	_	_
 11	אמריקאיות	אמריקני	ADJ	ADJ	Gender=Fem|Number=Plur	10	amod	_	_
-12	מחלקות	חילק	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	8	acl:relcl	_	_
+12	מחלקות	חילק	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ח.ל.ק|VerbForm=Part|Voice=Act	8	acl:relcl	_	_
 13	מדי	מדי	ADV	ADV	_	14	det	_	_
 14	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	12	dep	_	_
 15	אינו	אינו	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	16	advmod	_	_
-16	מיועד	יועד	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+16	מיועד	יועד	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=י.ע.ד|VerbForm=Part|Voice=Pass	0	root	_	_
 17-18	ליחידים	_	_	_	_	_	_	_	SpaceAfter=No
 17	ל	ל	ADP	ADP	_	18	case	_	_
 18	יחידים	יחיד	ADJ	ADJ	Gender=Masc|Number=Plur	16	obl	_	_
@@ -5810,7 +5810,7 @@
 1	ב	ב	ADP	ADP	_	4	advmod	_	_
 2	דרך	דרך	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	fixed	_	_
 3	כלל	כלל	NOUN	NOUN	Gender=Masc|Number=Sing	1	fixed	_	_
-4	מופנה	הופנה	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+4	מופנה	הופנה	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=פ.נ.י|VerbForm=Part|Voice=Pass	0	root	_	_
 5-6	הכסף	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
@@ -5866,7 +5866,7 @@
 6-7	עליך	_	_	_	_	_	_	_	_
 6	על_	על	ADP	ADP	_	7	case	_	_
 7	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	0	root	_	_
-8	לחשוב	חשב	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	xcomp	_	_
+8	לחשוב	חשב	VERB	VERB	HebBinyan=PAAL|Root=ח.ש.ב|VerbForm=Inf|Voice=Act	7	xcomp	_	_
 9	על	על	ADP	ADP	_	10	case	_	_
 10	קבלת	קבלה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	8	obl	_	_
 11	תפקיד	תפקיד	NOUN	NOUN	Gender=Masc|Number=Sing	10	compound:smixut	_	_
@@ -5887,7 +5887,7 @@
 # text = אז תוכל לתור אחר כסף באורח עצמאי פחות או יותר, אפילו לייסד במשך הזמן מכון משלך במסגרת המכון נותן החסות, למרות שנותן החסות שלך ירצה אחוז שמן מהמענק כדי לכסות "הוצאות קבועות".
 1	אז	אז	ADV	ADV	_	2	advmod	_	_
 2	תוכל	_	AUX	AUX	Gender=Masc|Number=Sing|Person=2|Tense=Fut|VerbType=Mod	3	aux	_	_
-3	לתור	תר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+3	לתור	תר	VERB	VERB	HebBinyan=PAAL|Root=ת.ו.ר|VerbForm=Inf|Voice=Act	0	root	_	_
 4	אחר	אחר	ADP	ADP	_	5	case	_	_
 5	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
 6-7	באורח	_	_	_	_	_	_	_	_
@@ -5899,7 +5899,7 @@
 11	יותר	יותר	ADV	ADV	_	9	fixed	_	SpaceAfter=No
 12	,	,	PUNCT	PUNCT	_	3	punct	_	_
 13	אפילו	אפילו	ADV	ADV	_	14	advmod	_	_
-14	לייסד	ייסד	VERB	VERB	HebBinyan=PIEL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	3	dep	_	_
+14	לייסד	ייסד	VERB	VERB	HebBinyan=PIEL|HebSource=ConvUncertainHead|Root=י.ס.ד|VerbForm=Inf|Voice=Act	3	dep	_	_
 15	במשך	במשך	ADP	ADP	_	17	case	_	_
 16-17	הזמן	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
@@ -5915,7 +5915,7 @@
 24-25	המכון	_	_	_	_	_	_	_	_
 24	ה	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	מכון	מכון	NOUN	NOUN	Gender=Masc|Number=Sing	18	nmod	_	_
-26	נותן	נתן	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	25	acl	_	_
+26	נותן	נתן	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ת.נ|VerbForm=Part|Voice=Act	25	acl	_	_
 27-28	החסות	_	_	_	_	_	_	_	SpaceAfter=No
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	חסות	חסות	NOUN	NOUN	Gender=Fem|Number=Sing	26	compound:smixut	_	_
@@ -5923,14 +5923,14 @@
 30	למרות	למרות	ADP	ADP	_	37	mark	_	_
 31-32	שנותן	_	_	_	_	_	_	_	_
 31	ש	ש	SCONJ	SCONJ	_	30	fixed	_	_
-32	נותן	נתן	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	37	nsubj	_	_
+32	נותן	נתן	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ת.נ|VerbForm=Part|Voice=Act	37	nsubj	_	_
 33-34	החסות	_	_	_	_	_	_	_	_
 33	ה	ה	DET	DET	PronType=Art	34	det:def	_	_
 34	חסות	חסות	NOUN	NOUN	Gender=Fem|Number=Sing	32	compound:smixut	_	_
 35-36	שלך	_	_	_	_	_	_	_	_
 35	של_	של	ADP	ADP	Case=Gen	36	case:gen	_	_
 36	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	32	nmod:poss	_	_
-37	ירצה	רצה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	2	advcl	_	_
+37	ירצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ר.צ.י|Tense=Fut	2	advcl	_	_
 38	אחוז	אחוז	NOUN	NOUN	Gender=Masc|Number=Sing	37	obj	_	_
 39	שמן	שמן	ADJ	ADJ	Gender=Masc|Number=Sing	38	amod	_	_
 40-42	מהמענק	_	_	_	_	_	_	_	_
@@ -5938,7 +5938,7 @@
 41	ה	ה	DET	DET	PronType=Art	42	det:def	_	_
 42	מענק	מענק	NOUN	NOUN	Gender=Masc|Number=Sing	38	nmod	_	_
 43	כדי	כדי	ADP	ADP	_	44	case	_	_
-44	לכסות	כיסה	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	37	advcl	_	_
+44	לכסות	כיסה	VERB	VERB	HebBinyan=PIEL|Root=כ.ס.י|VerbForm=Inf|Voice=Act	37	advcl	_	_
 45	"	"	PUNCT	PUNCT	_	46	punct	_	SpaceAfter=No
 46	הוצאות	הוצאה	NOUN	NOUN	Gender=Fem|Number=Plur	44	obj	_	_
 47	קבועות	קבוע	ADJ	ADJ	Gender=Fem|Number=Plur	46	amod	_	SpaceAfter=No
@@ -5949,15 +5949,15 @@
 # text = אם אתה מעדיף לפעול בלי איש ביניים, אתה יכול להקים ארגון משלך שלא למטרות רווח.
 1	אם	אם	SCONJ	SCONJ	_	3	mark	_	_
 2	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	3	dep	_	_
-3	מעדיף	העדיף	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	10	advcl	_	_
-4	לפעול	פעל	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
+3	מעדיף	העדיף	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ע.ד.פ|VerbForm=Part|Voice=Act	10	advcl	_	_
+4	לפעול	פעל	VERB	VERB	HebBinyan=PAAL|Root=פ.ע.ל|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 5	בלי	בלי	ADP	ADP	_	6	case	_	_
 6	איש	איש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
 7	ביניים	ביניים	NOUN	NOUN	Gender=Masc|Number=Sing	6	compound:smixut	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	10	punct	_	_
 9	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	10	nsubj	_	_
 10	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	11	aux	_	_
-11	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+11	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|Root=ק.ו.מ|VerbForm=Inf|Voice=Act	0	root	_	_
 12	ארגון	ארגון	NOUN	NOUN	Gender=Masc|Number=Sing	11	obj	_	_
 13-15	משלך	_	_	_	_	_	_	_	_
 13	מ	מ	ADP	ADP	_	15	case	_	_
@@ -5973,7 +5973,7 @@
 # sent_id = 174
 # text = כך נהג איל ההון בעל המודעות החברתית טד טרנר, כאשר מימן את "ההתאחדות לעולם טוב יותר", המבקשת מענקים מקרנות כדי להפיק סרטי טלוויזיה דוקומנטריים.
 1	כך	כך	ADV	ADV	_	2	advmod	_	_
-2	נהג	נהג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	נהג	נהג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ה.ג|Tense=Past|Voice=Act	0	root	_	_
 3	איל	איל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	nsubj	_	_
 4-5	ההון	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -5989,7 +5989,7 @@
 12	טרנר	טרנר	PROPN	PROPN	_	11	flat:name	_	SpaceAfter=No
 13	,	,	PUNCT	PUNCT	_	2	punct	_	_
 14	כאשר	כאשר	SCONJ	SCONJ	_	15	mark	_	_
-15	מימן	מימן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	advcl	_	_
+15	מימן	מימן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=מ.מ.נ|Tense=Past|Voice=Act	2	advcl	_	_
 16	את	את	ADP	ADP	Case=Acc	19	case:acc	_	_
 17	"	"	PUNCT	PUNCT	_	19	punct	_	SpaceAfter=No
 18-19	ההתאחדות	_	_	_	_	_	_	_	_
@@ -6004,13 +6004,13 @@
 25	,	,	PUNCT	PUNCT	_	19	punct	_	_
 26-27	המבקשת	_	_	_	_	_	_	_	_
 26	ה	ה	SCONJ	SCONJ	_	27	mark	_	_
-27	מבקשת	ביקש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	19	acl:relcl	_	_
+27	מבקשת	ביקש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ב.ק.ש|VerbForm=Part|Voice=Act	19	acl:relcl	_	_
 28	מענקים	מענק	NOUN	NOUN	Gender=Masc|Number=Plur	27	obj	_	_
 29-30	מקרנות	_	_	_	_	_	_	_	_
 29	מ	מ	ADP	ADP	_	30	case	_	_
 30	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	27	obl	_	_
 31	כדי	כדי	ADP	ADP	_	32	case	_	_
-32	להפיק	הפיק	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	27	advcl	_	_
+32	להפיק	הפיק	VERB	VERB	HebBinyan=HIFIL|Root=פ.ו.ק|VerbForm=Inf|Voice=Act	27	advcl	_	_
 33	סרטי	סרט	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	32	obj	_	_
 34	טלוויזיה	טלוויזיה	NOUN	NOUN	Gender=Fem|Number=Sing	33	compound:smixut	_	_
 35	דוקומנטריים	דוקומנטרי	ADJ	ADJ	Gender=Masc|Number=Plur	33	amod	_	SpaceAfter=No
@@ -6023,7 +6023,7 @@
 3	אחרי	אחרי	ADP	ADP	_	5	mark	_	_
 4-5	שקיבל	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	3	fixed	_	_
-5	קיבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	19	advcl	_	_
+5	קיבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Past|Voice=Act	19	advcl	_	_
 6	מימון	מימון	NOUN	NOUN	Gender=Masc|Number=Sing	5	obj	_	_
 7	פטור	פטור	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
 8-9	ממס	_	_	_	_	_	_	_	_
@@ -6041,7 +6041,7 @@
 16	ל	ל	ADP	ADP	_	17	case	_	_
 17	מטרות	מטרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	12	nmod	_	_
 18	רווח	רווח	NOUN	NOUN	Gender=Masc|Number=Sing	17	compound:smixut	_	_
-19	מקרין	הקרין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+19	מקרין	הקרין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ק.ר.נ|VerbForm=Part|Voice=Act	0	root	_	_
 20	טרנר	טרנר	PROPN	PROPN	_	19	nsubj	_	_
 21	את	את	ADP	ADP	Case=Acc	23	case:acc	_	_
 22-23	הסרטים	_	_	_	_	_	_	_	_
@@ -6064,7 +6064,7 @@
 33	קיימת	קיים	ADJ	ADJ	Gender=Fem|Number=Sing	27	acl:relcl	_	_
 34	בהחלט	בהחלט	ADV	ADV	_	33	advmod	_	_
 35	כדי	כדי	ADP	ADP	_	36	case	_	_
-36	לשאת	נשא	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	33	advcl	_	_
+36	לשאת	נשא	VERB	VERB	HebBinyan=PAAL|Root=נ.ש.א|VerbForm=Inf|Voice=Act	33	advcl	_	_
 37	רווחים	רווח	NOUN	NOUN	Gender=Masc|Number=Plur	36	obj	_	_
 38-40	וברשתות	_	_	_	_	_	_	_	_
 38	ו	ו	CCONJ	CCONJ	_	40	cc	_	_
@@ -6080,8 +6080,8 @@
 # text = אבל אל תטרחו לדווח לשלטונות המקומיים.
 1	אבל	אבל	CCONJ	CCONJ	_	3	cc	_	_
 2	אל	_	ADV	ADV	_	3	advmod	_	_
-3	תטרחו	טרח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=2|Tense=Fut|Voice=Act	0	root	_	_
-4	לדווח	דיווח	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
+3	תטרחו	טרח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=2|Root=ט.ר.ח|Tense=Fut|Voice=Act	0	root	_	_
+4	לדווח	דיווח	VERB	VERB	HebBinyan=PIEL|Root=ד.ו.ח|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 5-7	לשלטונות	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -6179,8 +6179,8 @@
 1-2	הדבר	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
-3	סייע	סייע	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-4	להכניס	הכניס	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
+3	סייע	סייע	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ס.י.ע|Tense=Past|Voice=Act	0	root	_	_
+4	להכניס	הכניס	VERB	VERB	HebBinyan=HIFIL|Root=כ.נ.ס|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 5	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 6-7	הספר	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -6206,7 +6206,7 @@
 23	ב	ב	ADP	ADP	_	26	advmod	_	_
 24	דרך	דרך	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	23	fixed	_	_
 25	כלל	כלל	NOUN	NOUN	Gender=Masc|Number=Sing	23	fixed	_	_
-26	גורר	גרר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	21	acl:relcl	_	_
+26	גורר	גרר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ג.ר.ר|VerbForm=Part|Voice=Act	21	acl:relcl	_	_
 27-28	בעקבותיו	_	_	_	_	_	_	_	_
 27	בעקבות_	בעקבות	ADP	ADP	_	28	case	_	_
 28	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	26	obl	_	_
@@ -6226,7 +6226,7 @@
 
 # sent_id = 181
 # text = לך להיות זמר אופרה או ביולוג מולקולרי.
-1	לך	הלך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Voice=Act	0	root	_	_
+1	לך	הלך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Root=ה.ל.כ|Voice=Act	0	root	_	_
 2	להיות	היה	AUX	AUX	Polarity=Pos|VerbForm=Inf|VerbType=Cop	1	xcomp	_	_
 3	זמר	זמר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	obj	_	_
 4	אופרה	אופרה	NOUN	NOUN	Gender=Fem|Number=Sing	3	compound:smixut	_	_
@@ -6243,12 +6243,12 @@
 3	ספר	ספר	NOUN	NOUN	Gender=Masc|Number=Sing	10	obl	_	_
 4	"	"	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 5	צדקה	צדקה	NOUN	NOUN	Gender=Fem|Number=Sing	6	nsubj	_	_
-6	מתחילה	התחיל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	appos	_	_
+6	מתחילה	התחיל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ת.ח.ל|VerbForm=Part|Voice=Act	3	appos	_	_
 7-8	מבית	_	_	_	_	_	_	_	SpaceAfter=No
 7	מ	מ	ADP	ADP	_	8	case	_	_
 8	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	6	obl	_	_
 9	"	"	PUNCT	PUNCT	_	6	punct	_	_
-10	התלוננה	התלונן	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+10	התלוננה	התלונן	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ל.ו.נ|Tense=Past	0	root	_	_
 11	תרזה	תרזה	PROPN	PROPN	_	10	nsubj	_	_
 12	אודנדל	אודנדל	PROPN	PROPN	_	11	flat:name	_	_
 13	על	על	ADP	ADP	_	14	case	_	_
@@ -6279,7 +6279,7 @@
 14	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	12	conj	_	_
 15	עשירים	עשיר	ADJ	ADJ	Gender=Masc|Number=Plur	14	amod	_	SpaceAfter=No
 16	)	)	PUNCT	PUNCT	_	12	punct	_	_
-17	מגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+17	מגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=נ.ג.ע|VerbForm=Part|Voice=Act	0	root	_	_
 18	לבסוף	לבסוף	ADV	ADV	_	17	advmod	_	_
 19-20	לנקודת	_	_	_	_	_	_	_	_
 19	ל	ל	ADP	ADP	_	20	case	_	_
@@ -6326,23 +6326,23 @@
 50-51	היכול	_	_	_	_	_	_	_	_
 50	ה	ה	SCONJ	SCONJ	_	51	mark	_	_
 51	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	52	aux	_	_
-52	להרשות	הרשה	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	60	advcl	_	_
+52	להרשות	הרשה	VERB	VERB	HebBinyan=HIFIL|Root=ר.ש.י|VerbForm=Inf|Voice=Act	60	advcl	_	_
 53-54	לעצמו	_	_	_	_	_	_	_	_
 53	ל	ל	ADP	ADP	_	54	case	_	_
 54	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	52	obl	_	_
-55	לתרום	תרם	VERB	VERB	HebBinyan=PAAL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	52	dep	_	_
+55	לתרום	תרם	VERB	VERB	HebBinyan=PAAL|HebSource=ConvUncertainHead|Root=ת.ר.מ|VerbForm=Inf|Voice=Act	52	dep	_	_
 56	תרומות	תרומה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	55	obj	_	_
 57	צדקה	צדקה	NOUN	NOUN	Gender=Fem|Number=Sing	56	compound:smixut	_	_
 58	הוא	הוא	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	60	cop	_	_
 59-60	המנהל	_	_	_	_	_	_	_	_
 59	ה	ה	SCONJ	SCONJ	_	60	mark	_	_
-60	מנהל	ניהל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	43	acl:relcl	_	_
+60	מנהל	ניהל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=נ.ה.ל|VerbForm=Part|Voice=Act	43	acl:relcl	_	_
 61-62	אותם	_	_	_	_	_	_	_	_
 61	את_	את	ADP	ADP	Case=Acc	62	case:acc	_	_
 62	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	60	obj	_	_
 63-64	ופוקד	_	_	_	_	_	_	_	_
 63	ו	ו	CCONJ	CCONJ	_	64	cc	_	_
-64	פוקד	פקד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	60	conj	_	_
+64	פוקד	פקד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=פ.ק.ד|VerbForm=Part|Voice=Act	60	conj	_	_
 65-66	אותם	_	_	_	_	_	_	_	SpaceAfter=No
 65	את_	את	ADP	ADP	Case=Acc	66	case:acc	_	_
 66	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	64	obj	_	_
@@ -6358,7 +6358,7 @@
 5-6	הקרנות	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	4	compound:smixut	_	_
-7	מופנים	הופנה	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+7	מופנים	הופנה	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=פ.נ.י|VerbForm=Part|Voice=Pass	0	root	_	_
 8-9	לפעילויות	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	פעילויות	פעילות	NOUN	NOUN	Gender=Fem|Number=Plur	7	obl	_	_
@@ -6374,7 +6374,7 @@
 4-5	העשויים	_	_	_	_	_	_	_	_
 4	ה	ה	SCONJ	SCONJ	_	5	mark	_	_
 5	עשויים	עשוי	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbType=Mod	6	aux	_	_
-6	לחשוב	חשב	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	acl:relcl	_	_
+6	לחשוב	חשב	VERB	VERB	HebBinyan=PAAL|Root=ח.ש.ב|VerbForm=Inf|Voice=Act	3	acl:relcl	_	_
 7	על	על	ADP	ADP	_	8	case	_	_
 8	קדימויות	קדימות	NOUN	NOUN	Gender=Masc|Number=Plur	6	obl	_	_
 9	חברתיות	חברתי	ADJ	ADJ	Gender=Fem|Number=Plur	8	amod	_	_
@@ -6410,7 +6410,7 @@
 8	מ	מ	ADP	ADP	HebSource=ConvUncertainLabel	10	case	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	11	nsubj	_	_
-11	מועבר	הועבר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+11	מועבר	הועבר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ע.ב.ר|VerbForm=Part|Voice=Pass	0	root	_	_
 12-13	לפרויקטים	_	_	_	_	_	_	_	_
 12	ל	ל	ADP	ADP	_	13	case	_	_
 13	פרויקטים	פרויקט	NOUN	NOUN	Gender=Masc|Number=Plur	11	obl	_	_
@@ -6449,7 +6449,7 @@
 3-4	משליש	_	_	_	_	_	_	_	_
 3	מ	מ	ADP	ADP	_	2	fixed	_	_
 4	שליש	שליש	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
-5	מושקע	הושקע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+5	מושקע	הושקע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ש.ק.ע|VerbForm=Part|Voice=Pass	0	root	_	_
 6-7	בשטח	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	שטח	שטח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
@@ -6463,7 +6463,7 @@
 12	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
 13	ב_	ב	ADP	ADP	_	14	case	_	_
 14	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	obl	_	_
-15	מתחרים	התחרה	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	7	acl:relcl	_	_
+15	מתחרים	התחרה	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ח.ר.י|VerbForm=Part	7	acl:relcl	_	_
 16	על	על	ADP	ADP	_	17	case	_	_
 17	תשומת	תשומה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	15	obl	_	_
 18-19	הלב	_	_	_	_	_	_	_	_
@@ -6549,7 +6549,7 @@
 # text = "אתה מתבונן בנושא שיהיה בעל ערך לגיטימי למחקר, ובו בזמן יכבוש את דמיונו של פקיד התוכנית", אומר וורן מילר, איש מדעי המדינה באוניברסיטת אריזונה.
 1	"	"	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 2	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
-3	מתבונן	התבונן	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	31	obl	_	_
+3	מתבונן	התבונן	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ב.ו.נ|VerbForm=Part	31	obl	_	_
 4-5	בנושא	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	נושא	נושא	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
@@ -6571,7 +6571,7 @@
 17	ב	ב	ADP	ADP	_	19	case	_	_
 18	ה_	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	זמן	זמן	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	16	dep	_	_
-20	יכבוש	כבש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	8	conj	_	_
+20	יכבוש	כבש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ב.ש|Tense=Fut|Voice=Act	8	conj	_	_
 21	את	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 22-24	דמיונו	_	_	_	_	_	_	_	_
 22	דמיון_	דמיון	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	20	obj	_	_
@@ -6584,7 +6584,7 @@
 28	תוכנית	תוכנית	NOUN	NOUN	Gender=Fem|Number=Sing	26	compound:smixut	_	_
 29	"	"	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 30	,	,	PUNCT	PUNCT	_	31	punct	_	_
-31	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+31	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 32	וורן	וורן	PROPN	PROPN	_	31	nsubj	_	_
 33	מילר	מילר	PROPN	PROPN	_	32	flat:name	_	SpaceAfter=No
 34	,	,	PUNCT	PUNCT	_	32	punct	_	_
@@ -6604,9 +6604,9 @@
 1	במשך	במשך	ADP	ADP	_	3	case	_	_
 2	עשרות	עשרות	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	3	nummod	_	_
 3	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obl	_	_
-4	שימש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	שימש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.מ.ש|Tense=Past|Voice=Act	0	root	_	_
 5	מילר	מילר	PROPN	PROPN	_	4	nsubj	_	_
-6	מגייס	גייס	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	obj	_	_
+6	מגייס	גייס	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ג.י.ס|VerbForm=Part|Voice=Act	4	obj	_	_
 7	מענקים	מענק	NOUN	NOUN	Gender=Masc|Number=Plur	6	compound:smixut	_	_
 8	מרכזי	מרכזי	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
 9-10	לפרויקט	_	_	_	_	_	_	_	_
@@ -6628,7 +6628,7 @@
 21	ש	ש	SCONJ	SCONJ	_	24	mark	_	_
 22	בעקבות_	בעקבות	ADP	ADP	_	23	case	_	_
 23	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	24	obl	_	_
-24	נכתב	נכתב	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	17	acl:relcl	_	_
+24	נכתב	נכתב	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=כ.ת.ב|Tense=Past|Voice=Mid	17	acl:relcl	_	_
 25-26	ב1960	_	_	_	_	_	_	_	_
 25	ב	ב	ADP	ADP	_	26	case	_	_
 26	1960	1960	NUM	NUM	_	24	obl	_	_
@@ -6651,14 +6651,14 @@
 # sent_id = 193
 # text = מאז המשיך במחקר והגדיל את מאגר הנתונים שלו.
 1	מאז	מאז	ADV	ADV	_	2	advmod	_	_
-2	המשיך	המשיך	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	המשיך	המשיך	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=מ.ש.כ|Tense=Past|Voice=Act	0	root	_	_
 3-5	במחקר	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	5	case	_	_
 4	ה_	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	מחקר	מחקר	NOUN	NOUN	Gender=Masc|Number=Sing	2	obl	_	_
 6-7	והגדיל	_	_	_	_	_	_	_	_
 6	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
-7	הגדיל	הגדיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+7	הגדיל	הגדיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ג.ד.ל|Tense=Past|Voice=Act	2	conj	_	_
 8	את	את	ADP	ADP	Case=Acc	9	case:acc	_	_
 9	מאגר	מאגר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obj	_	_
 10-11	הנתונים	_	_	_	_	_	_	_	_
@@ -6678,8 +6678,8 @@
 
 # sent_id = 195
 # text = תבטיח להציל את העולם.
-1	תבטיח	הבטיח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=2|Tense=Fut|Voice=Act	0	root	_	_
-2	להציל	הציל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	1	xcomp	_	_
+1	תבטיח	הבטיח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=2|Root=ב.ט.ח|Tense=Fut|Voice=Act	0	root	_	_
+2	להציל	הציל	VERB	VERB	HebBinyan=HIFIL|Root=נ.צ.ל|VerbForm=Inf|Voice=Act	1	xcomp	_	_
 3	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 4-5	העולם	_	_	_	_	_	_	_	SpaceAfter=No
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -6694,7 +6694,7 @@
 4-5	הדיווחים	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	דיווחים	דיווח	NOUN	NOUN	Gender=Masc|Number=Plur	6	obl	_	_
-6	חלה	חל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	חלה	חל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ו.ל|Tense=Past|Voice=Act	0	root	_	_
 7-9	בעשורים	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -6732,7 +6732,7 @@
 # sent_id = 197
 # text = מילר זוכר שבשנות ה05 וה06 הוא יכול היה להסתמך על סיוע מקרנות פורד ורוקפלר.
 1	מילר	מילר	PROPN	PROPN	_	2	nsubj	_	_
-2	זוכר	זכר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	זוכר	זכר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ז.כ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 3-5	שבשנות	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
@@ -6747,7 +6747,7 @@
 11	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nsubj	_	_
 12	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	14	aux	_	_
 13	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	12	cop	_	_
-14	להסתמך	הסתמך	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	2	ccomp	_	_
+14	להסתמך	הסתמך	VERB	VERB	HebBinyan=HITPAEL|Root=ס.מ.כ|VerbForm=Inf	2	ccomp	_	_
 15	על	על	ADP	ADP	_	16	case	_	_
 16	סיוע	סיוע	NOUN	NOUN	Gender=Masc|Number=Sing	14	obl	_	_
 17-18	מקרנות	_	_	_	_	_	_	_	_
@@ -6770,7 +6770,7 @@
 5	אחרון	אחרון	ADJ	ADJ	Gender=Masc|Number=Sing	1	amod	_	_
 6	של	של	ADP	ADP	Case=Gen	7	case:gen	_	_
 7	מילר	מילר	PROPN	PROPN	_	1	nmod:poss	_	_
-8	להשיג	השיג	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	1	acl	_	_
+8	להשיג	השיג	VERB	VERB	HebBinyan=HIFIL|Root=נ.שׂ.ג|VerbForm=Inf|Voice=Act	1	acl	_	_
 9	כספים	כסף	NOUN	NOUN	Gender=Masc|Number=Plur	8	obl	_	_
 10-11	מקרן	_	_	_	_	_	_	_	_
 10	מ	מ	ADP	ADP	_	11	case	_	_
@@ -6790,7 +6790,7 @@
 # text = אז הוא גילה עניין בגורמים המשפיעים על שיעור המצביעים, ופקיד התוכנית גילה עניין בשיעור המצביעים הנמוך בקרב בני מיעוטים.
 1	אז	אז	ADV	ADV	_	3	advmod	_	_
 2	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
-3	גילה	גילה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	גילה	גילה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ג.ל.י|Tense=Past|Voice=Act	0	root	_	_
 4	עניין	עניין	NOUN	NOUN	Gender=Masc|Number=Sing	3	obj	_	_
 5-7	בגורמים	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	7	case	_	_
@@ -6798,7 +6798,7 @@
 7	גורמים	גורם	NOUN	NOUN	Gender=Masc|Number=Plur	4	nmod	_	_
 8-9	המשפיעים	_	_	_	_	_	_	_	_
 8	ה	ה	SCONJ	SCONJ	_	9	mark	_	_
-9	משפיעים	השפיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	7	acl:relcl	_	_
+9	משפיעים	השפיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ש.פ.ע|VerbForm=Part|Voice=Act	7	acl:relcl	_	_
 10	על	על	ADP	ADP	_	11	case	_	_
 11	שיעור	שיעור	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	9	obl	_	_
 12-13	המצביעים	_	_	_	_	_	_	_	SpaceAfter=No
@@ -6811,7 +6811,7 @@
 17-18	התוכנית	_	_	_	_	_	_	_	_
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	תוכנית	תוכנית	NOUN	NOUN	Gender=Fem|Number=Sing	16	compound:smixut	_	_
-19	גילה	גילה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	conj	_	_
+19	גילה	גילה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ג.ל.י|Tense=Past|Voice=Act	3	conj	_	_
 20	עניין	עניין	NOUN	NOUN	Gender=Masc|Number=Sing	19	obl	_	_
 21-22	בשיעור	_	_	_	_	_	_	_	_
 21	ב	ב	ADP	ADP	_	22	case	_	_
@@ -6829,7 +6829,7 @@
 
 # sent_id = 200
 # text = נראה היה שזה זיווג טוב.
-1	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+1	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ר.א.י|VerbForm=Part|Voice=Mid	0	root	_	_
 2	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	1	cop	_	_
 3-4	שזה	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
@@ -6841,7 +6841,7 @@
 # sent_id = 201
 # text = מילר הדגיש שיעד המחקר יהיה איתור מחסומים המונעים מבני מיעוטים להצביע, דבר שלדעתו עשוי היה להיות צעד ראשון לקראת העלאת שיעור ההצבעה.
 1	מילר	מילר	PROPN	PROPN	_	2	nsubj	_	_
-2	הדגיש	הדגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	הדגיש	הדגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ד.ג.ש|Tense=Past|Voice=Act	0	root	_	_
 3-4	שיעד	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
 4	יעד	יעד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	8	nsubj	_	_
@@ -6853,12 +6853,12 @@
 9	מחסומים	מחסום	NOUN	NOUN	Gender=Masc|Number=Plur	8	compound:smixut	_	_
 10-11	המונעים	_	_	_	_	_	_	_	_
 10	ה	ה	SCONJ	SCONJ	_	11	mark	_	_
-11	מונעים	מנע	VERB	VERB	Gender=Masc|Number=Plur|Person=1,2,3|VerbForm=Part	8	acl:relcl	_	_
+11	מונעים	מנע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=מ.נ.ע|VerbForm=Part	8	acl:relcl	_	_
 12-13	מבני	_	_	_	_	_	_	_	_
 12	מ	מ	ADP	ADP	_	13	case	_	_
 13	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	obl	_	_
 14	מיעוטים	מיעוט	NOUN	NOUN	Gender=Masc|Number=Plur	13	compound:smixut	_	_
-15	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	11	xcomp	_	SpaceAfter=No
+15	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|Root=צ.ב.ע|VerbForm=Inf|Voice=Act	11	xcomp	_	SpaceAfter=No
 16	,	,	PUNCT	PUNCT	_	8	punct	_	_
 17	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	8	appos	_	_
 18-22	שלדעתו	_	_	_	_	_	_	_	_
@@ -6898,14 +6898,14 @@
 # text = קרן פורד רצתה להיות בטוחה שהמחקר יגדיר במפורש את הדרכים להעלאת שיעור המצביעים בקרב מיעוטים.
 1	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	nsubj	_	_
 2	פורד	פורד	PROPN	PROPN	_	1	flat:name	_	_
-3	רצתה	רצה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	רצתה	רצה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ר.צ.י|Tense=Past|Voice=Act	0	root	_	_
 4	להיות	היה	AUX	AUX	Polarity=Pos|VerbForm=Inf|VerbType=Cop	3	xcomp	_	_
 5	בטוחה	בטוח	ADJ	ADJ	Gender=Fem|Number=Sing	4	obl	_	_
 6-8	שהמחקר	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	מחקר	מחקר	NOUN	NOUN	Gender=Masc|Number=Sing	9	nsubj	_	_
-9	יגדיר	הגדיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	5	advmod	_	_
+9	יגדיר	הגדיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ג.ד.ר|Tense=Fut|Voice=Act	5	advmod	_	_
 10	במפורש	במפורש	ADV	ADV	_	9	advmod	_	_
 11	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 12-13	הדרכים	_	_	_	_	_	_	_	_
@@ -6928,7 +6928,7 @@
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
 3	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	5	aux	_	_
 4	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	3	cop	_	_
-5	להבטיח	הבטיח	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+5	להבטיח	הבטיח	VERB	VERB	HebBinyan=HIFIL|Root=ב.ט.ח|VerbForm=Inf|Voice=Act	0	root	_	_
 6	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	5	obj	_	_
 7-8	במצפון	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
@@ -6942,7 +6942,7 @@
 1	מ	מ	ADP	ADP	_	3	case	_	_
 2	אז	אז	ADV	ADV	_	1	fixed	_	_
 3	7791	7791	NUM	NUM	_	4	obl	_	_
-4	מומן	מומן	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	מומן	מומן	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=מ.מ.נ|Tense=Past|Voice=Pass	0	root	_	_
 5	פרויקט	פרויקט	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	nsubj	_	_
 6	חקר	חקר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	compound:smixut	_	_
 7-8	הבחירות	_	_	_	_	_	_	_	_
@@ -6985,7 +6985,7 @@
 
 # sent_id = 207
 # text = הייה קטליזטור לשינוי.
-1	הייה	היה	VERB	VERB	Gender=Masc|HebExistential=True|Mood=Imp|Number=Sing|Person=2|Polarity=Pos	0	root	_	_
+1	הייה	היה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Mood=Imp|Number=Sing|Person=2|Polarity=Pos|Root=ה.י.י	0	root	_	_
 2	קטליזטור	קטליזאטור	NOUN	NOUN	Gender=Masc|Number=Sing	1	nsubj	_	_
 3-4	לשינוי	_	_	_	_	_	_	_	SpaceAfter=No
 3	ל	ל	ADP	ADP	_	4	case	_	_
@@ -6998,8 +6998,8 @@
 2	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	1	nsubj	_	_
 3-4	המתקשים	_	_	_	_	_	_	_	_
 3	ה	ה	SCONJ	SCONJ	_	4	mark	_	_
-4	מתקשים	התקשה	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	2	acl:relcl	_	_
-5	להבטיח	הבטיח	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	4	xcomp	_	_
+4	מתקשים	התקשה	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ק.ש.י|VerbForm=Part	2	acl:relcl	_	_
+5	להבטיח	הבטיח	VERB	VERB	HebBinyan=HIFIL|Root=ב.ט.ח|VerbForm=Inf|Voice=Act	4	xcomp	_	_
 6-7	בפרצוף	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	פרצוף	פרצוף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
@@ -7007,7 +7007,7 @@
 9-10	שהם	_	_	_	_	_	_	_	_
 9	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
 10	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	11	nsubj	_	_
-11	יציעו	הציע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Fut|Voice=Act	5	ccomp	_	_
+11	יציעו	הציע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=י.צ.ע|Tense=Fut|Voice=Act	5	ccomp	_	_
 12	פתרון	פתרון	NOUN	NOUN	Gender=Masc|Number=Sing	11	obj	_	_
 13-14	לבעיה	_	_	_	_	_	_	_	_
 13	ל	ל	ADP	ADP	_	14	case	_	_
@@ -7023,29 +7023,29 @@
 2	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	4	obl	_	_
 3	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	2	det	_	_
 4	מומלץ	מומלץ	AUX	AUX	Gender=Masc|Number=Sing|Tense=Past|VerbType=Mod	5	aux	_	_
-5	ליהפך	נהפך	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	0	root	_	_
+5	ליהפך	נהפך	VERB	VERB	HebBinyan=NIFAL|Root=ה.פ.כ|VerbForm=Inf|Voice=Mid	0	root	_	_
 6-7	לקטליזטורים	_	_	_	_	_	_	_	SpaceAfter=No
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	קטליזטורים	קטליזאטור	NOUN	NOUN	Gender=Masc|Number=Plur	5	obl	_	_
 8	:	:	PUNCT	PUNCT	_	5	punct	_	_
-9	לקבץ	קיבץ	VERB	VERB	HebBinyan=PIEL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	5	dep	_	_
+9	לקבץ	קיבץ	VERB	VERB	HebBinyan=PIEL|HebSource=ConvUncertainHead|Root=ק.ב.צ|VerbForm=Inf|Voice=Act	5	dep	_	_
 10	יחד	יחד	ADV	ADV	_	9	advmod	_	_
 11	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	9	obj	_	_
 12	רבים	רב	ADJ	ADJ	Gender=Masc|Number=Plur	11	amod	_	_
 13-14	היכולים	_	_	_	_	_	_	_	_
 13	ה	ה	SCONJ	SCONJ	_	14	mark	_	_
 14	יכולים	יכול	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbForm=Part|VerbType=Mod	15	aux	_	_
-15	להבטיח	הבטיח	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	11	acl:relcl	_	_
+15	להבטיח	הבטיח	VERB	VERB	HebBinyan=HIFIL|Root=ב.ט.ח|VerbForm=Inf|Voice=Act	11	acl:relcl	_	_
 16	פתרונות	פתרון	NOUN	NOUN	Gender=Masc|Number=Plur	15	obj	_	_
 17	או	או	CCONJ	CCONJ	_	20	cc	_	_
 18-19	שלפחות	_	_	_	_	_	_	_	_
 18	ש	ש	SCONJ	SCONJ	_	20	mark	_	_
 19	לפחות	לפחות	ADV	ADV	_	20	advmod	_	_
-20	יכולים	יכול	VERB	VERB	VerbForm=Part	14	conj	_	_
+20	יכולים	יכול	VERB	VERB	HebBinyan=PAAL|Root=י.כ.ל|VerbForm=Part	14	conj	_	_
 21	היו	היה	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	20	cop	_	SpaceAfter=No
 22	,	,	PUNCT	PUNCT	_	24	punct	_	_
 23	אילו	אילו	CCONJ	CCONJ	_	24	mark	_	_
-24	סגרו	סגר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	20	parataxis	_	_
+24	סגרו	סגר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ס.ג.ר|Tense=Past|Voice=Act	20	parataxis	_	_
 25-26	אותם	_	_	_	_	_	_	_	_
 25	את_	את	ADP	ADP	Case=Acc	26	case:acc	_	_
 26	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	24	obj	_	_
@@ -7056,7 +7056,7 @@
 30	במשך	במשך	ADP	ADP	_	31	case	_	_
 31	ימים	יום	NOUN	NOUN	Gender=Masc|Number=Plur	24	obl	_	SpaceAfter=No
 32	,	,	PUNCT	PUNCT	_	24	punct	_	_
-33	להציע	הציע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	20	xcomp	_	_
+33	להציע	הציע	VERB	VERB	HebBinyan=HIFIL|Root=י.צ.ע|VerbForm=Inf|Voice=Act	20	xcomp	_	_
 34	פתרון	פתרון	NOUN	NOUN	Gender=Masc|Number=Sing	33	obj	_	SpaceAfter=No
 35	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
@@ -7065,7 +7065,7 @@
 1-2	הקרנות	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	3	nsubj	_	_
-3	אוהבות	אהב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+3	אוהבות	אהב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=א.ה.ב|VerbForm=Part|Voice=Act	0	root	_	_
 4	יותר	יותר	ADV	ADV	_	3	advmod	_	_
 5-6	ויותר	_	_	_	_	_	_	_	_
 5	ו	ו	CCONJ	CCONJ	_	6	cc	_	_
@@ -7096,8 +7096,8 @@
 # text = בעיקר הן אוהבות לאסוף אנשים שאילולא כן אפשר שלא היו נפגשים לעולם: אקדמאים ופוליטיקאים, ביורוקרטים ונבחרי ציבור, פנאטים של השמאל ופנאטים של הימין.
 1	בעיקר	בעיקר	ADV	ADV	_	3	advmod	_	_
 2	הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	3	nsubj	_	_
-3	אוהבות	אהב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
-4	לאסוף	אסף	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
+3	אוהבות	אהב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=א.ה.ב|VerbForm=Part|Voice=Act	0	root	_	_
+4	לאסוף	אסף	VERB	VERB	HebBinyan=PAAL|Root=א.ס.פ|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 5	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	4	obj	_	_
 6-7	שאילולא	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
@@ -7108,7 +7108,7 @@
 10	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
 11	לא	לא	ADV	ADV	Polarity=Neg	13	advmod	_	_
 12	היו	היה	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	13	cop	_	_
-13	נפגשים	נפגש	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	9	ccomp	_	_
+13	נפגשים	נפגש	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=פ.ג.ש|VerbForm=Part|Voice=Mid	9	ccomp	_	_
 14	לעולם	לעולם	ADV	ADV	_	13	advmod	_	SpaceAfter=No
 15	:	:	PUNCT	PUNCT	_	5	punct	_	_
 16	אקדמאים	אקדמאי	NOUN	NOUN	Gender=Masc|Number=Plur	5	appos	_	_
@@ -7140,7 +7140,7 @@
 # text = וזכרו: אפשר שפקיד התוכנית של הקרן יצטרף גם הוא למסע; הקפידו איפוא בבחירת האתר.
 1-2	וזכרו	_	_	_	_	_	_	_	SpaceAfter=No
 1	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
-2	זכרו	זכר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Voice=Act	0	root	_	_
+2	זכרו	זכר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Mood=Imp|Number=Plur|Person=2|Root=ז.כ.ר|Voice=Act	0	root	_	_
 3	:	:	PUNCT	PUNCT	_	4	punct	_	_
 4	אפשר	אפשר	AUX	AUX	VerbType=Mod	2	ccomp	_	_
 5-6	שפקיד	_	_	_	_	_	_	_	_
@@ -7153,7 +7153,7 @@
 10-11	הקרן	_	_	_	_	_	_	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	קרן	קרן	NOUN	NOUN	Gender=Fem|Number=Sing	6	nmod:poss	_	_
-12	יצטרף	הצטרף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	4	ccomp	_	_
+12	יצטרף	הצטרף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=צ.ר.פ|Tense=Fut	4	ccomp	_	_
 13	גם	גם	ADV	ADV	_	14	det	_	_
 14	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	dep	_	_
 15-17	למסע	_	_	_	_	_	_	_	SpaceAfter=No
@@ -7161,7 +7161,7 @@
 16	ה_	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	מסע	מסע	NOUN	NOUN	Gender=Masc|Number=Sing	12	obl	_	_
 18	;	;	PUNCT	PUNCT	_	19	cc	_	_
-19	הקפידו	הקפיד	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Mood=Imp|Number=Plur|Person=2|Voice=Act	2	conj	_	_
+19	הקפידו	הקפיד	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Mood=Imp|Number=Plur|Person=2|Root=ק.פ.ד|Voice=Act	2	conj	_	_
 20	איפוא	אפוא	ADV	ADV	_	19	advmod	_	_
 21-22	בבחירת	_	_	_	_	_	_	_	_
 21	ב	ב	ADP	ADP	_	22	case	_	_
@@ -7173,7 +7173,7 @@
 
 # sent_id = 213
 # text = אומרים שמרכז הוועידות והלימודים של קרן רוקפלר בבלאגיו שבאיטליה הוא מקום טוב לחישול קונסנזוס על בעיות דחופות של העולם.
-1	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+1	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 2-3	שמרכז	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
 3	מרכז	מרכז	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	18	nsubj:cop	_	_
@@ -7215,7 +7215,7 @@
 1	גם	גם	ADV	ADV	_	4	advmod	_	_
 2	אם	אם	SCONJ	SCONJ	_	4	mark	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
-4	ייווצר	נוצר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	11	advcl	_	_
+4	ייווצר	נוצר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.צ.ר|Tense=Fut|Voice=Mid	11	advcl	_	_
 5	קונסנסוס	קונצנזוס	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 6	חדש	חדש	ADJ	ADJ	Gender=Masc|Number=Sing	5	amod	_	_
 7-8	מאלכימיה	_	_	_	_	_	_	_	_
@@ -7229,7 +7229,7 @@
 13	וודאי	ודאי	ADJ	ADJ	Gender=Masc|Number=Sing	11	fixed	_	_
 14-15	שייצא	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
-15	ייצא	ייצא	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	ccomp	_	_
+15	ייצא	ייצא	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=י.צ.א|Tense=Past|Voice=Act	11	ccomp	_	_
 16	כרך	כרך	NOUN	NOUN	Gender=Masc|Number=Sing	15	nsubj	_	_
 17	של	של	ADP	ADP	Case=Gen	18	case:gen	_	_
 18	ניירות	נייר	NOUN	NOUN	Gender=Masc|Number=Plur	16	nmod:poss	_	SpaceAfter=No
@@ -7242,12 +7242,12 @@
 3-4	שאינם	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
 4	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	5	advmod	_	_
-5	מוזמנים	הוזמן	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	2	acl:relcl	_	_
+5	מוזמנים	הוזמן	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ז.מ.נ|VerbForm=Part|Voice=Pass	2	acl:relcl	_	_
 6-7	לוועידות	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	וועידות	ועידה	NOUN	NOUN	Gender=Fem|Number=Plur	5	obl	_	_
 8	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	7	det	_	_
-9	שוררת	שרר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+9	שוררת	שרר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=שׂ.ר.ר|VerbForm=Part|Voice=Act	0	root	_	_
 10	ציניות	ציניות	NOUN	NOUN	Gender=Fem|Number=Sing	9	nsubj	_	_
 11	רבה	רב	ADJ	ADJ	Gender=Fem|Number=Sing	10	amod	_	_
 12	באשר	באשר	CCONJ	CCONJ	_	14	case	_	_
@@ -7264,7 +7264,7 @@
 20	ניירות	נייר	NOUN	NOUN	Gender=Masc|Number=Plur	17	conj	_	_
 21-22	המונפקים	_	_	_	_	_	_	_	_
 21	ה	ה	SCONJ	SCONJ	_	22	mark	_	_
-22	מונפקים	הונפק	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	15	acl:relcl	_	_
+22	מונפקים	הונפק	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=נ.פ.ק|VerbForm=Part|Voice=Pass	15	acl:relcl	_	_
 23-24	בחסות	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	חסות	חסות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	22	obl	_	_
@@ -7285,7 +7285,7 @@
 8	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
 9	מעצבי	מעצב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	7	conj	_	_
 10	מדיניות	מדיניות	NOUN	NOUN	Gender=Fem|Number=Sing	9	compound:smixut	_	_
-11	רובצים	רבץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	3	ccomp	_	_
+11	רובצים	רבץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ר.ב.צ|VerbForm=Part|Voice=Act	3	ccomp	_	_
 12	כל	כול	DET	DET	Definite=Cons	13	det	_	_
 13	כרכי	כרך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	nsubj	_	_
 14	"	"	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
@@ -7315,7 +7315,7 @@
 34	כרכים	כרך	NOUN	NOUN	Gender=Masc|Number=Plur	30	nsubj	_	_
 35-36	המספקים	_	_	_	_	_	_	_	_
 35	ה	ה	SCONJ	SCONJ	_	36	mark	_	_
-36	מספקים	סיפק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	34	acl:relcl	_	_
+36	מספקים	סיפק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ס.פ.ק|VerbForm=Part|Voice=Act	34	acl:relcl	_	_
 37	מידע	מידע	NOUN	NOUN	Gender=Masc|Number=Sing	36	obj	_	_
 38-39	בנושא	_	_	_	_	_	_	_	_
 38	ב	ב	ADP	ADP	_	39	case	_	_
@@ -7339,11 +7339,11 @@
 
 # sent_id = 218
 # text = ערוך בדיקה מחודשת, נוקבת וקטלנית, לדוגמות ליברליות עייפות.
-1	ערוך	ערך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Voice=Act	0	root	_	_
+1	ערוך	ערך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Root=ע.ר.כ|Voice=Act	0	root	_	_
 2	בדיקה	בדיקה	NOUN	NOUN	Gender=Fem|Number=Sing	1	obj	_	_
 3	מחודשת	מחודש	ADJ	ADJ	Gender=Fem|Number=Sing	2	amod	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	2	punct	_	_
-5	נוקבת	נקב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	amod	_	_
+5	נוקבת	נקב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ק.ב|VerbForm=Part|Voice=Act	2	amod	_	_
 6-7	וקטלנית	_	_	_	_	_	_	_	SpaceAfter=No
 6	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
 7	קטלנית	קטלני	ADJ	ADJ	Gender=Fem|Number=Sing	5	conj	_	_
@@ -7362,7 +7362,7 @@
 2	כ	כ	ADP	ADP	_	4	advmod	_	_
 3	02	02	NUM	NUM	_	4	nummod	_	_
 4	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	5	dep	_	_
-5	מתאמצת	התאמץ	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+5	מתאמצת	התאמץ	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=א.מ.צ|VerbForm=Part	0	root	_	_
 6	חבורת	חבורה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	5	nsubj	_	_
 7	שמרנים	שמרן	NOUN	NOUN	Gender=Masc|Number=Plur	6	compound:smixut	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	10	punct	_	_
@@ -7372,7 +7372,7 @@
 11	אירווינג	אירווינג	PROPN	PROPN	_	10	nsubj	_	_
 12	קריסטול	קריסטול	PROPN	PROPN	_	11	flat:name	_	SpaceAfter=No
 13	,	,	PUNCT	PUNCT	_	10	punct	_	_
-14	להשיג	השיג	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
+14	להשיג	השיג	VERB	VERB	HebBinyan=HIFIL|Root=נ.שׂ.ג|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 15	סובסידיה	סובסידיה	NOUN	NOUN	Gender=Fem|Number=Sing	14	obj	_	_
 16	פילנטרופית	פילנתרופי	ADJ	ADJ	Gender=Fem|Number=Sing	15	amod	_	_
 17-18	להוגים	_	_	_	_	_	_	_	_
@@ -7389,7 +7389,7 @@
 # sent_id = 220
 # text = הם סבורים שיש אירוניה בכך שמענקי קרנות באים בדרך כלל מטיפוסים שמרניים, אך הקרן לובשת לעיתים קרובות חזות של שמאלה מהמרכז בהנהגת הפילנטרופואידים (המונח שטבע דווייט מקדונלד בקרן פורד), שבסופו של דבר מנהלים אותם.
 1	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	2	nsubj	_	_
-2	סבורים	סבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	סבורים	סבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ס.ב.ר|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	שיש	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
 4	יש	יש	VERB	VERB	HebExistential=True	2	ccomp	_	_
@@ -7401,7 +7401,7 @@
 8	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
 9	מענקי	מענק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	nsubj	_	_
 10	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	9	compound:smixut	_	_
-11	באים	בא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	7	acl:relcl	_	_
+11	באים	בא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ב.ו.א|VerbForm=Part|Voice=Act	7	acl:relcl	_	_
 12-13	בדרך	_	_	_	_	_	_	_	_
 12	ב	ב	ADP	ADP	_	11	advmod	_	_
 13	דרך	דרך	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	12	fixed	_	_
@@ -7415,7 +7415,7 @@
 20-21	הקרן	_	_	_	_	_	_	_	_
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	קרן	קרן	NOUN	NOUN	Gender=Fem|Number=Sing	22	nsubj	_	_
-22	לובשת	לבש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	11	conj	_	_
+22	לובשת	לבש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ל.ב.ש|VerbForm=Part|Voice=Act	11	conj	_	_
 23	לעיתים	לעתים	ADV	ADV	_	22	advmod	_	_
 24	קרובות	קרוב	ADJ	ADJ	Gender=Fem|Number=Plur	23	fixed	_	_
 25	חזות	חזות	NOUN	NOUN	Gender=Fem|Number=Sing	22	obj	_	_
@@ -7437,7 +7437,7 @@
 37	מונח	מונח	NOUN	NOUN	Gender=Masc|Number=Sing	34	appos	_	_
 38-39	שטבע	_	_	_	_	_	_	_	_
 38	ש	ש	SCONJ	SCONJ	_	39	mark	_	_
-39	טבע	טבע	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	37	acl:relcl	_	_
+39	טבע	טבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ט.ב.ע|Tense=Past	37	acl:relcl	_	_
 40	דווייט	דווייט	PROPN	PROPN	_	39	nsubj	_	_
 41	מקדונלד	מקדונלד	PROPN	PROPN	_	40	flat:name	_	_
 42-43	בקרן	_	_	_	_	_	_	_	_
@@ -7454,7 +7454,7 @@
 51	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	49	nmod:poss	_	_
 52	של	של	ADP	ADP	Case=Gen	53	case:gen	_	_
 53	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	49	nmod:poss	_	_
-54	מנהלים	ניהל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	34	acl:relcl	_	_
+54	מנהלים	ניהל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=נ.ה.ל|VerbForm=Part|Voice=Act	34	acl:relcl	_	_
 55-56	אותם	_	_	_	_	_	_	_	SpaceAfter=No
 55	את_	את	ADP	ADP	Case=Acc	56	case:acc	_	_
 56	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	54	obj	_	_
@@ -7471,16 +7471,16 @@
 6-7	השמרנים	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	שמרנים	שמרן	ADJ	ADJ	Gender=Masc|Number=Plur	3	amod	_	_
-8	עשו	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+8	עשו	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	0	root	_	_
 9	שני	שני	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	10	nummod	_	_
 10	דברים	דבר	NOUN	NOUN	Gender=Masc|Number=Plur	8	obj	_	SpaceAfter=No
 11	:	:	PUNCT	PUNCT	_	15	punct	_	_
 12	ראשית	ראשית	ADV	ADV	_	15	advmod	_	SpaceAfter=No
 13	,	,	PUNCT	PUNCT	_	15	punct	_	_
 14	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	15	nsubj	_	_
-15	עודדו	עודד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	10	appos	_	_
+15	עודדו	עודד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ע.ו.ד|Tense=Past|Voice=Act	10	appos	_	_
 16	חברות	חברה	NOUN	NOUN	Gender=Fem|Number=Plur	15	obj	_	_
-17	לתעל	תיעל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	15	xcomp	_	_
+17	לתעל	תיעל	VERB	VERB	HebBinyan=PIEL|Root=ת.ע.ל|VerbForm=Inf|Voice=Act	15	xcomp	_	_
 18	את	את	ADP	ADP	Case=Acc	20	case:acc	_	_
 19-20	הפילנטרופיה	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
@@ -7511,7 +7511,7 @@
 1	שנית	שנית	ADV	ADV	_	4	advmod	_	SpaceAfter=No
 2	,	,	PUNCT	PUNCT	_	4	punct	_	_
 3	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
-4	עודדו	עודד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	עודדו	עודד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ע.ד.ד|Tense=Past|Voice=Act	0	root	_	_
 5	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 6-7	היוצאים	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -7520,7 +7520,7 @@
 9-10	הכלל	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	כלל	כלל	NOUN	NOUN	Gender=Masc|Number=Sing	7	nmod	_	_
-11	להפעיל	הפעיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	4	xcomp	_	_
+11	להפעיל	הפעיל	VERB	VERB	HebBinyan=HIFIL|Root=פ.ע.ל|VerbForm=Inf|Voice=Act	4	xcomp	_	_
 12	השפעה	השפעה	NOUN	NOUN	Gender=Fem|Number=Sing	11	obj	_	_
 13	מודעת	מודע	ADJ	ADJ	Gender=Fem|Number=Sing	12	amod	_	_
 14	יותר	יותר	ADV	ADV	_	13	advmod	_	_
@@ -7541,7 +7541,7 @@
 3	מרכז	מרכז	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	nmod	_	_
 4	אותה	אותו	PRON	PRON	Definite=Def|Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	det	_	_
 5	תנועה	תנועה	NOUN	NOUN	Gender=Fem|Number=Sing	3	compound:smixut	_	_
-6	מדגישים	הדגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+6	מדגישים	הדגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ד.ג.ש|VerbForm=Part|Voice=Act	0	root	_	_
 7	כי	כי	SCONJ	SCONJ	_	11	mark	_	_
 8	לא	לא	ADV	ADV	Polarity=Neg	11	advmod	_	_
 9	היתה	היה	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	11	cop	_	_
@@ -7558,21 +7558,21 @@
 1	"	"	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 2	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
-4	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	17	obl	_	_
+4	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	17	obl	_	_
 5	הבה	הבה	AUX	AUX	VerbType=Mod	6	aux	_	_
-6	ניצור	יצר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Fut|Voice=Act	4	obl	_	_
+6	ניצור	יצר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=י.צ.ר|Tense=Fut|Voice=Act	4	obl	_	_
 7	אווירה	אווירה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obj	_	_
 8-10	שבה	_	_	_	_	_	_	_	_
 8	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
 9	ב_	ב	ADP	ADP	_	10	case	_	_
 10	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	11	obl	_	_
 11	נוכל	יכול	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=1|Tense=Fut|VerbType=Mod	12	aux	_	_
-12	לבחור	בחר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	acl:relcl	_	_
+12	לבחור	בחר	VERB	VERB	HebBinyan=PAAL|Root=ב.ח.ר|VerbForm=Inf|Voice=Act	7	acl:relcl	_	_
 13	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	12	obj	_	_
 14	שמרן	שמרן	ADJ	ADJ	Gender=Masc|Number=Sing	13	amod	_	SpaceAfter=No
 15	"	"	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 16	,	,	PUNCT	PUNCT	_	17	punct	_	_
-17	זוכר	זכר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+17	זוכר	זכר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ז.כ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 18	לזלי	לזלי	PROPN	PROPN	_	17	nsubj	_	_
 19	לנקובסקי	לנקובסקי	PROPN	PROPN	_	18	flat:name	_	SpaceAfter=No
 20	,	,	PUNCT	PUNCT	_	18	punct	_	_
@@ -7592,7 +7592,7 @@
 2	,	,	PUNCT	PUNCT	_	1	punct	_	_
 3-4	שניהל	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	ניהל	ניהל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	1	acl:relcl	_	_
+4	ניהל	ניהל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.ה.ל|Tense=Past|Voice=Act	1	acl:relcl	_	_
 5	את	את	ADP	ADP	Case=Acc	6	case:acc	_	_
 6	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	obj	_	_
 7	סמית	סמית	PROPN	PROPN	_	6	flat:name	_	SpaceAfter=No
@@ -7601,12 +7601,12 @@
 10-11	וכיום	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	12	cc	_	_
 11	כיום	כיום	ADV	ADV	_	12	advmod	_	_
-12	מנהל	ניהל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	conj	_	_
+12	מנהל	ניהל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=נ.ה.ל|VerbForm=Part|Voice=Act	4	conj	_	_
 13	את	את	ADP	ADP	Case=Acc	14	case:acc	_	_
 14	מכון	מכון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	obj	_	_
 15	הדסון	הדסון	PROPN	PROPN	_	14	flat:name	_	SpaceAfter=No
 16	,	,	PUNCT	PUNCT	_	17	punct	_	_
-17	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+17	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 18	כי	כי	SCONJ	SCONJ	_	26	mark	_	_
 19-20	הרעיון	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
@@ -7616,7 +7616,7 @@
 23	כל	כול	DET	DET	Definite=Cons	26	advmod	_	SpaceAfter=No
 24	-	-	PUNCT	PUNCT	_	23	fixed	_	SpaceAfter=No
 25	כך	כך	ADV	ADV	_	23	fixed	_	_
-26	לתת	נתן	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	17	ccomp	_	_
+26	לתת	נתן	VERB	VERB	HebBinyan=PAAL|Root=נ.ת.נ|VerbForm=Inf|Voice=Act	17	ccomp	_	_
 27	מענקים	מענק	NOUN	NOUN	Gender=Masc|Number=Plur	26	obj	_	_
 28-30	לחשיבה	_	_	_	_	_	_	_	_
 28	ל	ל	ADP	ADP	_	30	case	_	_
@@ -7631,7 +7631,7 @@
 35	עצמה	עצמו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	30	nmod	_	_
 36	,	,	PUNCT	PUNCT	_	26	punct	_	_
 37	אלא	אלא	CCONJ	CCONJ	_	38	cc	_	_
-38	לתגמל	תגמל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	26	conj	_	_
+38	לתגמל	תגמל	VERB	VERB	HebBinyan=PIEL|Root=ת.ג.מ.ל|VerbForm=Inf|Voice=Act	26	conj	_	_
 39	חלופות	חלופה	NOUN	NOUN	Gender=Fem|Number=Plur	38	obj	_	_
 40-41	לכל	_	_	_	_	_	_	_	_
 40	ל	ל	ADP	ADP	_	43	case	_	_
@@ -7644,7 +7644,7 @@
 45	שמאלית	שמאלי	ADJ	ADJ	Gender=Fem|Number=Sing	43	amod	_	_
 46-47	שקיבלה	_	_	_	_	_	_	_	_
 46	ש	ש	SCONJ	SCONJ	_	47	mark	_	_
-47	קיבלה	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	43	acl:relcl	_	_
+47	קיבלה	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Past|Voice=Act	43	acl:relcl	_	_
 48	עד	עד	ADP	ADP	_	49	case	_	_
 49	אז	אז	ADV	ADV	_	47	obl	_	_
 50	תגמולים	תגמול	NOUN	NOUN	Gender=Masc|Number=Plur	47	obj	_	_
@@ -7664,7 +7664,7 @@
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	אחרים	אחר	ADJ	ADJ	Gender=Masc|Number=Plur	1	conj	_	_
 7	פשוט	פשוט	ADV	ADV	_	8	advmod	_	_
-8	חשו	חש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+8	חשו	חש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ח.ו.ש|Tense=Past|Voice=Act	0	root	_	_
 9-11	ש"קיים	_	_	_	_	_	_	_	_
 9	ש	_	SCONJ	SCONJ	_	11	mark	_	_
 10	"	"	PUNCT	PUNCT	_	11	punct	_	_
@@ -7686,9 +7686,9 @@
 # text = הם פשוט תהו, נזכר לנקובסקי, "למי יש רעיונות מעניינים?".
 1	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	3	nsubj	_	_
 2	פשוט	פשוט	ADV	ADV	_	3	advmod	_	_
-3	תהו	תהה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+3	תהו	תהה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ת.ה.י|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	5	punct	_	_
-5	נזכר	נזכר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	3	parataxis	_	_
+5	נזכר	נזכר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ז.כ.ר|VerbForm=Part|Voice=Mid	3	parataxis	_	_
 6	לנקובסקי	לנקובסקי	PROPN	PROPN	_	5	nsubj	_	SpaceAfter=No
 7	,	,	PUNCT	PUNCT	_	5	punct	_	_
 8	"	"	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
@@ -7706,7 +7706,7 @@
 # text = ובכן, התברר שבעלי הרעיונות המעניינים היו אנשים כמו רוברט בורק, מרטין פלדסטיין, צארלס מאריי ואלן בלום שגם הודות לתמיכה הפילנטרופית שקיבלו בשנות ה70 ואו בראשית שנות ה80 אין צורך להציגם בציבור.
 1	ובכן	ובכן	ADV	ADV	_	3	advmod	_	SpaceAfter=No
 2	,	,	PUNCT	PUNCT	_	3	punct	_	_
-3	התברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	התברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ב.ר.ר|Tense=Past	0	root	_	_
 4-5	שבעלי	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
 5	בעלי	בעל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	nsubj	_	_
@@ -7744,7 +7744,7 @@
 31	פילנטרופית	פילנתרופי	ADJ	ADJ	Gender=Fem|Number=Sing	29	amod	_	_
 32-33	שקיבלו	_	_	_	_	_	_	_	_
 32	ש	ש	SCONJ	SCONJ	_	33	mark	_	_
-33	קיבלו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	29	acl:relcl	_	_
+33	קיבלו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ק.ב.ל|Tense=Past|Voice=Act	29	acl:relcl	_	_
 34-35	בשנות	_	_	_	_	_	_	_	_
 34	ב	ב	ADP	ADP	_	35	case	_	_
 35	שנות	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	33	obl	_	_
@@ -7764,7 +7764,7 @@
 45	אין	אין	VERB	VERB	HebExistential=True	11	acl:relcl	_	_
 46	צורך	צורך	NOUN	NOUN	Gender=Masc|Number=Sing	45	nsubj	_	_
 47-49	להציגם	_	_	_	_	_	_	_	_
-47	להציגם	הציג	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	46	acl	_	_
+47	להציגם	הציג	VERB	VERB	HebBinyan=HIFIL|Root=י.צ.ג|VerbForm=Inf|Voice=Act	46	acl	_	_
 48	את	את	ADP	ADP	Case=Acc	49	case	_	_
 49	_הם	הוא	PRON	PRON	Case=Acc|Gender=Masc|Number=Plur|Person=3|PronType=Prs	47	obj	_	_
 50-52	בציבור	_	_	_	_	_	_	_	SpaceAfter=No
@@ -7777,7 +7777,7 @@
 # text = אם אתה משמיע באוזני השמרנים רמז לכך שקריסטול ושות הפכו את הקערה על פיה, ולכן כיום כסף ימני הוא החולש בכיפה בעולם הרעיונות, הם יפנו אותך לרשימת הקרנות הפילנטרופיות הגדולות ביותר, ויזכירו לך שמבין הקרנות השמרניות אולין, סמית-ריצרדסון, לינד והרי בראדלו, פיו, שרה סקאיף רק פיו כלולה ברשימת הגדולות.
 1	אם	אם	SCONJ	SCONJ	_	3	mark	_	_
 2	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
-3	משמיע	השמיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	40	advcl	_	_
+3	משמיע	השמיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ש.מ.ע|VerbForm=Part|Voice=Act	40	advcl	_	_
 4	באוזני	באוזני	ADP	ADP	_	6	case	_	_
 5-6	השמרנים	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -7792,7 +7792,7 @@
 12-13	ושות	_	_	_	_	_	_	_	_
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
 13	שות	שת	NOUN	NOUN	Gender=Masc|Number=Plur	11	conj	_	_
-14	הפכו	הפך	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	9	acl:relcl	_	_
+14	הפכו	הפך	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ה.פ.כ|Tense=Past	9	acl:relcl	_	_
 15	את	את	ADP	ADP	Case=Acc	17	case:acc	_	_
 16-17	הקערה	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
@@ -7812,7 +7812,7 @@
 28	הוא	הוא	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	30	cop	_	_
 29-30	החולש	_	_	_	_	_	_	_	_
 29	ה	ה	SCONJ	SCONJ	_	30	mark	_	_
-30	חולש	חלש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	14	conj	_	_
+30	חולש	חלש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ח.ל.ש|VerbForm=Part|Voice=Act	14	conj	_	_
 31-33	בכיפה	_	_	_	_	_	_	_	_
 31	ב	ב	ADP	ADP	_	33	case	_	_
 32	ה_	ה	DET	DET	PronType=Art	33	det:def	_	_
@@ -7825,7 +7825,7 @@
 37	רעיונות	רעיון	NOUN	NOUN	Gender=Masc|Number=Plur	35	compound:smixut	_	_
 38	,	,	PUNCT	PUNCT	_	40	punct	_	_
 39	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	40	nsubj	_	_
-40	יפנו	הפנה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut	0	root	_	_
+40	יפנו	הפנה	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=פ.נ.י|Tense=Fut	0	root	_	_
 41-42	אותך	_	_	_	_	_	_	_	_
 41	את_	את	ADP	ADP	Case=Acc	42	case:acc	_	_
 42	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	40	obj	_	_
@@ -7845,7 +7845,7 @@
 52	,	,	PUNCT	PUNCT	_	40	punct	_	_
 53-54	ויזכירו	_	_	_	_	_	_	_	_
 53	ו	ו	CCONJ	CCONJ	_	54	cc	_	_
-54	יזכירו	הזכיר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Fut|Voice=Act	40	conj	_	_
+54	יזכירו	הזכיר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ז.כ.ר|Tense=Fut|Voice=Act	40	conj	_	_
 55-56	לך	_	_	_	_	_	_	_	_
 55	ל_	ל	ADP	ADP	_	56	case	_	_
 56	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	54	obl	_	_
@@ -7876,7 +7876,7 @@
 77	סקאיף	סקאיף	PROPN	PROPN	_	76	flat:name	_	_
 78	רק	רק	ADV	ADV	_	80	advmod	_	_
 79	פיו	פה	PROPN	PROPN	_	80	nsubj	_	_
-80	כלולה	כלל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	54	ccomp	_	_
+80	כלולה	כלל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	54	ccomp	_	_
 81-82	ברשימת	_	_	_	_	_	_	_	_
 81	ב	ב	ADP	ADP	_	82	case	_	_
 82	רשימת	רשימה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	80	obl	_	_
@@ -7940,7 +7940,7 @@
 1	לפני	לפני	ADP	ADP	_	3	case	_	_
 2	כמה	כמה	DET	DET	Definite=Cons	3	det	_	_
 3	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obl	_	_
-4	תרמה	תרם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	תרמה	תרם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ת.ר.מ|Tense=Past|Voice=Act	0	root	_	_
 5-6	הקרן	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	קרן	קרן	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
@@ -7958,7 +7958,7 @@
 16	של	של	ADP	ADP	Case=Gen	17	case:gen	_	_
 17	סטיוון	סטיוון	PROPN	PROPN	_	13	nmod:poss	_	_
 18	הוקינג	הוקינג	PROPN	PROPN	_	17	flat:name	_	_
-19	לאחד	איחד	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	13	acl	_	_
+19	לאחד	איחד	VERB	VERB	HebBinyan=PIEL|Root=א.ח.ד|VerbForm=Inf|Voice=Act	13	acl	_	_
 20	את	את	ADP	ADP	Case=Acc	21	case:acc	_	_
 21	תיאוריית	תיאוריה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	19	obj	_	_
 22-23	הקוונטים	_	_	_	_	_	_	_	_
@@ -7999,7 +7999,7 @@
 1	אבל	אבל	CCONJ	CCONJ	_	4	cc	_	_
 2	כמה	כמה	DET	DET	Definite=Cons	3	det	_	_
 3	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	4	obj	_	_
-4	העניקה	העניק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	העניקה	העניק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ע.נ.ק|Tense=Past|Voice=Act	0	root	_	_
 5	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	nsubj	_	_
 6	מקארתור	מקארתור	PROPN	PROPN	_	5	flat:name	_	_
 7-8	לפיסיקאים	_	_	_	_	_	_	_	_
@@ -8008,7 +8008,7 @@
 9	מבריקים	מבריק	ADJ	ADJ	Gender=Masc|Number=Plur	8	amod	_	_
 10-11	המתעמקים	_	_	_	_	_	_	_	_
 10	ה	ה	SCONJ	SCONJ	_	11	mark	_	_
-11	מתעמקים	התעמק	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|VerbForm=Part	8	dep	_	_
+11	מתעמקים	התעמק	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|Root=ע.מ.ק|VerbForm=Part	8	dep	_	_
 12-13	בבעיה	_	_	_	_	_	_	_	_
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	בעיה	בעיה	NOUN	NOUN	Gender=Fem|Number=Sing	11	obl	_	_
@@ -8016,7 +8016,7 @@
 15-16	ואינם	_	_	_	_	_	_	_	_
 15	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
 16	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	17	advmod	_	_
-17	סובלים	סבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	11	conj	_	_
+17	סובלים	סבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ס.ב.ל|VerbForm=Part|Voice=Act	11	conj	_	_
 18-19	משיתוק	_	_	_	_	_	_	_	_
 18	מ	מ	ADP	ADP	_	19	case	_	_
 19	שיתוק	שיתוק	NOUN	NOUN	Gender=Masc|Number=Sing	17	obl	_	_
@@ -8062,7 +8062,7 @@
 23	ל	ל	ADP	ADP	_	26	advmod	_	_
 24	עתים	עת	NOUN	NOUN	Gender=Fem|Number=Plur	23	fixed	_	_
 25	קרובות	קרוב	ADJ	ADJ	Gender=Fem|Number=Plur	23	fixed	_	_
-26	מתארים	תיאר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	14	advcl	_	_
+26	מתארים	תיאר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ת.א.ר|VerbForm=Part|Voice=Act	14	advcl	_	_
 27-28	אותן	_	_	_	_	_	_	_	SpaceAfter=No
 27	את_	את	ADP	ADP	Case=Acc	28	case:acc	_	_
 28	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	26	obj	_	_
@@ -8074,7 +8074,7 @@
 2	רוקפלר	רוקפלר	PROPN	PROPN	_	1	flat:name	_	_
 3	אמנם	אמנם	ADV	ADV	_	4	advmod	_	_
 4	מוכנה	מוכן	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbType=Mod	5	aux	_	_
-5	לחלק	חילק	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	0	root	_	_
+5	לחלק	חילק	VERB	VERB	HebBinyan=PIEL|Root=ח.ל.ק|VerbForm=Inf|Voice=Act	0	root	_	_
 6	פה	פה	ADV	ADV	_	5	advmod	_	_
 7-8	ושם	_	_	_	_	_	_	_	_
 7	ו	ו	CCONJ	CCONJ	_	6	fixed	_	_
@@ -8109,7 +8109,7 @@
 1	אבל	אבל	CCONJ	CCONJ	_	3	cc	_	_
 2	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 3	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	4	aux	_	_
-4	לעיין	עיין	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	0	root	_	_
+4	לעיין	עיין	VERB	VERB	HebBinyan=PIEL|Root=ע.י.נ|VerbForm=Inf|Voice=Act	0	root	_	_
 5-6	בעשרות	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	עשרות	עשרות	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	7	nummod	_	_
@@ -8120,7 +8120,7 @@
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	שנתי	שנתי	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
 12	בלי	בלי	ADP	ADP	_	13	case	_	_
-13	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	4	advcl	_	_
+13	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|Root=מ.צ.א|VerbForm=Inf|Voice=Act	4	advcl	_	_
 14	פריט	פריט	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	13	obj	_	_
 15	הוצאה	הוצאה	NOUN	NOUN	Gender=Fem|Number=Sing	14	compound:smixut	_	_
 16-17	שקל	_	_	_	_	_	_	_	_
@@ -8128,7 +8128,7 @@
 17	קל	קל	AUX	AUX	Gender=Masc|Number=Sing|Tense=Past|VerbType=Mod	20	aux	_	_
 18	כל	כול	DET	DET	Definite=Cons	17	advmod	_	_
 19	כך	כך	ADV	ADV	_	18	fixed	_	_
-20	ללעוג	לעג	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	14	acl:relcl	_	_
+20	ללעוג	לעג	VERB	VERB	HebBinyan=PAAL|Root=ל.ע.ג|VerbForm=Inf|Voice=Act	14	acl:relcl	_	_
 21-22	לו	_	_	_	_	_	_	_	SpaceAfter=No
 21	ל_	ל	ADP	ADP	_	22	case	_	_
 22	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	obl	_	_
@@ -8142,7 +8142,7 @@
 3	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	obl	_	_
 4	פורד	פורד	PROPN	PROPN	_	3	flat:name	_	_
 5	שמרנים	שמרן	NOUN	NOUN	Gender=Masc|Number=Plur	6	nsubj	_	_
-6	מתלוננים	התלונן	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	0	root	_	_
+6	מתלוננים	התלונן	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ל.ו.נ|VerbForm=Part	0	root	_	_
 7-8	שמדיניות	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	30	mark	_	_
 8	מדיניות	מדיניות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	30	nsubj:cop	_	_
@@ -8168,7 +8168,7 @@
 25-26	שהיא	_	_	_	_	_	_	_	_
 25	ש	ש	SCONJ	SCONJ	_	27	mark	_	_
 26	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	27	nsubj	_	_
-27	נוקטת	נקט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	8	acl:relcl	_	SpaceAfter=No
+27	נוקטת	נקט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ק.ט|VerbForm=Part|Voice=Act	8	acl:relcl	_	SpaceAfter=No
 28	,	,	PUNCT	PUNCT	_	30	punct	_	_
 29	היא	הוא	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	30	cop	_	_
 30	שריד	שריד	NOUN	NOUN	Gender=Masc|Number=Sing	6	ccomp	_	_
@@ -8202,7 +8202,7 @@
 16-17	הקרן	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	קרן	קרן	NOUN	NOUN	Gender=Fem|Number=Sing	15	compound:smixut	_	_
-18	נמסר	נמסר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	3	acl:relcl	_	_
+18	נמסר	נמסר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.ס.ר|Tense=Past|Voice=Mid	3	acl:relcl	_	_
 19-20	לקבוצות	_	_	_	_	_	_	_	_
 19	ל	ל	ADP	ADP	_	20	case	_	_
 20	קבוצות	קבוצה	NOUN	NOUN	Gender=Fem|Number=Plur	18	obl	_	_
@@ -8259,14 +8259,14 @@
 15	סעד	סעד	NOUN	NOUN	Gender=Masc|Number=Sing	11	nmod	_	_
 16-17	שפרסמה	_	_	_	_	_	_	_	_
 16	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
-17	פרסמה	פרסם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	acl:relcl	_	_
+17	פרסמה	פרסם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=פ.ר.ס.מ|Tense=Past|Voice=Act	11	acl:relcl	_	_
 18	קרן	קרן	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	17	nsubj	_	_
 19	פורד	פורד	PROPN	PROPN	_	18	flat:name	_	_
 20-21	ב9891	_	_	_	_	_	_	_	SpaceAfter=No
 20	ב	ב	ADP	ADP	_	21	case	_	_
 21	9891	9891	NUM	NUM	_	17	obl	_	_
 22	,	,	PUNCT	PUNCT	_	23	punct	_	_
-23	סיפק	סיפק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+23	סיפק	סיפק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ס.פ.ק|Tense=Past|Voice=Act	0	root	_	_
 24	תמיכה	תמיכה	NOUN	NOUN	Gender=Fem|Number=Sing	23	obj	_	_
 25	מנומקת	מנומק	ADJ	ADJ	Gender=Fem|Number=Sing	24	amod	_	_
 26	(	(	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
@@ -8296,18 +8296,18 @@
 46-47	שאמנם	_	_	_	_	_	_	_	_
 46	ש	ש	SCONJ	SCONJ	_	48	mark	_	_
 47	אמנם	אמנם	ADV	ADV	_	48	advmod	_	_
-48	הבטיחה	הבטיח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	37	acl:relcl	_	_
+48	הבטיחה	הבטיח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ב.ט.ח|Tense=Past|Voice=Act	37	acl:relcl	_	_
 49	מקומות	מקום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	48	obj	_	_
 50	עבודה	עבודה	NOUN	NOUN	Gender=Fem|Number=Sing	49	compound:smixut	_	SpaceAfter=No
 51	,	,	PUNCT	PUNCT	_	48	punct	_	_
 52	אבל	אבל	CCONJ	CCONJ	_	54	cc	_	_
 53	גם	גם	ADV	ADV	_	54	advmod	_	_
-54	קבעה	קבע	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	48	conj	_	_
+54	קבעה	קבע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ב.ע|Tense=Past	48	conj	_	_
 55-56	שכל	_	_	_	_	_	_	_	_
 55	ש	ש	SCONJ	SCONJ	_	58	mark	_	_
 56	כל	כול	DET	DET	Definite=Cons	57	det	_	_
 57	אדם	אדם	NOUN	NOUN	Gender=Masc|Number=Sing	58	nsubj	_	_
-58	ייזרק	נזרק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	54	ccomp	_	_
+58	ייזרק	נזרק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ז.ר.ק|Tense=Fut|Voice=Mid	54	ccomp	_	_
 59-60	מרשימות	_	_	_	_	_	_	_	_
 59	מ	מ	ADP	ADP	_	60	case	_	_
 60	רשימות	רשימה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	58	obl	_	_
@@ -8321,14 +8321,14 @@
 
 # sent_id = 241
 # text = נוסף על כל זה, אין זה משנה עד כמה גדול מספרן של הקרנות במרכז ומעט שמאלה ממנו.
-1	נוסף	נוסף	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	4	case	_	_
+1	נוסף	נוסף	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=י.ס.פ|VerbForm=Part	4	case	_	_
 2	על	על	ADP	ADP	_	1	fixed	_	_
 3	כל	כול	DET	DET	Definite=Cons	4	det	_	_
 4	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	8	obl	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	8	punct	_	_
 6	אין	_	ADV	ADV	Polarity=Neg	8	advmod	_	_
 7	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	8	nsubj	_	_
-8	משנה	שינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+8	משנה	שינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ש.נ.י|VerbForm=Part|Voice=Act	0	root	_	_
 9	עד	עד	ADP	ADP	_	11	advmod	_	_
 10	כמה	כמה	DET	DET	Definite=Cons	9	fixed	_	_
 11	גדול	גדול	ADJ	ADJ	Gender=Masc|Number=Sing	8	xcomp	_	_
@@ -8356,7 +8356,7 @@
 # sent_id = 242
 # text = כאשר מגיעים הדברים למדיניות ציבורית, כסף שמרן מקבל יותר תמורת הדולר שלו.
 1	כאשר	כאשר	SCONJ	SCONJ	_	2	mark	_	_
-2	מגיעים	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	11	advcl	_	_
+2	מגיעים	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=נ.ג.ע|VerbForm=Part|Voice=Act	11	advcl	_	_
 3-4	הדברים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	דברים	דבר	NOUN	NOUN	Gender=Masc|Number=Plur	2	nsubj	_	_
@@ -8367,7 +8367,7 @@
 8	,	,	PUNCT	PUNCT	_	11	punct	_	_
 9	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	11	nsubj	_	_
 10	שמרן	שמרן	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	_
-11	מקבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+11	מקבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ק.ב.ל|VerbForm=Part|Voice=Act	0	root	_	_
 12	יותר	יותר	ADV	ADV	_	11	advmod	_	_
 13	תמורת	תמורת	ADP	ADP	_	15	case	_	_
 14-15	הדולר	_	_	_	_	_	_	_	_
@@ -8381,7 +8381,7 @@
 # sent_id = 243
 # text = די לתת מבט בצוותות החשיבה, הצינורות העיקריים בין הקרנות לבין הדיון הציבורי.
 1	די	די	ADV	ADV	_	0	root	_	_
-2	לתת	נתן	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	1	xcomp	_	_
+2	לתת	נתן	VERB	VERB	HebBinyan=PAAL|Root=נ.ת.נ|VerbForm=Inf|Voice=Act	1	xcomp	_	_
 3	מבט	מבט	NOUN	NOUN	Gender=Masc|Number=Sing	2	obj	_	_
 4-5	בצוותות	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
@@ -8413,13 +8413,13 @@
 # text = קרנות שמרניות נמנעו בתבונה מלהגביל את התמיכה הפיננסית שלהן לצוותות חשיבה שמרניים.
 1	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	3	nsubj	_	_
 2	שמרניות	שמרני	ADJ	ADJ	Gender=Fem|Number=Plur	1	amod	_	_
-3	נמנעו	נמנע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+3	נמנעו	נמנע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=מ.נ.ע|Tense=Past|Voice=Mid	0	root	_	_
 4-5	בתבונה	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	3	advmod	_	_
 5	תבונה	תבונה	NOUN	NOUN	Gender=Fem|Number=Sing	4	fixed	_	_
 6-7	מלהגביל	_	_	_	_	_	_	_	_
 6	מ	מ	ADP	ADP	_	7	case	_	_
-7	להגביל	הגביל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	3	advcl	_	_
+7	להגביל	הגביל	VERB	VERB	HebBinyan=HIFIL|Root=ג.ב.ל|VerbForm=Inf|Voice=Act	3	advcl	_	_
 8	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 9-10	התמיכה	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -8447,7 +8447,7 @@
 4	ו	_	CCONJ	CCONJ	_	6	cc	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	רוקפלרים	_	NOUN	NOUN	_	3	conj	_	_
-7	הפכו	הפך	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	9	aux	_	_
+7	הפכו	הפך	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ה.פ.כ|Tense=Past	9	aux	_	_
 8-9	למקורות	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	מקורות	מקור	NOUN	NOUN	Gender=Masc|Number=Plur	17	advcl	_	_
@@ -8459,7 +8459,7 @@
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	מחקר	מחקר	NOUN	NOUN	Gender=Masc|Number=Sing	13	nmod	_	_
 16	,	,	PUNCT	PUNCT	_	17	punct	_	_
-17	נשאו	נשא	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	0	root	_	_
+17	נשאו	נשא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=נ.ש.א|Tense=Past	0	root	_	_
 18	תמיד	תמיד	ADV	ADV	_	17	advmod	_	_
 19	מוסדות	מוסד	NOUN	NOUN	Gender=Masc|Number=Plur	17	nsubj	_	_
 20	כמו	כמו	ADP	ADP	_	21	case	_	_
@@ -8474,7 +8474,7 @@
 27	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	17	obl	_	_
 28	שמרניות	שמרני	ADJ	ADJ	Gender=Fem|Number=Plur	27	amod	_	_
 29	כדי	כדי	ADP	ADP	_	30	case	_	_
-30	למלא	מילא	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	17	advcl	_	_
+30	למלא	מילא	VERB	VERB	HebBinyan=PIEL|Root=מ.ל.א|VerbForm=Inf|Voice=Act	17	advcl	_	_
 31	את	את	ADP	ADP	Case=Acc	33	case:acc	_	_
 32-33	החסר	_	_	_	_	_	_	_	SpaceAfter=No
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
@@ -8510,15 +8510,15 @@
 6	נושאים	נושא	NOUN	NOUN	Gender=Masc|Number=Plur	12	nsubj	_	_
 7-8	הזוכים	_	_	_	_	_	_	_	_
 7	ה	ה	SCONJ	SCONJ	_	8	mark	_	_
-8	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
+8	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ז.כ.י|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
 9-10	לסבסוד	_	_	_	_	_	_	_	_
 9	ל	ל	ADP	ADP	_	10	case	_	_
 10	סבסוד	סבסוד	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	_
 11	נכבד	נכבד	ADJ	ADJ	Gender=Masc|Number=Sing	10	amod	_	_
-12	באים	בא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+12	באים	בא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ב.ו.א|VerbForm=Part|Voice=Act	0	root	_	_
 13-14	והולכים	_	_	_	_	_	_	_	SpaceAfter=No
 13	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
-14	הולכים	הלך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	12	conj	_	_
+14	הולכים	הלך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ה.ל.כ|VerbForm=Part|Voice=Act	12	conj	_	_
 15	.	.	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 249
@@ -8530,9 +8530,9 @@
 4-5	ה07	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	07	07	NUM	NUM	_	3	compound:smixut	_	_
-6	הרבו	הרבה	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	הרבו	הרבה	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ר.ב.י|Tense=Past|Voice=Act	0	root	_	_
 7	למשל	למשל	ADV	ADV	_	6	advmod	_	_
-8	לדבר	דיבר	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
+8	לדבר	דיבר	VERB	VERB	HebBinyan=PIEL|Root=ד.ב.ר|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 9-10	בתחום	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	תחום	תחום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	8	obl	_	_
@@ -8567,7 +8567,7 @@
 33	ו	ו	CCONJ	CCONJ	_	36	cc	_	_
 34	הרבה	הרבה	DET	DET	Definite=Cons	35	det	_	_
 35	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	36	dep	_	_
-36	הוקדש	הוקדש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	6	conj	_	_
+36	הוקדש	הוקדש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ק.ד.ש|Tense=Past|Voice=Pass	6	conj	_	_
 37-38	להגות	_	_	_	_	_	_	_	_
 37	ל	ל	ADP	ADP	_	38	case	_	_
 38	הגות	הגות	NOUN	NOUN	Gender=Fem|Number=Sing	36	obl	_	_
@@ -8584,7 +8584,7 @@
 # sent_id = 250
 # text = אז באו הפלישה לאפגניסטן ורונלד רייגן ונאום אימפריית הרשע.
 1	אז	אז	ADV	ADV	_	2	advmod	_	_
-2	באו	בא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	באו	בא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ב.ו.א|Tense=Past|Voice=Act	0	root	_	_
 3-4	הפלישה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	פלישה	פלישה	NOUN	NOUN	Gender=Fem|Number=Sing	2	nsubj	_	_
@@ -8649,7 +8649,7 @@
 9	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	0	root	_	_
 10-11	שפרסמו	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	פרסמו	פרסם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	9	acl:relcl	_	_
+11	פרסמו	פרסם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=פ.ר.ס.מ|Tense=Past|Voice=Act	9	acl:relcl	_	_
 12	מחקרים	מחקר	NOUN	NOUN	Gender=Masc|Number=Plur	11	obj	_	_
 13-14	לאין	_	_	_	_	_	_	_	SpaceAfter=No
 13	ל	ל	ADP	ADP	_	14	case	_	_
@@ -8661,7 +8661,7 @@
 18	ה_	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	שאלה	שאלה	NOUN	NOUN	Gender=Fem|Number=Sing	12	nmod	_	_
 20	כיצד	כיצד	ADV	ADV	PronType=Int	21	advmod	_	_
-21	לשמור	שמר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	19	acl	_	_
+21	לשמור	שמר	VERB	VERB	HebBinyan=PAAL|Root=ש.מ.ר|VerbForm=Inf|Voice=Act	19	acl	_	_
 22	על	על	ADP	ADP	_	24	case	_	_
 23-24	השלום	_	_	_	_	_	_	_	SpaceAfter=No
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
@@ -8679,11 +8679,11 @@
 6-7	הקרה	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	קרה	קר	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
-8	חלפה	חלף	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	parataxis	_	SpaceAfter=No
+8	חלפה	חלף	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ל.פ|Tense=Past|Voice=Act	10	parataxis	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	8	punct	_	_
-10	מנסים	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+10	מנסים	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=נ.ס.י|VerbForm=Part|Voice=Act	0	root	_	_
 11	כולם	_	NOUN	NOUN	Gender=Masc|Number=Plur	10	nsubj	_	_
-12	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	10	xcomp	_	_
+12	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|Root=מ.צ.א|VerbForm=Inf|Voice=Act	10	xcomp	_	_
 13	משפטים	משפט	NOUN	NOUN	Gender=Masc|Number=Plur	12	obj	_	_
 14-15	ומטבעות	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
@@ -8692,7 +8692,7 @@
 17	חדשים	חדש	ADJ	ADJ	Gender=Masc|Number=Plur	13	amod	_	_
 18-19	שילכדו	_	_	_	_	_	_	_	_
 18	ש	ש	SCONJ	SCONJ	_	19	mark	_	_
-19	ילכדו	לכד	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut	13	acl:relcl	_	_
+19	ילכדו	לכד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ל.כ.ד|Tense=Fut	13	acl:relcl	_	_
 20	את	את	ADP	ADP	Case=Acc	21	case:acc	_	_
 21	תשומת	תשומה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	19	obj	_	_
 22-24	לבם	_	_	_	_	_	_	_	_
@@ -8713,10 +8713,10 @@
 
 # sent_id = 255
 # text = גייס והפקע לרשותך טרמינולוגיה קיימת.
-1	גייס	גייס	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Mood=Imp|Number=Sing|Person=2|Voice=Act	0	root	_	_
+1	גייס	גייס	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Mood=Imp|Number=Sing|Person=2|Root=ג.י.ס|Voice=Act	0	root	_	_
 2-3	והפקע	_	_	_	_	_	_	_	_
 2	ו	ו	CCONJ	CCONJ	_	3	cc	_	_
-3	הפקע	הפקיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Mood=Imp|Number=Sing|Person=2|Voice=Act	1	conj	_	_
+3	הפקע	הפקיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Mood=Imp|Number=Sing|Person=2|Root=פ.ק.ע|Voice=Act	1	conj	_	_
 4-5	לרשותך	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	5	case	_	_
 5	רשותך	רשות	NOUN	NOUN	_	3	obl	_	_
@@ -8726,7 +8726,7 @@
 
 # sent_id = 256
 # text = נראה שיעד המשחק הוא לחטוף "ביטחון לאומי", נושא רב-שנתי עמיד, ולנווט אותו לתחום המומחיות שלך.
-1	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+1	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ר.א.י|VerbForm=Part|Voice=Mid	0	root	_	_
 2-3	שיעד	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
 3	יעד	יעד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	nsubj:cop	_	_
@@ -8734,7 +8734,7 @@
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	משחק	משחק	NOUN	NOUN	Gender=Masc|Number=Sing	3	compound:smixut	_	_
 6	הוא	הוא	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	7	cop	_	_
-7	לחטוף	חטף	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	1	ccomp	_	_
+7	לחטוף	חטף	VERB	VERB	HebBinyan=PAAL|Root=ח.ט.פ|VerbForm=Inf|Voice=Act	1	ccomp	_	_
 8	"	"	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 9	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	7	obj	_	_
 10	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	SpaceAfter=No
@@ -8748,7 +8748,7 @@
 18	,	,	PUNCT	PUNCT	_	7	punct	_	_
 19-20	ולנווט	_	_	_	_	_	_	_	_
 19	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
-20	לנווט	ניווט	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	7	conj	_	_
+20	לנווט	ניווט	VERB	VERB	HebBinyan=PIEL|Root=נ.ו.ט|VerbForm=Inf|Voice=Act	7	conj	_	_
 21-22	אותו	_	_	_	_	_	_	_	_
 21	את_	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 22	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	obj	_	_
@@ -8777,7 +8777,7 @@
 7	כלל	כלל	ADV	ADV	Prefix=Yes	9	compound:affix	_	_
 8	-	-	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 9	עולמית	עולמי	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
-10	מדגישים	הדגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+10	מדגישים	הדגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ד.ג.ש|VerbForm=Part|Voice=Act	0	root	_	_
 11-12	שכעת	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
 12	כעת	כעת	ADV	ADV	_	15	advmod	_	_
@@ -8785,7 +8785,7 @@
 14	-	-	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
 15	אפשר	אפשר	AUX	AUX	VerbType=Mod	17	aux	_	_
 16	כמעט	כמעט	ADV	ADV	_	15	advmod	_	_
-17	להבדיל	הבדיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	10	ccomp	_	_
+17	להבדיל	הבדיל	VERB	VERB	HebBinyan=HIFIL|Root=ב.ד.ל|VerbForm=Inf|Voice=Act	10	ccomp	_	_
 18	בין	בין	ADP	ADP	_	19	case	_	_
 19	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	17	obl	_	_
 20	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	_
@@ -8804,7 +8804,7 @@
 1-2	הטיפוסים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	טיפוסים	טיפוס	NOUN	NOUN	Gender=Masc|Number=Plur	16	nsubj	_	_
-3	לובשי	לבש	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	amod	_	_
+3	לובשי	לבש	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ל.ב.ש|VerbForm=Part|Voice=Act	2	amod	_	_
 4-5	החליפות	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	חליפות	חליפה	NOUN	NOUN	Gender=Fem|Number=Plur	3	compound:smixut	_	_
@@ -8821,7 +8821,7 @@
 13	מרכזי	מרכזי	ADJ	ADJ	Gender=Masc|Number=Sing	12	amod	_	_
 14	יותר	יותר	ADV	ADV	_	13	advmod	_	SpaceAfter=No
 15	,	,	PUNCT	PUNCT	_	16	punct	_	_
-16	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+16	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 17-18	ששום	_	_	_	_	_	_	_	_
 17	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
 18	שום	שום	DET	DET	Definite=Cons	19	det	_	_
@@ -8832,7 +8832,7 @@
 23	בטוחה	בטוח	ADJ	ADJ	Gender=Fem|Number=Sing	22	obl	_	_
 24	אם	אם	SCONJ	SCONJ	_	26	mark	_	_
 25	לא	לא	ADV	ADV	Polarity=Neg	26	advmod	_	_
-26	יהיה	היה	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	21	advcl	_	_
+26	יהיה	היה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	21	advcl	_	_
 27	"	"	PUNCT	PUNCT	_	28	punct	_	SpaceAfter=No
 28	מבנה	מבנה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	26	nsubj	_	_
 29	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	28	compound:smixut	_	_
@@ -8870,11 +8870,11 @@
 18	ל	ל	ADP	ADP	_	19	case	_	_
 19	מצוינות	מצוינות	NOUN	NOUN	Gender=Fem|Number=Sing	17	nmod	_	_
 20	,	,	PUNCT	PUNCT	_	21	punct	_	_
-21	ניסו	ניסה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+21	ניסו	ניסה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=נ.ס.י|Tense=Past|Voice=Act	0	root	_	_
 22-23	בעורמה	_	_	_	_	_	_	_	_
 22	ב	ב	ADP	ADP	_	21	advmod	_	_
 23	עורמה	עורמה	NOUN	NOUN	Gender=Fem|Number=Sing	22	fixed	_	_
-24	לשים	שם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	21	xcomp	_	_
+24	לשים	שם	VERB	VERB	HebBinyan=PAAL|Root=ש.י.מ|VerbForm=Inf|Voice=Act	21	xcomp	_	_
 25-27	ידם	_	_	_	_	_	_	_	_
 25	יד_	יד	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	24	obj	_	_
 26	_של_	של	ADP	ADP	_	27	case:gen	_	_
@@ -8894,7 +8894,7 @@
 37	ב	ב	ADP	ADP	_	39	case	_	_
 38	ה_	ה	DET	DET	PronType=Art	39	det:def	_	_
 39	עתיד	עתיד	NOUN	NOUN	Gender=Masc|Number=Sing	40	obl	_	_
-40	יוגדר	הוגדר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	35	acl:relcl	_	_
+40	יוגדר	הוגדר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ג.ד.ר|Tense=Fut|Voice=Pass	35	acl:relcl	_	_
 41-42	הביטחון	_	_	_	_	_	_	_	_
 41	ה	ה	DET	DET	PronType=Art	42	det:def	_	_
 42	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	40	nsubj	_	_
@@ -8954,13 +8954,13 @@
 20	,	,	PUNCT	PUNCT	_	11	punct	_	_
 21-22	הטוענים	_	_	_	_	_	_	_	_
 21	ה	ה	SCONJ	SCONJ	_	22	mark	_	_
-22	טוענים	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	11	acl:relcl	_	_
+22	טוענים	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ט.ע.נ|VerbForm=Part|Voice=Act	11	acl:relcl	_	_
 23	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	24	det	_	_
 24	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	22	dep	_	_
 25-26	שיש	_	_	_	_	_	_	_	_
 25	ש	ש	SCONJ	SCONJ	_	26	mark	_	_
 26	יש	יש	AUX	AUX	VerbType=Mod	27	aux	_	_
-27	להפסיק	הפסיק	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	22	ccomp	_	_
+27	להפסיק	הפסיק	VERB	VERB	HebBinyan=HIFIL|Root=פ.ס.ק|VerbForm=Inf|Voice=Act	22	ccomp	_	_
 28	את	את	ADP	ADP	Case=Acc	29	case:acc	_	_
 29-31	הזרמתו	_	_	_	_	_	_	_	_
 29	הזרמה_	הזרמה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	27	obj	_	_
@@ -8984,15 +8984,15 @@
 
 # sent_id = 262
 # text = מדובר בקומץ אנשים שניסו למשוך אליהם כספי מענקים בעת שהעולם המטיר דולרים עלאסטרטגיה גרעינית ופיקוח רב-צדדי על הנשק.
-1	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+1	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ד.ב.ר|VerbForm=Part|Voice=Pass	0	root	_	_
 2-3	בקומץ	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
 3	קומץ	קומץ	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	obl	_	_
 4	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	3	compound:smixut	_	_
 5-6	שניסו	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	ניסו	ניסה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	3	acl:relcl	_	_
-7	למשוך	משך	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
+6	ניסו	ניסה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=נ.ס.י|Tense=Past|Voice=Act	3	acl:relcl	_	_
+7	למשוך	משך	VERB	VERB	HebBinyan=PAAL|Root=מ.ש.כ|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 8-9	אליהם	_	_	_	_	_	_	_	_
 8	אל_	אל	ADP	ADP	_	9	case	_	_
 9	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	7	obl	_	_
@@ -9005,7 +9005,7 @@
 14	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	עולם	עולם	NOUN	NOUN	Gender=Masc|Number=Sing	17	nsubj	_	_
-17	המטיר	המטיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	13	acl:relcl	_	_
+17	המטיר	המטיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=מ.ט.ר|Tense=Past|Voice=Act	13	acl:relcl	_	_
 18	דולרים	דולר	NOUN	NOUN	Gender=Masc|Number=Plur	17	obj	_	_
 19-20	עלאסטרטגיה	_	_	_	_	_	_	_	_
 19	על	על	ADP	ADP	_	20	case	_	_
@@ -9027,7 +9027,7 @@
 # text = עובדה זו שימשה יסוד לתלונה שכיחה בתחום הפילנטרופיה: התמקדותם של קרנות וצוותות חשיבה במגמות אופנתיות גורמת לכך שהחברה בקושי ערוכה לגלים היסטוריים חדשים.
 1	עובדה	עובדה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
 2	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	1	det	_	_
-3	שימשה	שימש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	שימשה	שימש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.מ.ש|Tense=Past|Voice=Act	0	root	_	_
 4	יסוד	יסוד	NOUN	NOUN	Gender=Masc|Number=Sing	3	obj	_	_
 5-6	לתלונה	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
@@ -9054,7 +9054,7 @@
 21	ב	ב	ADP	ADP	_	22	case	_	_
 22	מגמות	מגמה	NOUN	NOUN	Gender=Fem|Number=Plur	13	nmod	_	_
 23	אופנתיות	אופנתי	ADJ	ADJ	Gender=Fem|Number=Plur	22	amod	_	_
-24	גורמת	גרם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	6	appos	_	_
+24	גורמת	גרם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ג.ר.מ|VerbForm=Part|Voice=Act	6	appos	_	_
 25-26	לכך	_	_	_	_	_	_	_	_
 25	ל	ל	ADP	ADP	_	26	case	_	_
 26	כך	כך	PRON	PRON	Person=3|PronType=Dem	24	obl	_	_
@@ -9103,7 +9103,7 @@
 24	חדשה	חדש	ADJ	ADJ	Gender=Fem|Number=Sing	22	amod	_	SpaceAfter=No
 25	"	"	PUNCT	PUNCT	_	10	punct	_	SpaceAfter=No
 26	,	,	PUNCT	PUNCT	_	27	punct	_	_
-27	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+27	אומר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 28	כי	כי	SCONJ	SCONJ	_	52	mark	_	_
 29-30	ההתמקדות	_	_	_	_	_	_	_	_
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
@@ -9112,7 +9112,7 @@
 31	ב	ב	ADP	ADP	_	32	case	_	_
 32	בעיות	בעיה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	30	nmod	_	_
 33	מדיניות	מדיניות	NOUN	NOUN	Gender=Fem|Number=Sing	32	compound:smixut	_	_
-34	דוחקות	דחק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	32	amod	_	SpaceAfter=No
+34	דוחקות	דחק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ד.ח.ק|VerbForm=Part|Voice=Act	32	amod	_	SpaceAfter=No
 35	,	,	PUNCT	PUNCT	_	30	punct	_	_
 36-37	ודעיכת	_	_	_	_	_	_	_	_
 36	ו	ו	CCONJ	CCONJ	_	37	cc	_	_
@@ -9135,7 +9135,7 @@
 49	ה	ה	DET	DET	PronType=Art	50	det:def	_	_
 50	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	48	compound:smixut	_	_
 51	,	,	PUNCT	PUNCT	_	52	punct	_	_
-52	הותירו	הותיר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	27	ccomp	_	_
+52	הותירו	הותיר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=י.ת.ר|Tense=Past|Voice=Act	27	ccomp	_	_
 53-54	אותנו	_	_	_	_	_	_	_	_
 53	את_	את	ADP	ADP	Case=Acc	54	case:acc	_	_
 54	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	52	obj	_	_
@@ -9150,9 +9150,9 @@
 62	מן_	מן	ADP	ADP	_	63	case	_	_
 63	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	64	obl	_	_
 64	ניתן	ניתן	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	65	aux	_	_
-65	לשאוב	שאב	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	56	acl:relcl	_	_
+65	לשאוב	שאב	VERB	VERB	HebBinyan=PAAL|Root=ש.א.ב|VerbForm=Inf|Voice=Act	56	acl:relcl	_	_
 66	כאשר	כאשר	SCONJ	SCONJ	_	67	mark	_	_
-67	יתעורר	התעורר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	64	advcl	_	_
+67	יתעורר	התעורר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ע.ו.ר|Tense=Fut	64	advcl	_	_
 68-69	הצורך	_	_	_	_	_	_	_	SpaceAfter=No
 68	ה	ה	DET	DET	PronType=Art	69	det:def	_	_
 69	צורך	צורך	NOUN	NOUN	Gender=Masc|Number=Sing	67	nsubj	_	_
@@ -9175,7 +9175,7 @@
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	חסות	חסות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	5	nmod	_	_
 8	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	7	compound:smixut	_	_
-9	הוקדשו	הוקדש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+9	הוקדשו	הוקדש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=ק.ד.ש|Tense=Past|Voice=Pass	0	root	_	_
 10-11	בתקופת	_	_	_	_	_	_	_	_
 10	ב	ב	ADP	ADP	_	11	case	_	_
 11	תקופת	תקופה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	9	obl	_	_
@@ -9195,7 +9195,7 @@
 21-22	לניסיון	_	_	_	_	_	_	_	_
 21	ל	ל	ADP	ADP	_	22	case	_	_
 22	ניסיון	ניסיון	NOUN	NOUN	Gender=Masc|Number=Sing	9	obl	_	_
-23	לגלות	גילה	VERB	VERB	VerbForm=Inf	22	acl	_	_
+23	לגלות	גילה	VERB	VERB	HebBinyan=PIEL|Root=ג.ל.י|VerbForm=Inf	22	acl	_	_
 24-25	באיזו	_	_	_	_	_	_	_	_
 24	ב	ב	ADP	ADP	_	26	case	_	_
 25	איזו	איזה	ADV	ADV	PronType=Int	26	det	_	_
@@ -9213,9 +9213,9 @@
 # text = כמה מחקרים שאלו כיצד להפוך כלכלה סטליניסטית לכלכלת שוק חופשי?
 1	כמה	כמה	DET	DET	Definite=Cons	2	det	_	_
 2	מחקרים	מחקר	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
-3	שאלו	שאל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	שאלו	שאל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ש.א.ל|Tense=Past|Voice=Act	0	root	_	_
 4	כיצד	כיצד	ADV	ADV	PronType=Int	3	advcl	_	_
-5	להפוך	הפך	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	4	xcomp	_	_
+5	להפוך	הפך	VERB	VERB	HebBinyan=PAAL|Root=ה.פ.כ|VerbForm=Inf|Voice=Act	4	xcomp	_	_
 6	כלכלה	כלכלה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obj	_	_
 7	סטליניסטית	סטליניסטית	ADJ	ADJ	_	6	amod	_	_
 8-9	לכלכלת	_	_	_	_	_	_	_	_
@@ -9244,7 +9244,7 @@
 12	בעיות	בעיה	NOUN	NOUN	Gender=Fem|Number=Plur	5	acl:relcl	_	_
 13-14	הדוחקות	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
-14	דוחקות	דחק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	12	amod	_	_
+14	דוחקות	דחק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ד.ח.ק|VerbForm=Part|Voice=Act	12	amod	_	_
 15	ביותר	ביותר	ADV	ADV	_	14	advmod	_	_
 16	של	של	ADP	ADP	Case=Gen	18	case:gen	_	_
 17-18	העולם	_	_	_	_	_	_	_	SpaceAfter=No
@@ -9256,7 +9256,7 @@
 # text = אך אפשר לומר בביטחון, שאף לא דולר אחד מבין למעלה מ05 מיליארד הדולרים שהוציאו קרנות בין 9791 ל9891 לא הוקדש להבהרתן.
 1	אך	אך	CCONJ	CCONJ	_	2	cc	_	_
 2	אפשר	אפשר	AUX	AUX	VerbType=Mod	3	aux	_	_
-3	לומר	אמר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+3	לומר	אמר	VERB	VERB	HebBinyan=PAAL|Root=א.מ.ר|VerbForm=Inf|Voice=Act	0	root	_	_
 4-5	בביטחון	_	_	_	_	_	_	_	SpaceAfter=No
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	ביטחון	ביטחון	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
@@ -9278,7 +9278,7 @@
 18	דולרים	דולר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Plur	10	dep	_	_
 19-20	שהוציאו	_	_	_	_	_	_	_	_
 19	ש	ש	SCONJ	SCONJ	_	20	mark	_	_
-20	הוציאו	הוציא	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	18	acl:relcl	_	_
+20	הוציאו	הוציא	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=י.צ.א|Tense=Past|Voice=Act	18	acl:relcl	_	_
 21	קרנות	קרן	NOUN	NOUN	Gender=Fem|Number=Plur	20	nsubj	_	_
 22	בין	בין	ADP	ADP	_	23	case	_	_
 23	9791	9791	NUM	NUM	_	20	obl	_	_
@@ -9286,7 +9286,7 @@
 24	ל	ל	ADP	ADP	_	25	case	_	_
 25	9891	9891	NUM	NUM	_	23	conj	_	_
 26	לא	לא	ADV	ADV	Polarity=Neg	27	advmod	_	_
-27	הוקדש	הוקדש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	3	ccomp	_	_
+27	הוקדש	הוקדש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ק.ד.ש|Tense=Past|Voice=Pass	3	ccomp	_	_
 28-31	להבהרתן	_	_	_	_	_	_	_	SpaceAfter=No
 28	ל	ל	ADP	ADP	_	29	case	_	_
 29	הבהרה_	הבהרה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	27	obl	_	_
@@ -9300,14 +9300,14 @@
 2-3	הכסף	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
-4	דוחף	דחף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+4	דוחף	דחף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ד.ח.פ|VerbForm=Part|Voice=Act	0	root	_	_
 5	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 6-7	הרעיונות	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	רעיונות	רעיון	NOUN	NOUN	Gender=Masc|Number=Plur	4	obj	_	_
 8	או	או	CCONJ	CCONJ	_	10	cc	_	_
 9	שמא	שמא	SCONJ	SCONJ	_	10	mark:q	_	_
-10	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	4	conj	_	_
+10	זוכים	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ז.כ.י|VerbForm=Part|Voice=Act	4	conj	_	_
 11-12	הרעיונות	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	רעיונות	רעיון	NOUN	NOUN	Gender=Masc|Number=Plur	10	nsubj	_	_
@@ -9333,14 +9333,14 @@
 # sent_id = 271
 # text = כדי לענות על שאלות אלו עליך להשתקע קודם לכל באי-אלו הרהורים קוסמיים על טבעה של ההיסטוריה, ולהקדיש מחשבה לדיאלקטיקה הגליאנית, לתיאוריות על מקומו של האדם הגדול בהיסטוריה וכך הלאה.
 1	כדי	כדי	ADP	ADP	_	2	case	_	_
-2	לענות	ענה	VERB	VERB	VerbForm=Inf	7	advcl	_	_
+2	לענות	ענה	VERB	VERB	HebBinyan=PAAL|Root=ע.נ.י|VerbForm=Inf	7	advcl	_	_
 3	על	על	ADP	ADP	_	4	case	_	_
 4	שאלות	שאלה	NOUN	NOUN	Gender=Fem|Number=Plur	2	obl	_	_
 5	אלו	אלו	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=3|PronType=Dem	4	det	_	_
 6-7	עליך	_	_	_	_	_	_	_	_
 6	על_	על	ADP	ADP	_	7	case	_	_
 7	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	0	root	_	_
-8	להשתקע	השתקע	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	7	xcomp	_	_
+8	להשתקע	השתקע	VERB	VERB	HebBinyan=HITPAEL|Root=ש.ק.ע|VerbForm=Inf	7	xcomp	_	_
 9	קודם	קודם	ADV	ADV	_	8	advmod	_	_
 10-11	לכל	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	9	fixed	_	_
@@ -9364,7 +9364,7 @@
 25	,	,	PUNCT	PUNCT	_	8	punct	_	_
 26-27	ולהקדיש	_	_	_	_	_	_	_	_
 26	ו	ו	CCONJ	CCONJ	_	27	cc	_	_
-27	להקדיש	הקדיש	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	8	conj	_	_
+27	להקדיש	הקדיש	VERB	VERB	HebBinyan=HIFIL|Root=ק.ד.ש|VerbForm=Inf|Voice=Act	8	conj	_	_
 28	מחשבה	מחשבה	NOUN	NOUN	Gender=Fem|Number=Sing	27	obj	_	_
 29-30	לדיאלקטיקה	_	_	_	_	_	_	_	_
 29	ל	ל	ADP	ADP	_	30	case	_	_
@@ -9410,7 +9410,7 @@
 8-9	שיש	_	_	_	_	_	_	_	_
 8	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
 9	יש	יש	AUX	AUX	VerbType=Mod	10	aux	_	_
-10	לגשת	לגשת	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	7	acl:relcl	_	_
+10	לגשת	לגשת	VERB	VERB	HebBinyan=NIFAL|Root=נ.ג.ש|VerbForm=Inf|Voice=Mid	7	acl:relcl	_	_
 11-12	אליו	_	_	_	_	_	_	_	_
 11	אל_	אל	ADP	ADP	_	12	case	_	_
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obl	_	_
@@ -9424,7 +9424,7 @@
 1-2	היכולת	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	יכולת	יכולת	NOUN	NOUN	Gender=Fem|Number=Sing	14	nsubj	_	_
-3	לחזות	חזה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	acl	_	_
+3	לחזות	חזה	VERB	VERB	HebBinyan=PAAL|Root=ח.ז.י|VerbForm=Inf|Voice=Act	2	acl	_	_
 4	תוצאות	תוצאה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	3	obl	_	_
 5	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	4	compound:smixut	_	_
 6-7	בארצות	_	_	_	_	_	_	_	_
@@ -9438,7 +9438,7 @@
 12	דעת	דעה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	11	compound:smixut	_	_
 13	קהל	קהל	NOUN	NOUN	Gender=Masc|Number=Sing	12	compound:smixut	_	_
 14	עשויה	עשוי	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbType=Mod	15	aux	_	_
-15	להצטמצם	הצטמצם	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	0	root	_	_
+15	להצטמצם	הצטמצם	VERB	VERB	HebBinyan=HITPAEL|Root=צ.מ.צ.מ|VerbForm=Inf	0	root	_	_
 16-18	בשנים	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	18	case	_	_
 17	ה_	ה	DET	DET	PronType=Art	18	det:def	_	_
@@ -9458,7 +9458,7 @@
 1	כישלונות	כישלון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	חיזוי	חיזוי	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3	כבר	כבר	ADV	ADV	_	4	advmod	_	_
-4	נראו	נראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+4	נראו	נראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ר.א.י|Tense=Past|Voice=Mid	0	root	_	_
 5-6	בכמה	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	8	case	_	_
 6	כמה	כמה	DET	DET	Definite=Cons	8	det	_	_
@@ -9501,7 +9501,7 @@
 19	)	)	PUNCT	PUNCT	_	18	punct	_	_
 20	אמריקאים	אמריקני	NOUN	NOUN	Gender=Masc|Number=Plur	22	nsubj	_	_
 21	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	22	advmod	_	_
-22	מתעניינים	התעניין	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	15	appos	_	_
+22	מתעניינים	התעניין	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ע.נ.י.נ|VerbForm=Part	15	appos	_	_
 23	ביותר	ביותר	ADV	ADV	_	22	advmod	_	_
 24-26	בתהליך	_	_	_	_	_	_	_	_
 24	ב	ב	ADP	ADP	_	26	case	_	_
@@ -9517,14 +9517,14 @@
 32	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	41	nsubj	_	_
 33-34	היודעים	_	_	_	_	_	_	_	_
 33	ה	ה	SCONJ	SCONJ	_	34	mark	_	_
-34	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	32	acl:relcl	_	_
+34	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	32	acl:relcl	_	_
 35	בעד	בעד	ADP	ADP	_	36	case	_	_
 36	מי	מי	ADV	ADV	PronType=Int	38	obl	_	_
 37	היו	היה	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	38	cop	_	_
-38	רוצים	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	34	advcl	_	_
-39	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	38	xcomp	_	_
+38	רוצים	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ר.צ.י|VerbForm=Part|Voice=Act	34	advcl	_	_
+39	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|Root=צ.ב.ע|VerbForm=Inf|Voice=Act	38	xcomp	_	_
 40	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	41	advmod	_	_
-41	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	22	conj	_	_
+41	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	22	conj	_	_
 42	עד	עד	ADP	ADP	_	44	case	_	_
 43-44	הרגע	_	_	_	_	_	_	_	_
 43	ה	ה	DET	DET	PronType=Art	44	det:def	_	_
@@ -9533,8 +9533,8 @@
 45	ה	ה	DET	DET	PronType=Art	46	det:def	_	_
 46	אחרון	אחרון	ADJ	ADJ	Gender=Masc|Number=Sing	44	amod	_	_
 47	אם	אם	SCONJ	SCONJ	_	48	mark	_	_
-48	יטרחו	טרח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Fut|Voice=Act	41	advcl	_	_
-49	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	48	xcomp	_	SpaceAfter=No
+48	יטרחו	טרח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ט.ר.ח|Tense=Fut|Voice=Act	41	advcl	_	_
+49	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|Root=צ.ב.ע|VerbForm=Inf|Voice=Act	48	xcomp	_	SpaceAfter=No
 50	.	.	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 276
@@ -9545,7 +9545,7 @@
 4-5	מהם	_	_	_	_	_	_	_	_
 4	מן_	מן	ADP	ADP	_	5	case	_	_
 5	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	3	nmod	_	_
-6	הצביעו	הצביע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	הצביעו	הצביע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=צ.ב.ע|Tense=Past|Voice=Act	0	root	_	_
 7-8	ביום	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	יום	יום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	obl	_	_
@@ -9595,7 +9595,7 @@
 1-2	בקליפורניה	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	קליפורניה	קליפורניה	PROPN	PROPN	_	3	obl	_	_
-3	הצביעו	הצביע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הצביעו	הצביע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=צ.ב.ע|Tense=Past|Voice=Act	0	root	_	_
 4	השנה	השנה	ADV	ADV	_	3	advmod	_	_
 5	לא	לא	ADV	ADV	Polarity=Neg	9	advmod	_	_
 6	פחות	פחות	ADV	ADV	_	9	advmod	_	_
@@ -9635,14 +9635,14 @@
 33	מפני	מפני	ADP	ADP	_	35	mark	_	_
 34-35	שהעדיפו	_	_	_	_	_	_	_	_
 34	ש	ש	SCONJ	SCONJ	_	33	fixed	_	_
-35	העדיפו	העדיף	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	22	conj	_	_
+35	העדיפו	העדיף	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ע.ד.פ|Tense=Past|Voice=Act	22	conj	_	_
 36	את	את	ADP	ADP	Case=Acc	38	case:acc	_	_
 37-38	הנוחות	_	_	_	_	_	_	_	_
 37	ה	ה	DET	DET	PronType=Art	38	det:def	_	_
 38	נוחות	נוחות	NOUN	NOUN	Gender=Fem|Number=Sing	35	obj	_	_
 39-40	הכרוכה	_	_	_	_	_	_	_	_
 39	ה	ה	SCONJ	SCONJ	_	40	mark	_	_
-40	כרוכה	כרך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	38	acl:relcl	_	_
+40	כרוכה	כרך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ר.כ|VerbForm=Part|Voice=Act	38	acl:relcl	_	_
 41-42	במילוי	_	_	_	_	_	_	_	_
 41	ב	ב	ADP	ADP	_	42	case	_	_
 42	מילוי	מילוי	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	40	obl	_	_
@@ -9709,14 +9709,14 @@
 6	ב	ב	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	דואר	דואר	NOUN	NOUN	Gender=Masc|Number=Sing	5	nmod	_	_
-9	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+9	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ל.ח|Tense=Past|Voice=Act	0	root	_	_
 10	לבסוף	לבסוף	ADV	ADV	_	9	advmod	_	_
 11-12	הסנאטור	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	סנאטור	סנטור	NOUN	NOUN	Gender=Masc|Number=Sing	9	nsubj	_	_
 13	פיט	פיט	PROPN	PROPN	_	12	flat:name	_	_
 14	ווילסון	ווילסון	PROPN	PROPN	_	12	flat:name	_	_
-15	לנצח	ניצח	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	9	xcomp	_	SpaceAfter=No
+15	לנצח	ניצח	VERB	VERB	HebBinyan=PIEL|Root=נ.צ.ח|VerbForm=Inf|Voice=Act	9	xcomp	_	SpaceAfter=No
 16	,	,	PUNCT	PUNCT	_	15	punct	_	_
 17-18	בהפרש	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
@@ -9741,22 +9741,22 @@
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	באות	בא	ADJ	ADJ	Gender=Fem|Number=Plur	9	amod	_	_
 12	תהיה	היה	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	0	root	_	_
-13	לברר	בירר	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	12	xcomp	_	_
+13	לברר	בירר	VERB	VERB	HebBinyan=PIEL|Root=ב.ר.ר|VerbForm=Inf|Voice=Act	12	xcomp	_	_
 14	תחילה	תחילה	ADV	ADV	_	13	advmod	_	_
 15	האם	האם	ADV	ADV	PronType=Int	18	mark:q	_	_
 16-17	הנשאל	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
-17	נשאל	נשאל	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	18	nsubj	_	_
-18	מתכוון	התכוון	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	13	dep	_	_
-19	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	18	xcomp	_	SpaceAfter=No
+17	נשאל	נשאל	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ש.א.ל|VerbForm=Part|Voice=Mid	18	nsubj	_	_
+18	מתכוון	התכוון	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=כ.ו.נ|VerbForm=Part	13	dep	_	_
+19	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|Root=צ.ב.ע|VerbForm=Inf|Voice=Act	18	xcomp	_	SpaceAfter=No
 20	,	,	PUNCT	PUNCT	_	18	punct	_	_
 21-22	ובאם	_	_	_	_	_	_	_	_
 21	ו	ו	CCONJ	CCONJ	_	25	cc	_	_
 22	באם	באם	CCONJ	CCONJ	_	25	mark:q	_	_
 23	אין	_	ADV	ADV	Polarity=Neg	25	advmod	_	_
 24	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	25	nsubj	_	_
-25	מתכוון	התכוון	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	18	conj	_	_
-26	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	25	xcomp	_	_
+25	מתכוון	התכוון	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=כ.ו.נ|VerbForm=Part	18	conj	_	_
+26	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|Root=צ.ב.ע|VerbForm=Inf|Voice=Act	25	xcomp	_	_
 27-28	הייתכן	_	_	_	_	_	_	_	_
 27	ה	ה	DET	DET	PronType=Art	28	mark:q	_	_
 28	ייתכן	ייתכן	AUX	AUX	HebSource=ConvUncertainHead|VerbType=Mod	25	dep	_	_
@@ -9765,7 +9765,7 @@
 30	ב	ב	ADP	ADP	_	33	advmod	_	_
 31	כל	כול	DET	DET	Definite=Cons	30	fixed	_	_
 32	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	30	fixed	_	_
-33	יצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	28	ccomp	_	_
+33	יצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ב.ע|Tense=Fut|Voice=Act	28	ccomp	_	_
 34	באמצעות	באמצעות	ADP	ADP	_	36	case	_	_
 35-36	הדואר	_	_	_	_	_	_	_	SpaceAfter=No
 35	ה	ה	DET	DET	PronType=Art	36	det:def	_	_
@@ -9785,13 +9785,13 @@
 8	בוסטון	בוסטון	PROPN	PROPN	_	7	flat:name	_	_
 9-10	שהתמודד	_	_	_	_	_	_	_	_
 9	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
-10	התמודד	התמודד	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	6	acl:relcl	_	_
+10	התמודד	התמודד	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=מ.ד.ד|Tense=Past	6	acl:relcl	_	_
 11	על	על	ADP	ADP	_	12	case	_	_
 12	כהונת	כהונה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	10	obl	_	_
 13	מושל	מושל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	compound:smixut	_	_
 14	מסצוסטס	מסצוסטס	PROPN	PROPN	_	13	compound:smixut	_	SpaceAfter=No
 15	,	,	PUNCT	PUNCT	_	16	punct	_	_
-16	היתה	היה	VERB	VERB	Gender=Fem|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+16	היתה	היה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 17	תיאוריה	תיאוריה	NOUN	NOUN	Gender=Fem|Number=Sing	16	nsubj	_	_
 18	שלמה	שלם	ADJ	ADJ	Gender=Fem|Number=Sing	17	amod	_	_
 19	על	על	ADP	ADP	_	23	case	_	_
@@ -9833,7 +9833,7 @@
 1-2	הסקרים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	סקרים	סקר	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
-3	חזו	חזה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	חזו	חזה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ח.ז.י|Tense=Past|Voice=Act	0	root	_	_
 4-5	לו	_	_	_	_	_	_	_	_
 4	ל_	ל	ADP	ADP	_	5	case	_	_
 5	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	obl	_	_
@@ -9863,7 +9863,7 @@
 # sent_id = 285
 # text = הוא הדהים את מפלגתו, את מדינתו ואת ארה"ב בניצחון.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	הדהים	הדהים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	הדהים	הדהים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ד.ה.מ|Tense=Past|Voice=Act	0	root	_	_
 3	את	את	ADP	ADP	Case=Acc	4	case:acc	_	_
 4-6	מפלגתו	_	_	_	_	_	_	_	SpaceAfter=No
 4	מפלגה_	מפלגה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	2	obj	_	_
@@ -9897,7 +9897,7 @@
 6-7	הכללית	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	כללית	כללי	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
-8	העלה	העלה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+8	העלה	העלה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ע.ל.י|Tense=Past|Voice=Act	0	root	_	_
 9	סילבר	סילבר	PROPN	PROPN	_	8	nsubj	_	_
 10	את	את	ADP	ADP	Case=Acc	12	case:acc	_	_
 11-12	ההסבר	_	_	_	_	_	_	_	_
@@ -9921,7 +9921,7 @@
 2	אמריקאים	אמריקני	NOUN	NOUN	Gender=Masc|Number=Plur	8	nsubj	_	SpaceAfter=No
 3	"	"	PUNCT	PUNCT	_	8	punct	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	5	punct	_	_
-5	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	8	parataxis	_	SpaceAfter=No
+5	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	8	parataxis	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	5	punct	_	_
 7	"	"	PUNCT	PUNCT	_	8	punct	_	SpaceAfter=No
 8	מתרעמים	התרעם	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	0	root	_	_
@@ -9931,7 +9931,7 @@
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	שאלה	שאלה	NOUN	NOUN	Gender=Fem|Number=Sing	10	compound:smixut	_	_
 13	איך	איך	ADV	ADV	PronType=Int	14	advmod	_	_
-14	תצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Sing|Person=2|Tense=Fut|Voice=Act	12	dep	_	SpaceAfter=No
+14	תצביע	הצביע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Sing|Person=2|Root=צ.ב.ע|Tense=Fut|Voice=Act	12	dep	_	SpaceAfter=No
 15	.	.	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 288
@@ -9959,7 +9959,7 @@
 # sent_id = 289
 # text = כאשר מטלפן אליהם מישהו, שאין הם מכירים, ושואל, איך תצביעו, אין הם בטוחים לעולם מיהו, ומדוע הוא שואל.
 1	כאשר	כאשר	SCONJ	SCONJ	_	2	mark	_	_
-2	מטלפן	טילפן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	20	advcl	_	_
+2	מטלפן	טילפן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ט.ל.פ.נ|VerbForm=Part|Voice=Act	20	advcl	_	_
 3-4	אליהם	_	_	_	_	_	_	_	_
 3	אל_	אל	ADP	ADP	_	4	case	_	_
 4	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	2	obl	_	_
@@ -9969,18 +9969,18 @@
 7	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
 8	אין	_	ADV	ADV	Polarity=Neg	10	advmod	_	_
 9	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	10	nsubj	_	_
-10	מכירים	הכיר	VERB	VERB	Gender=Masc|Number=Plur|Person=1,2,3|VerbForm=Part	5	acl:relcl	_	SpaceAfter=No
+10	מכירים	הכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=נ.כ.ר|VerbForm=Part	5	acl:relcl	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	2	punct	_	_
 12-13	ושואל	_	_	_	_	_	_	_	SpaceAfter=No
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
-13	שואל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	conj	_	_
+13	שואל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ש.א.ל|VerbForm=Part|Voice=Act	2	conj	_	_
 14	,	,	PUNCT	PUNCT	_	13	punct	_	_
 15	איך	איך	ADV	ADV	PronType=Int	16	advmod	_	_
-16	תצביעו	הצביע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=2|Tense=Fut|Voice=Act	13	obl	_	SpaceAfter=No
+16	תצביעו	הצביע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=2|Root=צ.ב.ע|Tense=Fut|Voice=Act	13	obl	_	SpaceAfter=No
 17	,	,	PUNCT	PUNCT	_	20	punct	_	_
 18	אין	_	ADV	ADV	Polarity=Neg	20	advmod	_	_
 19	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	20	nsubj	_	_
-20	בטוחים	בטוח	VERB	VERB	VerbForm=Part	0	root	_	_
+20	בטוחים	בטוח	VERB	VERB	HebBinyan=PAAL|Root=ב.ט.ח|VerbForm=Part	0	root	_	_
 21	לעולם	לעולם	ADV	ADV	_	20	advmod	_	_
 22	מיהו	מי	PRON	PRON	Gender=Masc|Number=Sing|PronType=Int	20	advcl	_	SpaceAfter=No
 23	,	,	PUNCT	PUNCT	_	22	punct	_	_
@@ -9988,7 +9988,7 @@
 24	ו	ו	CCONJ	CCONJ	_	27	cc	_	_
 25	מדוע	מדוע	ADV	ADV	PronType=Int	27	advmod	_	_
 26	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	27	nsubj	_	_
-27	שואל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	22	conj	_	SpaceAfter=No
+27	שואל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ש.א.ל|VerbForm=Part|Voice=Act	22	conj	_	SpaceAfter=No
 28	.	.	PUNCT	PUNCT	_	20	punct	_	_
 
 # sent_id = 290
@@ -10008,9 +10008,9 @@
 4	,	,	PUNCT	PUNCT	_	3	punct	_	_
 5-6	המנסה	_	_	_	_	_	_	_	_
 5	ה	ה	SCONJ	SCONJ	_	6	mark	_	_
-6	מנסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	acl:relcl	_	_
+6	מנסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=נ.ס.י|VerbForm=Part|Voice=Act	3	acl:relcl	_	_
 7-9	להכשילם	_	_	_	_	_	_	_	SpaceAfter=No
-7	להכשילם	הכשיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
+7	להכשילם	הכשיל	VERB	VERB	HebBinyan=HIFIL|Root=כ.ש.ל|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 8	את	את	ADP	ADP	Case=Acc	9	case	_	_
 9	_הם	הוא	PRON	PRON	Case=Acc|Gender=Masc|Number=Plur|Person=3|PronType=Prs	7	obj	_	_
 10	?	?	PUNCT	PUNCT	_	3	punct	_	_
@@ -10025,8 +10025,8 @@
 5	,	,	PUNCT	PUNCT	_	4	punct	_	_
 6-7	המתכוון	_	_	_	_	_	_	_	_
 6	ה	ה	SCONJ	SCONJ	_	7	mark	_	_
-7	מתכוון	התכוון	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	4	acl:relcl	_	_
-8	לעשות	עשה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	xcomp	_	_
+7	מתכוון	התכוון	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=כ.ו.נ|VerbForm=Part	4	acl:relcl	_	_
+8	לעשות	עשה	VERB	VERB	HebBinyan=PAAL|Root=ע.ש.י|VerbForm=Inf|Voice=Act	7	xcomp	_	_
 9	טיהור	טיהור	NOUN	NOUN	Gender=Fem|Number=Sing	8	obj	_	_
 10	פוליטי	פוליטי	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	_
 11-13	במשרד	_	_	_	_	_	_	_	SpaceAfter=No
@@ -10041,10 +10041,10 @@
 1	ו	ו	CCONJ	CCONJ	_	5	cc	_	_
 2	אז	אז	ADV	ADV	_	4	advmod	_	_
 3	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
-4	מתרגזים	התרגז	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	0	root	_	_
+4	מתרגזים	התרגז	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ר.ג.ז|VerbForm=Part	0	root	_	_
 5-6	ומשקרים	_	_	_	_	_	_	_	SpaceAfter=No
 5	ו	ו	CCONJ	CCONJ	_	6	cc	_	_
-6	משקרים	שיקר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	4	conj	_	_
+6	משקרים	שיקר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ש.ק.ר|VerbForm=Part|Voice=Act	4	conj	_	_
 7	"	"	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 8	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
@@ -10056,7 +10056,7 @@
 3	יום	יום	NOUN	NOUN	Gender=Masc|Number=Sing	14	obl	_	_
 4-5	ששמעתי	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	שמעתי	שמע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Sing|Person=1|Tense=Past|Voice=Act	3	acl:relcl	_	_
+5	שמעתי	שמע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Sing|Person=1|Root=ש.מ.ע|Tense=Past|Voice=Act	3	acl:relcl	_	_
 6	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 7-8	התיאוריה	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -10068,7 +10068,7 @@
 11	מ	מ	ADP	ADP	_	13	case	_	_
 12	פי	פה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	fixed	_	_
 13	סילבר	סילבר	PROPN	PROPN	_	5	obl	_	_
-14	פרסם	פרסם	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+14	פרסם	פרסם	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=פ.ר.ס.מ|Tense=Past|Voice=Act	0	root	_	_
 15-16	העיתון	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	עיתון	עיתון	NOUN	NOUN	Gender=Masc|Number=Sing	14	nsubj	_	_
@@ -10080,7 +10080,7 @@
 22	,	,	PUNCT	PUNCT	_	21	punct	_	_
 23-24	שהראה	_	_	_	_	_	_	_	_
 23	ש	ש	SCONJ	SCONJ	_	24	mark	_	_
-24	הראה	הראה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	21	acl:relcl	_	_
+24	הראה	הראה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ר.א.י|Tense=Past|Voice=Act	21	acl:relcl	_	_
 25	לראשונה	לראשונה	ADV	ADV	_	24	advmod	_	_
 26	יתרון	יתרון	NOUN	NOUN	Gender=Masc|Number=Sing	24	obj	_	_
 27-28	לסילבר	_	_	_	_	_	_	_	_
@@ -10104,7 +10104,7 @@
 # text = כעבור שבוע התרחב היתרון עד 9%, ובמסצוסטס היו אנשים משוכנעים בניצחונו של סילבר.
 1	כעבור	כעבור	ADP	ADP	_	2	case	_	_
 2	שבוע	שבוע	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
-3	התרחב	התרחב	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	התרחב	התרחב	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ר.ח.ב|Tense=Past	0	root	_	_
 4-5	היתרון	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	יתרון	יתרון	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
@@ -10118,7 +10118,7 @@
 12	מסצוסטס	מסצוסטס	PROPN	PROPN	_	15	obl	_	_
 13	היו	היה	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	15	cop	_	_
 14	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	15	nsubj	_	_
-15	משוכנעים	שוכנע	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	3	conj	_	_
+15	משוכנעים	שוכנע	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ש.כ.נ.ע|VerbForm=Part|Voice=Pass	3	conj	_	_
 16-19	בניצחונו	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	ניצחון_	ניצחון	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	15	obl	_	_
@@ -10131,7 +10131,7 @@
 # sent_id = 296
 # text = הוא נוצח השבוע בהפרש של שני אחוזים.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	נוצח	נוצח	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+2	נוצח	נוצח	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=נ.צ.ח|Tense=Past|Voice=Pass	0	root	_	_
 3	השבוע	השבוע	ADV	ADV	_	2	advmod	_	_
 4-5	בהפרש	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
@@ -10182,18 +10182,18 @@
 4	,	,	PUNCT	PUNCT	_	2	punct	_	_
 5-6	שהתייחס	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	התייחס	התייחס	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	2	acl:relcl	_	_
+6	התייחס	התייחס	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=י.ח.ס|Tense=Past	2	acl:relcl	_	_
 7-8	בבוז	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	בוז	בוז	NOUN	NOUN	Gender=Masc|Number=Sing	6	obl	_	_
-9	מתנשא	התנשא	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	8	amod	_	_
+9	מתנשא	התנשא	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=נ.ש.א|VerbForm=Part	8	amod	_	_
 10-11	לכל	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	12	case	_	_
 11	כל	כול	DET	DET	Definite=Cons	12	det	_	_
 12	שאלה	שאלה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
 13-14	שנשאל	_	_	_	_	_	_	_	SpaceAfter=No
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
-14	נשאל	נשאל	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	12	acl:relcl	_	_
+14	נשאל	נשאל	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.א.ל|Tense=Past|Voice=Mid	12	acl:relcl	_	_
 15	,	,	PUNCT	PUNCT	_	12	punct	_	_
 16-18	ולכל	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	19	cc	_	_
@@ -10208,7 +10208,7 @@
 # sent_id = 299
 # text = הוא השמיע הכרזות שערורייתיות בגנות מיעוטים אתניים ונגד קבוצות אוכלוסייה חלשות.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	השמיע	השמיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	השמיע	השמיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ש.מ.ע|Tense=Past|Voice=Act	0	root	_	_
 3	הכרזות	הכרזה	NOUN	NOUN	Gender=Fem|Number=Plur	2	obj	_	_
 4	שערורייתיות	שערורייתי	ADJ	ADJ	Gender=Fem|Number=Plur	3	amod	_	_
 5-6	בגנות	_	_	_	_	_	_	_	_
@@ -10227,11 +10227,11 @@
 # sent_id = 300
 # text = הוא גידף ברבים את יריבו ("בן כלבה, תוקע סכין בגב", אמר עליו בראיון עיתונאי).
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	גידף	גידף	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	גידף	גידף	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ג.ד.פ|Tense=Past|Voice=Act	0	root	_	_
 3-5	ברבים	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	5	case	_	_
 4	ה_	ה	DET	DET	PronType=Art	5	det:def	_	_
-5	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	obl	_	_
+5	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ר.ב.י|VerbForm=Part|Voice=Act	2	obl	_	_
 6	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 7-9	יריבו	_	_	_	_	_	_	_	_
 7	יריב_	יריב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	2	obj	_	_
@@ -10242,7 +10242,7 @@
 12	בן	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	parataxis	_	_
 13	כלבה	כלב	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	SpaceAfter=No
 14	,	,	PUNCT	PUNCT	_	12	punct	_	_
-15	תוקע	תקע	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	12	appos	_	_
+15	תוקע	תקע	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ת.ק.ע|VerbForm=Part|Voice=Act	12	appos	_	_
 16	סכין	סכין	NOUN	NOUN	Gender=Fem,Masc|Number=Sing	15	compound:smixut	_	_
 17-19	בגב	_	_	_	_	_	_	_	SpaceAfter=No
 17	ב	ב	ADP	ADP	_	19	case	_	_
@@ -10250,7 +10250,7 @@
 19	גב	גב	NOUN	NOUN	Gender=Masc|Number=Sing	15	obl	_	_
 20	"	"	PUNCT	PUNCT	_	12	punct	_	SpaceAfter=No
 21	,	,	PUNCT	PUNCT	_	12	punct	_	_
-22	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Tense=Past|Voice=Act	12	dep	_	_
+22	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	12	dep	_	_
 23-24	עליו	_	_	_	_	_	_	_	_
 23	על_	על	ADP	ADP	_	24	case	_	_
 24	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nmod	_	_
@@ -10264,7 +10264,7 @@
 # sent_id = 301
 # text = הוא צווח על עיתונאים מפורסמים ברשתות טלוויזיה ארציות.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	צווח	צווח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	צווח	צווח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=צ.ו.ח|Tense=Past|Voice=Act	0	root	_	_
 3	על	על	ADP	ADP	_	4	case	_	_
 4	עיתונאים	עיתונאי	NOUN	NOUN	Gender=Masc|Number=Plur	2	obl	_	_
 5	מפורסמים	מפורסם	ADJ	ADJ	Gender=Masc|Number=Plur	4	amod	_	_
@@ -10281,7 +10281,7 @@
 2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	5	obl	_	_
 3	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
 4	גם	גם	ADV	ADV	_	5	advmod	_	_
-5	השמיע	השמיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	השמיע	השמיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ש.מ.ע|Tense=Past|Voice=Act	0	root	_	_
 6	מסר	מסר	NOUN	NOUN	Gender=Masc|Number=Sing	5	obj	_	_
 7	פוליטי	פוליטי	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
 8	רב	רב	ADJ	ADJ	Definite=Cons|Gender=Masc|Number=Sing	6	amod	_	SpaceAfter=No
@@ -10292,7 +10292,7 @@
 12	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
 13	ב_	ב	ADP	ADP	_	14	case	_	_
 14	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	obl	_	_
-15	הדגיש	הדגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	acl:relcl	_	_
+15	הדגיש	הדגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ד.ג.ש|Tense=Past|Voice=Act	6	acl:relcl	_	_
 16	יותר	יותר	ADV	ADV	_	15	advmod	_	_
 17-18	מכל	_	_	_	_	_	_	_	_
 17	מ	מ	ADP	ADP	_	16	fixed	_	_
@@ -10310,7 +10310,7 @@
 27	,	,	PUNCT	PUNCT	_	15	punct	_	_
 28-29	והציע	_	_	_	_	_	_	_	_
 28	ו	ו	CCONJ	CCONJ	_	29	cc	_	_
-29	הציע	הציע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	15	conj	_	_
+29	הציע	הציע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.צ.ע|Tense=Past|Voice=Act	15	conj	_	_
 30	חלופות	חלופה	NOUN	NOUN	Gender=Fem|Number=Plur	29	obj	_	_
 31	רציניות	רציני	ADJ	ADJ	Gender=Fem|Number=Plur	30	amod	_	SpaceAfter=No
 32	.	.	PUNCT	PUNCT	_	5	punct	_	_
@@ -10318,7 +10318,7 @@
 # sent_id = 303
 # text = הוא שכנע הרבה משומעיו שיש לו המיומנות הנחוצה להיות מושל.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	שכנע	שכנע	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	שכנע	שכנע	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.כ.נ.ע|Tense=Past|Voice=Act	0	root	_	_
 3	הרבה	הרבה	DET	DET	Definite=Cons	5	det	_	_
 4-7	משומעיו	_	_	_	_	_	_	_	_
 4	מ	מ	ADP	ADP	_	5	case	_	_
@@ -10353,7 +10353,7 @@
 6	הליכה_	הליכה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	2	conj	_	_
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
 8	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nmod:poss	_	_
-9	הטילו	הטיל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+9	הטילו	הטיל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=נ.ט.ל|Tense=Past|Voice=Act	0	root	_	_
 10	פחד	פחד	NOUN	NOUN	Gender=Masc|Number=Sing	9	obj	_	_
 11	על	על	ADP	ADP	_	12	case	_	_
 12-14	סביבותיו	_	_	_	_	_	_	_	SpaceAfter=No
@@ -10369,7 +10369,7 @@
 3	פרנקלין	פרנקלין	PROPN	PROPN	_	6	obl	_	_
 4	דלאנו	דלאנו	PROPN	PROPN	_	3	flat:name	_	_
 5	רוזוולט	רוזוולט	PROPN	PROPN	_	3	flat:name	_	_
-6	אמרו	אמר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	27	advcl	_	_
+6	אמרו	אמר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	27	advcl	_	_
 7-8	שיש	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
 8	יש	יש	VERB	VERB	HebExistential=True	6	ccomp	_	_
@@ -10396,7 +10396,7 @@
 25	סילבר	סילבר	PROPN	PROPN	_	27	obl	_	_
 26	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	27	cop	_	_
 27	אפשר	אפשר	AUX	AUX	VerbType=Mod	28	aux	_	_
-28	לומר	אמר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+28	לומר	אמר	VERB	VERB	HebBinyan=PAAL|Root=א.מ.ר|VerbForm=Inf|Voice=Act	0	root	_	_
 29	בדיוק	בדיוק	ADV	ADV	_	28	advmod	_	_
 30	את	את	ADP	ADP	Case=Acc	32	case:acc	_	_
 31-32	ההיפך	_	_	_	_	_	_	_	SpaceAfter=No
@@ -10413,7 +10413,7 @@
 4-5	באוקטובר	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	אוקטובר	אוקטובר	PROPN	PROPN	_	3	obl	_	_
-6	התפעלה	התפעל	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+6	התפעלה	התפעל	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=פ.ע.ל|Tense=Past	0	root	_	_
 7-8	ממנו	_	_	_	_	_	_	_	_
 7	מן_	מן	ADP	ADP	_	8	case	_	_
 8	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	obl	_	_
@@ -10441,7 +10441,7 @@
 26	:	:	PUNCT	PUNCT	_	29	punct	_	_
 27	"	"	PUNCT	PUNCT	_	29	punct	_	SpaceAfter=No
 28	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	29	nsubj	_	_
-29	עשה	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	19	appos	_	_
+29	עשה	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	19	appos	_	_
 30-31	בחודשים	_	_	_	_	_	_	_	_
 30	ב	ב	ADP	ADP	_	31	case	_	_
 31	חודשים	חודש	NOUN	NOUN	Gender=Masc|Number=Plur	29	obl	_	_
@@ -10454,14 +10454,14 @@
 37	מה	מה	ADV	ADV	PronType=Int	29	obj	_	_
 38-39	שלקח	_	_	_	_	_	_	_	_
 38	ש	ש	SCONJ	SCONJ	_	39	mark	_	_
-39	לקח	לקח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	37	acl:relcl	_	_
+39	לקח	לקח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	37	acl:relcl	_	_
 40-42	לחברה	_	_	_	_	_	_	_	_
 40	ל	ל	ADP	ADP	_	42	case	_	_
 41	ה_	ה	DET	DET	PronType=Art	42	det:def	_	_
 42	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	39	obl	_	_
 43	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	39	obj	_	_
 44	כדי	כדי	ADP	ADP	_	45	case	_	_
-45	לעשות	עשה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	39	advcl	_	_
+45	לעשות	עשה	VERB	VERB	HebBinyan=PAAL|Root=ע.ש.י|VerbForm=Inf|Voice=Act	39	advcl	_	_
 46	למען	למען	ADP	ADP	_	47	case	_	_
 47	טלוויזיה	טלוויזיה	NOUN	NOUN	Gender=Fem|Number=Sing	45	obl	_	_
 48	צבעונית	צבעוני	ADJ	ADJ	Gender=Fem|Number=Sing	47	amod	_	SpaceAfter=No
@@ -10474,7 +10474,7 @@
 55	,	,	PUNCT	PUNCT	_	58	punct	_	_
 56	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	58	nsubj	_	_
 57	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	58	cop	_	_
-58	זוכה	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	29	dep	_	_
+58	זוכה	זכה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|Root=ז.כ.י|VerbForm=Part|Voice=Act	29	dep	_	_
 59-60	במדליית	_	_	_	_	_	_	_	_
 59	ב	ב	ADP	ADP	_	60	case	_	_
 60	מדליית	מדליה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	58	obl	_	_
@@ -10490,18 +10490,18 @@
 69-70	שהוא	_	_	_	_	_	_	_	_
 69	ש	ש	SCONJ	SCONJ	_	68	fixed	_	_
 70	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	71	nsubj	_	_
-71	גורם	גרם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	64	advcl	_	_
+71	גורם	גרם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|Root=ג.ר.מ|VerbForm=Part|Voice=Act	64	advcl	_	_
 72-73	לאנגלית	_	_	_	_	_	_	_	_
 72	ל	ל	ADP	ADP	_	73	case	_	_
 73	אנגלית	אנגלית	PROPN	PROPN	_	71	obl	_	_
-74	להישמע	נשמע	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	71	xcomp	_	_
+74	להישמע	נשמע	VERB	VERB	HebBinyan=NIFAL|Root=ש.מ.ע|VerbForm=Inf|Voice=Mid	71	xcomp	_	_
 75	כמו	כמו	ADP	ADP	_	76	case	_	_
 76	צרפתית	צרפתית	PROPN	PROPN	_	74	obl	_	SpaceAfter=No
 77	...	...	PUNCT	PUNCT	_	29	punct	_	_
 78	אם	אם	SCONJ	SCONJ	_	79	mark	_	_
-79	ייבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	81	advcl	_	SpaceAfter=No
+79	ייבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ב.ח.ר|Tense=Fut|Voice=Mid	81	advcl	_	SpaceAfter=No
 80	,	,	PUNCT	PUNCT	_	81	punct	_	_
-81	תהיה	היה	VERB	VERB	Gender=Fem|HebExistential=True|HebSource=ConvUncertainHead|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	29	dep	_	_
+81	תהיה	היה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|HebExistential=True|HebSource=ConvUncertainHead|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	29	dep	_	_
 82-84	לכולנו	_	_	_	_	_	_	_	_
 82	ל	ל	ADP	ADP	_	83	case	_	_
 83	כולנו	כול	NOUN	NOUN	Gender=Masc|Number=Sing	81	obl	_	_
@@ -10509,7 +10509,7 @@
 85-86	ההזדמנות	_	_	_	_	_	_	_	_
 85	ה	ה	DET	DET	PronType=Art	86	det:def	_	_
 86	הזדמנות	הזדמנות	NOUN	NOUN	Gender=Fem|Number=Sing	81	nsubj	_	_
-87	ללמוד	למד	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	86	acl	_	_
+87	ללמוד	למד	VERB	VERB	HebBinyan=PAAL|Root=ל.מ.ד|VerbForm=Inf|Voice=Act	86	acl	_	_
 88-89	ממנו	_	_	_	_	_	_	_	_
 88	מן_	מן	ADP	ADP	_	89	case	_	_
 89	_הוא	הוא	PRON	PRON	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing|Person=3|PronType=Prs	87	dep	_	_
@@ -10526,7 +10526,7 @@
 98	,	,	PUNCT	PUNCT	_	93	punct	_	_
 99-100	הנקראת	_	_	_	_	_	_	_	_
 99	ה	ה	SCONJ	SCONJ	_	100	mark	_	_
-100	נקראת	נקרא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	93	acl:relcl	_	_
+100	נקראת	נקרא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ק.ר.א|VerbForm=Part|Voice=Mid	93	acl:relcl	_	_
 101	מסצוסטס	מסצוסטס	PROPN	PROPN	_	100	dep	_	SpaceAfter=No
 102	"	"	PUNCT	PUNCT	_	29	punct	_	SpaceAfter=No
 103	.	.	PUNCT	PUNCT	_	6	punct	_	_
@@ -10557,7 +10557,7 @@
 18	של	של	ADP	ADP	Case=Gen	19	case:gen	_	_
 19	פרופסור	פרופסור	NOUN	NOUN	Gender=Masc|Number=Sing	15	nmod:poss	_	_
 20	יהיר	יהיר	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	_
-21	שלח	שלח	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+21	שלח	שלח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.ל.ח|Tense=Past	0	root	_	_
 22	מספר	מספר	NOUN	NOUN	Gender=Masc|Number=Sing	21	obj	_	_
 23	מפתיע	מפתיע	ADJ	ADJ	Gender=Masc|Number=Sing	22	amod	_	_
 24	של	של	ADP	ADP	Case=Gen	25	case:gen	_	_
@@ -10587,14 +10587,14 @@
 4	חייכן	חייכן	ADJ	ADJ	Gender=Masc|Number=Sing	2	advmod	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	2	punct	_	_
 6	מסוגל	מסוגל	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	7	aux	_	_
-7	להתבדח	התבדח	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	2	parataxis	_	_
+7	להתבדח	התבדח	VERB	VERB	HebBinyan=HITPAEL|Root=ב.ד.ח|VerbForm=Inf	2	parataxis	_	_
 8	על	על	ADP	ADP	_	9	case	_	_
 9	חשבון	חשבון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obl	_	_
 10	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	9	compound:smixut	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	6	punct	_	_
 12-13	ולוקח	_	_	_	_	_	_	_	_
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
-13	לוקח	לקח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	6	conj	_	_
+13	לוקח	לקח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ל.ק.ח|VerbForm=Part|Voice=Act	6	conj	_	_
 14	את	את	ADP	ADP	Case=Acc	16	case:acc	_	_
 15-16	החיים	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
@@ -10609,7 +10609,7 @@
 # sent_id = 309
 # text = אילו ניצח סילבר, יתכן מאוד שהיה מנסה בעוד שנתיים, או בעוד שש שנים, להתמודד על הנשיאות.
 1	אילו	אילו	CCONJ	CCONJ	_	2	case	_	_
-2	ניצח	ניצח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	obl	_	_
+2	ניצח	ניצח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.צ.ח|Tense=Past|Voice=Act	5	obl	_	_
 3	סילבר	סילבר	PROPN	PROPN	_	2	nsubj	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	5	punct	_	_
 5	יתכן	ייתכן	AUX	AUX	VerbType=Mod	0	root	_	_
@@ -10617,7 +10617,7 @@
 7-8	שהיה	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
 8	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	9	cop	_	_
-9	מנסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	ccomp	_	_
+9	מנסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=נ.ס.י|VerbForm=Part|Voice=Act	5	ccomp	_	_
 10	בעוד	בעוד	ADP	ADP	_	11	case	_	_
 11	שנתיים	שנה	NOUN	NOUN	Gender=Fem|Number=Dual	9	obl	_	SpaceAfter=No
 12	,	,	PUNCT	PUNCT	_	11	punct	_	_
@@ -10626,7 +10626,7 @@
 15	שש	שש	NUM	NUM	Gender=Fem|Number=Sing	16	nummod	_	_
 16	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	11	conj	_	SpaceAfter=No
 17	,	,	PUNCT	PUNCT	_	9	punct	_	_
-18	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	9	xcomp	_	_
+18	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|Root=מ.ד.ד|VerbForm=Inf	9	xcomp	_	_
 19	על	על	ADP	ADP	_	21	case	_	_
 20-21	הנשיאות	_	_	_	_	_	_	_	SpaceAfter=No
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
@@ -10647,7 +10647,7 @@
 9-10	שסילבר	_	_	_	_	_	_	_	_
 9	ש	_	SCONJ	SCONJ	_	11	mark	_	_
 10	סילבר	שסילבר	PROPN	PROPN	_	11	nsubj	_	_
-11	התאמץ	התאמץ	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	4	acl:relcl	_	_
+11	התאמץ	התאמץ	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=א.מ.צ|Tense=Past	4	acl:relcl	_	_
 12	הרבה	הרבה	ADV	ADV	_	11	advmod	_	_
 13	למען	למען	ADP	ADP	_	14	case	_	_
 14-16	זכייתו	_	_	_	_	_	_	_	_
@@ -10662,7 +10662,7 @@
 20	ל	ל	ADP	ADP	_	21	case	_	_
 21	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	18	nmod	_	_
 22	,	,	PUNCT	PUNCT	_	23	punct	_	_
-23	תמך	תמך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+23	תמך	תמך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ת.מ.כ|Tense=Past|Voice=Act	0	root	_	_
 24	בגלוי	בגלוי	ADV	ADV	_	23	advmod	_	_
 25-28	במועמדותו	_	_	_	_	_	_	_	_
 25	ב	ב	ADP	ADP	_	26	case	_	_
@@ -10684,10 +10684,10 @@
 3	אפילו	אפילו	ADV	ADV	_	4	advmod	_	_
 4	מסוגל	מסוגל	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	5	aux	_	_
 5-7	לראותו	_	_	_	_	_	_	_	_
-5	לראותו	ראה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+5	לראותו	ראה	VERB	VERB	HebBinyan=PAAL|Root=ר.א.י|VerbForm=Inf|Voice=Act	0	root	_	_
 6	את	את	ADP	ADP	Case=Acc	7	case	_	_
 7	_הוא	הוא	PRON	PRON	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	obj	_	_
-8	מכהן	כיהן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	7	acl	_	_
+8	מכהן	כיהן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=כ.ה.נ|VerbForm=Part|Voice=Act	7	acl	_	_
 9-11	בבית	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
@@ -10705,7 +10705,7 @@
 4	?	?	PUNCT	PUNCT	HebSource=ConvUncertainHead	2	dep	_	SpaceAfter=No
 5	"	"	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	7	punct	_	_
-7	שאל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+7	שאל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.א.ל|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 8	.	.	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 313
@@ -10718,7 +10718,7 @@
 6	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	9	nsubj	_	_
 7	לא	לא	ADV	ADV	Polarity=Neg	9	advmod	_	_
 8	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	9	cop	_	_
-9	מאמין	האמין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
+9	מאמין	האמין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=א.מ.נ|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 10	"	"	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 11	.	.	PUNCT	PUNCT	_	9	punct	_	_
 
@@ -10738,7 +10738,7 @@
 9	_של_	של	ADP	ADP	_	10	case:gen	_	_
 10	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	8	nmod:poss	_	_
 11	,	,	PUNCT	PUNCT	_	12	punct	_	_
-12	תיחסך	נחסך	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	0	root	_	_
+12	תיחסך	נחסך	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ח.ס.כ|Tense=Fut|Voice=Mid	0	root	_	_
 13-14	מאתנו	_	_	_	_	_	_	_	SpaceAfter=No
 13	מאת_	מאת	ADP	ADP	_	14	case	_	_
 14	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	12	obl	_	_
@@ -10747,14 +10747,14 @@
 # sent_id = 315
 # text = סילבר חזר השבוע לאוניברסיטה, כועס ומתוסכל יותר מאי-פעם.
 1	סילבר	סילבר	PROPN	PROPN	_	2	nsubj	_	_
-2	חזר	חזר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+2	חזר	חזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Past	0	root	_	_
 3	השבוע	השבוע	ADV	ADV	_	2	advmod	_	_
 4-6	לאוניברסיטה	_	_	_	_	_	_	_	SpaceAfter=No
 4	ל	ל	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	אוניברסיטה	אוניברסיטה	NOUN	NOUN	Gender=Fem|Number=Sing	2	obl	_	_
 7	,	,	PUNCT	PUNCT	_	2	punct	_	_
-8	כועס	כעס	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainLabel|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	advmod	_	_
+8	כועס	כעס	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainLabel|Number=Sing|Person=1,2,3|Root=כ.ע.ס|VerbForm=Part|Voice=Act	2	advmod	_	_
 9-10	ומתוסכל	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	10	cc	_	_
 10	מתוסכל	מתוסכל	ADJ	ADJ	Gender=Masc|Number=Sing	8	conj	_	_
@@ -10777,7 +10777,7 @@
 5-6	בארה"ב	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	2	nmod	_	_
-7	מתחילות	התחיל	VERB	VERB	Gender=Fem|Number=Plur|Person=1,2,3|VerbForm=Part	0	root	_	_
+7	מתחילות	התחיל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ת.ח.ל|VerbForm=Part	0	root	_	_
 8	כבר	כבר	ADV	ADV	_	7	advmod	_	_
 9	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 10-12	הכנותיהן	_	_	_	_	_	_	_	_
@@ -10800,7 +10800,7 @@
 # sent_id = 317
 # text = אז ייבחר לא רק הקונגרס, אלא גם הנשיא.
 1	אז	אז	ADV	ADV	_	2	advmod	_	_
-2	ייבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	0	root	_	_
+2	ייבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ב.ח.ר|Tense=Fut|Voice=Mid	0	root	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
 4	רק	רק	ADV	ADV	_	6	advmod	_	_
 5-6	הקונגרס	_	_	_	_	_	_	_	SpaceAfter=No
@@ -10829,15 +10829,15 @@
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	אחרונות	אחרון	ADJ	ADJ	Gender=Fem|Number=Plur	7	amod	_	_
 10	לא	לא	ADV	ADV	Polarity=Neg	11	advmod	_	_
-11	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+11	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ל.ח|Tense=Past|Voice=Act	0	root	_	_
 12	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	11	nsubj	_	_
-13	לחזור	חזר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	11	xcomp	_	_
+13	לחזור	חזר	VERB	VERB	HebBinyan=PAAL|Root=ח.ז.ר|VerbForm=Inf|Voice=Act	11	xcomp	_	_
 14-15	ולהיבחר	_	_	_	_	_	_	_	SpaceAfter=No
 14	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
-15	להיבחר	נבחר	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	13	conj	_	_
+15	להיבחר	נבחר	VERB	VERB	HebBinyan=NIFAL|Root=ב.ח.ר|VerbForm=Inf|Voice=Mid	13	conj	_	_
 16	,	,	PUNCT	PUNCT	_	11	punct	_	_
 17	אם	אם	SCONJ	SCONJ	_	18	mark	_	_
-18	רצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	advcl	_	SpaceAfter=No
+18	רצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ר.צ.י|Tense=Past|Voice=Act	11	advcl	_	SpaceAfter=No
 19	.	.	PUNCT	PUNCT	_	11	punct	_	_
 
 # sent_id = 319
@@ -10846,10 +10846,10 @@
 2	לפני	לפני	ADP	ADP	_	1	fixed	_	_
 3	חודשיים	חודש	NOUN	NOUN	Gender=Masc|Number=Dual	5	obl	_	_
 4	לא	לא	ADV	ADV	Polarity=Neg	5	advmod	_	_
-5	היתה	היה	VERB	VERB	Gender=Fem|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+5	היתה	היה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 6	סיבה	סיבה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
 7	טובה	טוב	ADJ	ADJ	Gender=Fem|Number=Sing	6	amod	_	_
-8	להניח	הניח	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	6	acl	_	_
+8	להניח	הניח	VERB	VERB	HebBinyan=HIFIL|Root=נ.ו.ח|VerbForm=Inf|Voice=Act	6	acl	_	_
 9-10	שגורג	_	_	_	_	_	_	_	_
 9	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
 10	גורג	גורג	PROPN	PROPN	_	14	dep	_	_
@@ -10869,7 +10869,7 @@
 2-3	מאז	_	_	_	_	_	_	_	_
 2	מ	מ	ADP	ADP	_	4	case	_	_
 3	אז	אז	ADV	ADV	_	2	fixed	_	_
-4	נכשל	נכשל	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	32	obl	_	_
+4	נכשל	נכשל	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=כ.ש.ל|Tense=Past|Voice=Mid	32	obl	_	_
 5	בוש	בוש	PROPN	PROPN	_	4	nsubj	_	_
 6-9	בטיפולו	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
@@ -10883,7 +10883,7 @@
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	תקציב	תקציב	NOUN	NOUN	Gender=Masc|Number=Sing	11	compound:smixut	_	_
 14	,	,	PUNCT	PUNCT	_	4	punct	_	_
-15	הסתבך	הסתבך	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	4	conj	_	_
+15	הסתבך	הסתבך	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ס.ב.כ|Tense=Past	4	conj	_	_
 16-17	בהתכתשויות	_	_	_	_	_	_	_	SpaceAfter=No
 16	ב	ב	ADP	ADP	_	19	case	_	_
 17	התכתשויות	התכתשות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	19	nmod	_	_
@@ -10896,7 +10896,7 @@
 23	,	,	PUNCT	PUNCT	_	4	punct	_	_
 24-25	ונכנע	_	_	_	_	_	_	_	_
 24	ו	ו	CCONJ	CCONJ	_	25	cc	_	_
-25	נכנע	נכנע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	conj	_	_
+25	נכנע	נכנע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=כ.נ.ע|Tense=Past|Voice=Mid	4	conj	_	_
 26	לבסוף	לבסוף	ADV	ADV	_	25	advmod	_	_
 27	לאורך	לאורך	ADP	ADP	_	30	case	_	_
 28	כל	כול	DET	DET	Definite=Cons	30	det	_	_
@@ -10904,7 +10904,7 @@
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	דרך	דרך	NOUN	NOUN	Gender=Fem|Number=Sing	25	obl	_	_
 31	,	,	PUNCT	PUNCT	_	32	punct	_	_
-32	שוררת	שרר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+32	שוררת	שרר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=שׂ.ר.ר|VerbForm=Part|Voice=Act	0	root	_	_
 33	בין	בין	ADP	ADP	_	34	case	_	_
 34	דמוקרטים	דמוקרט	NOUN	NOUN	Gender=Masc|Number=Plur	32	obl	_	_
 35-36	התחושה	_	_	_	_	_	_	_	_
@@ -10918,7 +10918,7 @@
 40	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	38	obl	_	_
 41	סיכוי	סיכוי	NOUN	NOUN	Gender=Masc|Number=Sing	38	nsubj	_	_
 42	ממשי	ממשי	ADJ	ADJ	Gender=Masc|Number=Sing	41	amod	_	_
-43	להוציא	הוציא	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	41	acl	_	_
+43	להוציא	הוציא	VERB	VERB	HebBinyan=HIFIL|Root=י.צ.א|VerbForm=Inf|Voice=Act	41	acl	_	_
 44	את	את	ADP	ADP	Case=Acc	45	case:acc	_	_
 45	בוש	בוש	PROPN	PROPN	_	43	obj	_	_
 46	מן	מן	ADP	ADP	_	48	case	_	_
@@ -10940,8 +10940,8 @@
 4	רפובליקאים	רפובליקאים	NOUN	NOUN	_	1	nsubj	_	_
 5-6	הנוטים	_	_	_	_	_	_	_	_
 5	ה	ה	SCONJ	SCONJ	_	6	mark	_	_
-6	נוטים	נטה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	4	acl:relcl	_	_
-7	להסכים	הסכים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
+6	נוטים	נטה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=נ.ט.י|VerbForm=Part|Voice=Act	4	acl:relcl	_	_
+7	להסכים	הסכים	VERB	VERB	HebBinyan=HIFIL|Root=ס.כ.מ|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 8-9	אתם	_	_	_	_	_	_	_	SpaceAfter=No
 8	אתם	את	ADP	ADP	_	9	case	_	_
 9	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	7	obl	_	_
@@ -10950,7 +10950,7 @@
 # sent_id = 322
 # text = עכשיו נבחנים המועמדים ל1992.
 1	עכשיו	עכשיו	ADV	ADV	_	2	advmod	_	_
-2	נבחנים	נבחן	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+2	נבחנים	נבחן	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=ב.ח.נ|VerbForm=Part|Voice=Mid	0	root	_	_
 3-4	המועמדים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	מועמדים	מועמד	NOUN	NOUN	Gender=Masc|Number=Plur	2	nsubj	_	_
@@ -10968,8 +10968,8 @@
 4-5	השבוע	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	שבוע	שבוע	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod:poss	_	_
-6	יכלו	יכל	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut	0	root	_	_
-7	להעניק	העניק	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
+6	יכלו	יכל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.כ.ל|Tense=Fut	0	root	_	_
+7	להעניק	העניק	VERB	VERB	HebBinyan=HIFIL|Root=ע.נ.ק|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 8	דחיפה	דחיפה	NOUN	NOUN	Gender=Fem|Number=Sing	7	obj	_	_
 9	נאה	נאה	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
 10-11	לשניים	_	_	_	_	_	_	_	_
@@ -10981,7 +10981,7 @@
 14	פוליטיקאים	פוליטיקאי	NOUN	NOUN	Gender=Masc|Number=Plur	7	obl	_	_
 15-16	המוזכרים	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
-16	מוזכרים	הוזכר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	14	amod	_	_
+16	מוזכרים	הוזכר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ז.כ.ר|VerbForm=Part|Voice=Pass	14	amod	_	_
 17	ביותר	ביותר	ADV	ADV	_	16	advmod	_	SpaceAfter=No
 18	:	:	PUNCT	PUNCT	_	14	punct	_	_
 19-20	המושל	_	_	_	_	_	_	_	_
@@ -11005,7 +11005,7 @@
 34	שם_	שם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	37	nsubj	_	_
 35	_של_	של	ADP	ADP	_	36	case:gen	_	_
 36	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	34	nmod:poss	_	_
-37	מתרוצץ	התרוצץ	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	20	acl:relcl	_	_
+37	מתרוצץ	התרוצץ	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ר.ו.צ|VerbForm=Part	20	acl:relcl	_	_
 38-39	בהקשרים	_	_	_	_	_	_	_	_
 38	ב	ב	ADP	ADP	_	39	case	_	_
 39	הקשרים	הקשר	NOUN	NOUN	Gender=Masc|Number=Plur	37	obl	_	_
@@ -11051,7 +11051,7 @@
 1	ניצחונות	ניצחון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	שניהם	שניים	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	1	compound:smixut	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
-4	הועמדו	הועמד	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	הועמדו	הועמד	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=ע.מ.ד|Tense=Past|Voice=Pass	0	root	_	_
 5	אף	אף	DET	DET	Definite=Cons	6	det	_	_
 6	דקה	דקה	NOUN	NOUN	Gender=Fem|Number=Sing	4	dep	_	_
 7	אחת	אחת	NUM	NUM	Gender=Fem|Number=Sing	6	nummod	_	_
@@ -11080,7 +11080,7 @@
 6	ב	ב	ADP	ADP	_	8	case	_	_
 7	איזה	איזה	DET	DET	Definite=Cons	8	det	_	_
 8	הפרש	הפרש	NOUN	NOUN	Gender=Masc|Number=Sing	9	obl	_	_
-9	ירסקו	ריסק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+9	ירסקו	ריסק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ר.ס.ק|Tense=Fut|Voice=Act	0	root	_	_
 10	יריבים	יריב	NOUN	NOUN	Gender=Masc|Number=Plur	9	obj	_	_
 11	רפובליקאיים	רפובליקני	ADJ	ADJ	Gender=Masc|Number=Plur	10	amod	_	_
 12	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	10	acl	_	_
@@ -11091,7 +11091,7 @@
 # sent_id = 326
 # text = בראדלי ניצח לבסוף בהפרש של שלושה אחוזים.
 1	בראדלי	בראדלי	PROPN	PROPN	_	2	nsubj	_	_
-2	ניצח	ניצח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	ניצח	ניצח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.צ.ח|Tense=Past|Voice=Act	0	root	_	_
 3	לבסוף	לבסוף	ADV	ADV	_	2	advmod	_	_
 4-5	בהפרש	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
@@ -11110,7 +11110,7 @@
 4-5	הבחירות	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	3	compound:smixut	_	_
-6	התבוננו	התבונן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
+6	התבוננו	התבונן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=ב.ו.נ|Tense=Past	0	root	_	_
 7	רפובליקאים	רפובליקאים	NOUN	NOUN	_	6	nsubj	_	_
 8-9	באי	_	_	_	_	_	_	_	SpaceAfter=No
 8	ב	ב	ADP	ADP	_	11	case	_	_
@@ -11124,7 +11124,7 @@
 15	,	,	PUNCT	PUNCT	_	6	punct	_	_
 16-17	ואמרו	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
-17	אמרו	אמר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	6	conj	_	_
+17	אמרו	אמר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	6	conj	_	_
 18-19	באנחה	_	_	_	_	_	_	_	_
 18	ב	ב	ADP	ADP	_	19	case	_	_
 19	אנחה	אנחה	NOUN	NOUN	Gender=Fem|Number=Sing	17	obl	_	_
@@ -11132,8 +11132,8 @@
 21	כי	כי	SCONJ	SCONJ	_	35	mark	_	_
 22	אילו	אילו	CCONJ	CCONJ	_	24	mark	_	_
 23	היו	היה	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	24	cop	_	_
-24	משכילים	השכיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	35	advcl	_	_
-25	לעמוד	עמד	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	24	xcomp	_	_
+24	משכילים	השכיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ש.כ.ל|VerbForm=Part|Voice=Act	35	advcl	_	_
+25	לעמוד	עמד	VERB	VERB	HebBinyan=PAAL|Root=ע.מ.ד|VerbForm=Inf|Voice=Act	24	xcomp	_	_
 26	על	על	ADP	ADP	_	27	case	_	_
 27	גודל	גודל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	25	obl	_	_
 28-29	ההזדמנות	_	_	_	_	_	_	_	_
@@ -11145,7 +11145,7 @@
 32	גרסי	גרס	PROPN	PROPN	_	31	flat:name	_	SpaceAfter=No
 33	,	,	PUNCT	PUNCT	_	35	punct	_	_
 34	היו	היה	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	35	cop	_	_
-35	מתגייסים	התגייס	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	17	ccomp	_	_
+35	מתגייסים	התגייס	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ג.י.ס|VerbForm=Part	17	ccomp	_	_
 36-37	לעזרת	_	_	_	_	_	_	_	_
 36	ל	ל	ADP	ADP	_	37	case	_	_
 37	עזרת	עזרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	35	obl	_	_
@@ -11167,19 +11167,19 @@
 2-3	שהכול	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	1	fixed	_	_
 3	הכול	_	PRON	PRON	Gender=Masc|Number=Sing|Person=3	4	nsubj	_	_
-4	ראו	ראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	14	advcl	_	_
+4	ראו	ראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ר.א.י|Tense=Past|Voice=Act	14	advcl	_	_
 5-6	בה	_	_	_	_	_	_	_	_
 5	ב_	ב	ADP	ADP	_	6	case	_	_
 6	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	4	obl	_	_
 7	שיה	שי	NOUN	NOUN	_	4	obj	_	_
-8	מובלת	מובלת	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	7	amod	_	_
+8	מובלת	מובלת	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=י.ב.ל|VerbForm=Part|Voice=Pass	7	amod	_	_
 9-11	לטבח	_	_	_	_	_	_	_	SpaceAfter=No
 9	ל	ל	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	טבח	טבח	NOUN	NOUN	Gender=Masc|Number=Sing	8	advmod	_	_
 12	,	,	PUNCT	PUNCT	_	14	punct	_	_
 13	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
-14	נשארה	נשאר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+14	נשארה	נשאר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.א.ר|Tense=Past|Voice=Mid	0	root	_	_
 15	עם	עם	ADP	ADP	_	16	case	_	_
 16	תקציב	תקציב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	obl	_	_
 17	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	16	compound:smixut	_	_
@@ -11214,9 +11214,9 @@
 12-13	מאז	_	_	_	_	_	_	_	_
 12	מ	מ	ADP	ADP	_	14	case	_	_
 13	אז	אז	ADV	ADV	_	12	fixed	_	_
-14	נשא	נשא	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	5	nmod	_	_
+14	נשא	נשא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ש.א|Tense=Past	5	nmod	_	_
 15	נאום	נאום	NOUN	NOUN	Gender=Masc|Number=Sing	14	obj	_	_
-16	מלהיב	הלהיב	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	15	amod	_	_
+16	מלהיב	הלהיב	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ל.ה.ב|VerbForm=Part|Voice=Act	15	amod	_	_
 17	באוזני	באוזני	ADP	ADP	_	18	case	_	_
 18	ועידת	ועידה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	14	obl	_	_
 19-20	המפלגה	_	_	_	_	_	_	_	_
@@ -11256,7 +11256,7 @@
 14	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	חמימות	חמימות	NOUN	NOUN	Gender=Fem|Number=Sing	1	conj	_	_
-17	שכנעו	שכנע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+17	שכנעו	שכנע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ש.כ.נ.ע|Tense=Past|Voice=Act	0	root	_	_
 18	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	17	obj	_	_
 19	רבים	רב	ADJ	ADJ	Gender=Masc|Number=Plur	18	amod	_	_
 20-21	בארה"ב	_	_	_	_	_	_	_	_
@@ -11287,7 +11287,7 @@
 2	עובדה	עובדה	NOUN	NOUN	Gender=Fem|Number=Sing	17	nsubj	_	_
 3-4	שנחל	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	נחל	נחל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	acl:relcl	_	_
+4	נחל	נחל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ח.ל|Tense=Past|Voice=Act	2	acl:relcl	_	_
 5	ניצחון	ניצחון	NOUN	NOUN	Gender=Masc|Number=Sing	4	obj	_	_
 6	כל	כול	DET	DET	Definite=Cons	9	advmod	_	_
 7	כך	כך	ADV	ADV	_	6	fixed	_	_
@@ -11300,14 +11300,14 @@
 14	לא	לא	ADV	ADV	Polarity=Neg	15	advmod	_	_
 15	מרשימים	מרשים	ADJ	ADJ	Gender=Masc|Number=Plur	11	amod	_	_
 16	אינה	אינו	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	17	advmod	_	_
-17	אומרת	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+17	אומרת	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 18	בהכרח	בהכרח	ADV	ADV	_	17	advmod	_	_
 19-22	שסיכויו	_	_	_	_	_	_	_	_
 19	ש	ש	SCONJ	SCONJ	_	29	mark	_	_
 20	סיכוי_	סיכוי	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	29	nsubj	_	_
 21	_של_	של	ADP	ADP	_	22	case:gen	_	_
 22	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nmod:poss	_	_
-23	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	20	acl	_	_
+23	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|Root=מ.ד.ד|VerbForm=Inf	20	acl	_	_
 24	על	על	ADP	ADP	_	26	case	_	_
 25-26	הבית	_	_	_	_	_	_	_	_
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
@@ -11315,14 +11315,14 @@
 27-28	הלבן	_	_	_	_	_	_	_	_
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	לבן	לבן	ADJ	ADJ	Gender=Masc|Number=Sing	26	amod	_	_
-29	אבדו	אבד	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	17	ccomp	_	_
+29	אבדו	אבד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=א.ב.ד|Tense=Past	17	ccomp	_	_
 30	לנצח	לנצח	ADV	ADV	_	29	advmod	_	SpaceAfter=No
 31	.	.	PUNCT	PUNCT	_	17	punct	_	_
 
 # sent_id = 332
 # text = היא אומרת לעומת זאת, שמשהו מן הקסם שלו אבד.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	אומרת	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	אומרת	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 3	לעומת	לעומת	ADP	ADP	_	4	case	_	_
 4	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	obl	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	2	punct	_	_
@@ -11336,14 +11336,14 @@
 11-12	שלו	_	_	_	_	_	_	_	_
 11	של_	של	ADP	ADP	Case=Gen	12	case:gen	_	_
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nmod:poss	_	_
-13	אבד	אבד	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	2	ccomp	_	SpaceAfter=No
+13	אבד	אבד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.ב.ד|Tense=Past	2	ccomp	_	SpaceAfter=No
 14	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 333
 # text = על סנאטורים אומרים כי אין לך אחד מהם שאינו רואה את עצמו, כך או אחרת, מועמד פוטנציאלי לנשיאות.
 1	על	על	ADP	ADP	_	2	case	_	_
 2	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	3	obl	_	_
-3	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+3	אומרים	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 4	כי	כי	SCONJ	SCONJ	_	5	mark	_	_
 5	אין	אין	VERB	VERB	HebExistential=True	3	ccomp	_	_
 6-7	לך	_	_	_	_	_	_	_	_
@@ -11356,7 +11356,7 @@
 11-12	שאינו	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
 12	אינו	אינו	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	13	advmod	_	_
-13	רואה	ראה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	10	acl:relcl	_	_
+13	רואה	ראה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.א.י|VerbForm=Part|Voice=Act	10	acl:relcl	_	_
 14	את	את	ADP	ADP	Case=Acc	15	case:acc	_	_
 15	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	13	obj	_	SpaceAfter=No
 16	,	,	PUNCT	PUNCT	_	15	punct	_	_
@@ -11381,7 +11381,7 @@
 4-5	הזו	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	det	_	_
-6	נבחרו	נבחר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+6	נבחרו	נבחר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ב.ח.ר|Tense=Past|Voice=Mid	0	root	_	_
 7	שני	שני	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	8	nummod	_	_
 8	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	6	nsubj	_	_
 9-10	לנשיאים	_	_	_	_	_	_	_	SpaceAfter=No
@@ -11393,7 +11393,7 @@
 13	שלושה	שלושה	NUM	NUM	Gender=Masc|Number=Sing	14	nummod	_	_
 14	נשיאים	נשיא	NOUN	NOUN	Gender=Masc|Number=Plur	16	nsubj	_	_
 15	אחרים	אחר	ADJ	ADJ	Gender=Masc|Number=Plur	14	amod	_	_
-16	כיהנו	כיהן	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	6	conj	_	_
+16	כיהנו	כיהן	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=כ.ה.נ|Tense=Past|Voice=Act	6	conj	_	_
 17-19	בסנאט	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	19	case	_	_
 18	ה_	ה	DET	DET	PronType=Art	19	det:def	_	_
@@ -11415,7 +11415,7 @@
 # text = לעומת זאת הגיעו לנשיאות חמישה מושלי מדינות.
 1	לעומת	לעומת	ADP	ADP	_	2	case	_	_
 2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	obl	_	_
-3	הגיעו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הגיעו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=נ.ג.ע|Tense=Past|Voice=Act	0	root	_	_
 4-6	לנשיאות	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -11454,7 +11454,7 @@
 2	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	15	obl	_	_
 3-4	המתעניינת	_	_	_	_	_	_	_	_
 3	ה	ה	SCONJ	SCONJ	_	4	mark	_	_
-4	מתעניינת	התעניין	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	2	acl:relcl	_	_
+4	מתעניינת	התעניין	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ע.נ.י.נ|VerbForm=Part	2	acl:relcl	_	_
 5	קודם	קודם	ADV	ADV	_	4	advmod	_	_
 6	כל	כול	DET	DET	Definite=Cons	5	fixed	_	_
 7-8	ביכולת	_	_	_	_	_	_	_	_
@@ -11468,7 +11468,7 @@
 13-14	הנשיא	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	12	compound:smixut	_	_
-15	נתפסת	נתפס	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+15	נתפסת	נתפס	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ת.פ.ס|VerbForm=Part|Voice=Mid	0	root	_	_
 16	לעתים	לעתים	ADV	ADV	_	15	advmod	_	_
 17	קרובות	קרוב	ADJ	ADJ	Gender=Fem|Number=Plur	16	fixed	_	_
 18-19	באותו	_	_	_	_	_	_	_	_
@@ -11477,7 +11477,7 @@
 20	אופן	אופן	NOUN	NOUN	Gender=Masc|Number=Sing	15	obl	_	_
 21-22	שנתפסת	_	_	_	_	_	_	_	_
 21	ש	ש	SCONJ	SCONJ	_	22	mark	_	_
-22	נתפסת	נתפס	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	20	acl:relcl	_	_
+22	נתפסת	נתפס	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ת.פ.ס|VerbForm=Part|Voice=Mid	20	acl:relcl	_	_
 23	כהונת	כהונה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	22	nsubj	_	_
 24	מנכ"ל	מנכ"ל	NOUN	NOUN	Abbr=Yes|Definite=Cons|Gender=Masc|Number=Sing	23	compound:smixut	_	_
 25	תעשיית	תעשייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	24	compound:smixut	_	_
@@ -11495,7 +11495,7 @@
 3-4	האלה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	2	det	_	_
-5	מתנהלות	התנהל	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	14	obl	_	_
+5	מתנהלות	התנהל	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=נ.ה.ל|VerbForm=Part	14	obl	_	_
 6	על	על	ADP	ADP	_	7	case	_	_
 7	מיומנות	מיומנות	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	5	punct	_	_
@@ -11504,13 +11504,13 @@
 11	אידיאולוגיה	אידיאולוגיה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	SpaceAfter=No
 12	"	"	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
 13	,	,	PUNCT	PUNCT	_	14	punct	_	_
-14	הכריז	הכריז	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+14	הכריז	הכריז	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=כ.ר.ז|Tense=Past|Voice=Act	0	root	_	_
 15	חגיגית	חגיגית	ADV	ADV	_	14	advmod	_	_
 16	מייקל	מייקל	PROPN	PROPN	_	14	nsubj	_	_
 17	דוקאקיס	דוקאקיס	PROPN	PROPN	_	16	flat:name	_	SpaceAfter=No
 18	,	,	PUNCT	PUNCT	_	14	punct	_	_
 19	כאשר	כאשר	SCONJ	SCONJ	_	20	mark	_	_
-20	נבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	14	advcl	_	_
+20	נבחר	נבחר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ב.ח.ר|Tense=Past|Voice=Mid	14	advcl	_	_
 21-23	למועמד	_	_	_	_	_	_	_	_
 21	ל	ל	ADP	ADP	_	23	case	_	_
 22	ה_	ה	DET	DET	PronType=Art	23	det:def	_	_
@@ -11565,7 +11565,7 @@
 4	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nmod:poss	_	_
 5	של	של	ADP	ADP	Case=Gen	6	case:gen	_	_
 6	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod:poss	_	_
-7	התברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+7	התברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ב.ר.ר|Tense=Past	0	root	_	_
 8-10	שההצלחה	_	_	_	_	_	_	_	_
 8	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -11576,7 +11576,7 @@
 14-15	ודוקאקיס	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
 15	דוקאקיס	דוקאקיס	PROPN	PROPN	_	16	nsubj	_	_
-16	הובס	הובס	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	7	conj	_	SpaceAfter=No
+16	הובס	הובס	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ב.ו.ס|Tense=Past|Voice=Pass	7	conj	_	SpaceAfter=No
 17	.	.	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 341
@@ -11586,13 +11586,13 @@
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	נוסחה	נוסחה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
 4	בעינה	בעין	ADV	ADV	_	5	advmod	_	_
-5	עומדת	עמד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
+5	עומדת	עמד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ע.מ.ד|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 342
 # text = לכן יעוררו מידה גדולה של סקרנות המושלים החדשים של קליפורניה, של טקסס, של פלורידה, של אילינוי ושל מישיגן.
 1	לכן	לכן	ADV	ADV	_	2	advmod	_	_
-2	יעוררו	עורר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+2	יעוררו	עורר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ע.ו.ר|Tense=Fut|Voice=Act	0	root	_	_
 3	מידה	מידה	NOUN	NOUN	Gender=Fem|Number=Sing	2	obj	_	_
 4	גדולה	גדול	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
 5	של	של	ADP	ADP	Case=Gen	6	case:gen	_	_
@@ -11631,7 +11631,7 @@
 5-6	האלה	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	4	det	_	_
-7	בולטת	בלט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+7	בולטת	בלט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ב.ל.ט|VerbForm=Part|Voice=Act	0	root	_	_
 8	אן	אן	PROPN	PROPN	_	7	nsubj	_	_
 9	ריצארדס	ריצארדס	PROPN	PROPN	_	8	flat:name	_	SpaceAfter=No
 10	.	.	PUNCT	PUNCT	_	7	punct	_	_
@@ -11644,7 +11644,7 @@
 3	85	85	NUM	NUM	_	2	compound:smixut	_	_
 4	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
 5	רשאית	רשאי	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbType=Mod	6	aux	_	_
-6	לטעון	טען	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+6	לטעון	טען	VERB	VERB	HebBinyan=PAAL|Root=ט.ע.נ|VerbForm=Inf|Voice=Act	0	root	_	_
 7-8	לתואר	_	_	_	_	_	_	_	_
 7	ל	ל	ADP	ADP	_	8	case	_	_
 8	תואר	תואר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	obl	_	_
@@ -11663,7 +11663,7 @@
 # sent_id = 345
 # text = היא נבחרה השבוע למושלת טקסס, מקץ מערכת הבחירות המכוערת והדרמטית ביותר של 0991.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	נבחרה	נבחר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+2	נבחרה	נבחר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ב.ח.ר|Tense=Past|Voice=Mid	0	root	_	_
 3	השבוע	השבוע	ADV	ADV	_	2	advmod	_	_
 4-5	למושלת	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	5	case	_	_
@@ -11692,7 +11692,7 @@
 # sent_id = 346
 # text = ריצארדס הגיעה לראשונה אל התודעה הלאומית בארה"ב, כאשר הוזמנה לשאת את הנאום המרכזי בוועידת המפלגה הדמוקרטית, ערב הבחירות לנשיאות של 8891.
 1	ריצארדס	ריצארדס	PROPN	PROPN	_	2	nsubj	_	_
-2	הגיעה	הגיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	הגיעה	הגיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ע|Tense=Past|Voice=Act	0	root	_	_
 3	לראשונה	לראשונה	ADV	ADV	_	2	advmod	_	_
 4	אל	אל	ADP	ADP	_	6	case	_	_
 5-6	התודעה	_	_	_	_	_	_	_	_
@@ -11706,8 +11706,8 @@
 10	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	6	nmod	_	_
 11	,	,	PUNCT	PUNCT	_	2	punct	_	_
 12	כאשר	כאשר	SCONJ	SCONJ	_	13	mark	_	_
-13	הוזמנה	הוזמן	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	2	advcl	_	_
-14	לשאת	נשא	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	13	xcomp	_	_
+13	הוזמנה	הוזמן	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ז.מ.נ|Tense=Past|Voice=Pass	2	advcl	_	_
+14	לשאת	נשא	VERB	VERB	HebBinyan=PAAL|Root=נ.ש.א|VerbForm=Inf|Voice=Act	13	xcomp	_	_
 15	את	את	ADP	ADP	Case=Acc	17	case:acc	_	_
 16-17	הנאום	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
@@ -11750,7 +11750,7 @@
 7	,	,	PUNCT	PUNCT	_	5	punct	_	_
 8-9	והניחו	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
-9	הניחו	הניח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	5	conj	_	_
+9	הניחו	הניח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=נ.ו.ח|Tense=Past|Voice=Act	5	conj	_	_
 10-13	שמועמדם	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
 11	מועמד_	מועמד	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	16	nsubj	_	_
@@ -11758,9 +11758,9 @@
 13	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	11	nmod:poss	_	_
 14	דוקאקיס	דוקאקיס	PROPN	PROPN	_	11	appos	_	_
 15	לא	לא	ADV	ADV	Polarity=Neg	16	advmod	_	_
-16	יצטרך	הצטרך	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	9	ccomp	_	_
+16	יצטרך	הצטרך	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=צ.ר.כ|Tense=Fut	9	ccomp	_	_
 17	אפילו	אפילו	ADV	ADV	_	16	advmod	_	_
-18	לרוץ	רץ	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	16	xcomp	_	_
+18	לרוץ	רץ	VERB	VERB	HebBinyan=PAAL|Root=ר.ו.צ|VerbForm=Inf|Voice=Act	16	xcomp	_	_
 19-21	לבית	_	_	_	_	_	_	_	_
 19	ל	ל	ADP	ADP	_	21	case	_	_
 20	ה_	ה	DET	DET	PronType=Art	21	det:def	_	_
@@ -11774,7 +11774,7 @@
 # text = הוא יוכל ללכת לשם בנחת, בגלל הבוז והלעג שעורר היריב הרפובליקאי גורג בוש.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	יוכל	יכול	AUX	AUX	Gender=Masc|Number=Sing|Person=2|Tense=Fut|VerbType=Mod	3	aux	_	_
-3	ללכת	הלך	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+3	ללכת	הלך	VERB	VERB	HebBinyan=PAAL|Root=ה.ל.כ|VerbForm=Inf|Voice=Act	0	root	_	_
 4-5	לשם	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	5	case	_	_
 5	שם	שם	ADV	ADV	_	3	obl	_	_
@@ -11792,7 +11792,7 @@
 14	לעג	לעג	NOUN	NOUN	Gender=Masc|Number=Sing	11	conj	_	_
 15-16	שעורר	_	_	_	_	_	_	_	_
 15	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
-16	עורר	עורר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	acl:relcl	_	_
+16	עורר	עורר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ע.ו.ר|Tense=Past|Voice=Act	11	acl:relcl	_	_
 17-18	היריב	_	_	_	_	_	_	_	_
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	יריב	יריב	NOUN	NOUN	Gender=Masc|Number=Sing	16	nsubj	_	_
@@ -11806,7 +11806,7 @@
 # sent_id = 349
 # text = ריצארדס הצחיקה מיליוני אמריקאים בנאום שזור עקיצות לגלגניות על בוש.
 1	ריצארדס	ריצארדס	PROPN	PROPN	_	2	nsubj	_	_
-2	הצחיקה	הצחיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	הצחיקה	הצחיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ח.ק|Tense=Past|Voice=Act	0	root	_	_
 3	מיליוני	מיליוני	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	4	nummod	_	_
 4	אמריקאים	אמריקני	NOUN	NOUN	Gender=Masc|Number=Plur	2	obj	_	_
 5-6	בנאום	_	_	_	_	_	_	_	_
@@ -11828,7 +11828,7 @@
 4	מסכן	מסכן	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
 5	"	"	PUNCT	PUNCT	_	2	punct	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	7	punct	_	_
-7	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	parataxis	_	_
+7	אמרה	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	2	parataxis	_	_
 8	ריצארדס	ריצארדס	PROPN	PROPN	_	7	nsubj	_	_
 9-11	בהגיה	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	11	case	_	_
@@ -11850,7 +11850,7 @@
 22	אשם	אשם	ADJ	ADJ	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	2	dep	_	SpaceAfter=No
 23	,	,	PUNCT	PUNCT	_	22	punct	_	_
 24	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	25	nsubj	_	_
-25	נולד	נולד	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	22	parataxis	_	_
+25	נולד	נולד	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.ל.ד|Tense=Past|Voice=Mid	22	parataxis	_	_
 26	עם	עם	ADP	ADP	_	27	case	_	_
 27	רגל	רגל	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	25	obl	_	_
 28	כסף	כסף	NOUN	NOUN	Gender=Masc|Number=Sing	27	compound:smixut	_	_
@@ -11869,7 +11869,7 @@
 4	הן	הן	ADV	ADV	_	5	advmod	_	_
 5-6	להיותו	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
-6	היותו	היות	VERB	VERB	Gender=Masc|Number=Sing	3	nmod	_	_
+6	היותו	היות	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Root=ה.י.י	3	nmod	_	_
 7	בן	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	acl	_	_
 8	טובים	טוב	NOUN	NOUN	Gender=Masc|Number=Plur	7	compound:smixut	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	6	punct	_	_
@@ -11881,11 +11881,11 @@
 13	יכולת_	יכולת	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	6	conj	_	_
 14	_של_	של	ADP	ADP	_	15	case:gen	_	_
 15	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nmod:poss	_	_
-16	יוצאת	יצא	VERB	VERB	Definite=Cons|Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	13	amod	_	_
+16	יוצאת	יצא	VERB	VERB	Definite=Cons|Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=י.צ.א|VerbForm=Part|Voice=Act	13	amod	_	_
 17-18	הדופן	_	_	_	_	_	_	_	_
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	דופן	דופן	NOUN	NOUN	Gender=Fem,Masc|Number=Sing	16	compound:smixut	_	_
-19	להגיד	הגיד	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	13	acl	_	_
+19	להגיד	הגיד	VERB	VERB	HebBinyan=HIFIL|Root=נ.ג.ד|VerbForm=Inf|Voice=Act	13	acl	_	_
 20	את	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 21-22	הדברים	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
@@ -11919,7 +11919,7 @@
 # sent_id = 352
 # text = בוש טען לימים כי ההתקפה ההיא נסכה בו את הנחישות להשיב לדמוקרטים במתקפת נגד, שזכר תוקפנותה מעורר עד עכשיו אי-נוחות ניכרת בין משקיפים פוליטים.
 1	בוש	בוש	PROPN	PROPN	_	2	dep	_	_
-2	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ט.ע.נ|Tense=Past|Voice=Act	0	root	_	_
 3-4	לימים	_	_	_	_	_	_	_	_
 3	ל	ל	ADP	ADP	_	4	case	_	_
 4	ימים	יום	NOUN	NOUN	Gender=Masc|Number=Plur	2	obl	_	_
@@ -11930,7 +11930,7 @@
 8-9	ההיא	_	_	_	_	_	_	_	_
 8	ה	ה	SCONJ	SCONJ	_	7	amod	_	_
 9	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	8	fixed	_	_
-10	נסכה	נסך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	ccomp	_	_
+10	נסכה	נסך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ס.כ|Tense=Past|Voice=Act	2	ccomp	_	_
 11-12	בו	_	_	_	_	_	_	_	_
 11	ב_	ב	ADP	ADP	_	12	case	_	_
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obl	_	_
@@ -11938,7 +11938,7 @@
 14-15	הנחישות	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	נחישות	נחישות	NOUN	NOUN	Gender=Fem|Number=Sing	10	obj	_	_
-16	להשיב	השיב	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	15	acl	_	_
+16	להשיב	השיב	VERB	VERB	HebBinyan=HIFIL|Root=ש.ו.ב|VerbForm=Inf|Voice=Act	15	acl	_	_
 17-19	לדמוקרטים	_	_	_	_	_	_	_	_
 17	ל	ל	ADP	ADP	_	19	case	_	_
 18	ה_	ה	DET	DET	PronType=Art	19	det:def	_	_
@@ -11955,7 +11955,7 @@
 26	תוקפנות_	תוקפנות	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	25	compound:smixut	_	_
 27	_של_	של	ADP	ADP	_	28	case:gen	_	_
 28	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	26	nmod:poss	_	_
-29	מעורר	עורר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	21	acl:relcl	_	_
+29	מעורר	עורר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ע.ו.ר|VerbForm=Part|Voice=Act	21	acl:relcl	_	_
 30	עד	עד	ADP	ADP	_	31	case	_	_
 31	עכשיו	עכשיו	ADV	ADV	_	29	obl	_	_
 32	אי	אי	ADV	ADV	HebSource=ConvUncertainHead|Prefix=Yes	34	compound:affix	_	SpaceAfter=No
@@ -11982,8 +11982,8 @@
 # sent_id = 354
 # text = כאשר החליטה להתמודד על מועמדות מפלגתה למושל, התייצבו נגדה שני דמוקרטים אחרים, שהפיצו ידיעות כי היא השתמשה בעבר בסמים.
 1	כאשר	כאשר	SCONJ	SCONJ	_	2	mark	_	_
-2	החליטה	החליט	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	12	advcl	_	_
-3	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	2	xcomp	_	_
+2	החליטה	החליט	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ל.ט|Tense=Past|Voice=Act	12	advcl	_	_
+3	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|Root=מ.ד.ד|VerbForm=Inf	2	xcomp	_	_
 4	על	על	ADP	ADP	_	5	case	_	_
 5	מועמדות	מועמדות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	obl	_	_
 6-8	מפלגתה	_	_	_	_	_	_	_	_
@@ -11994,7 +11994,7 @@
 9	ל	ל	ADP	ADP	_	10	case	_	_
 10	מושל	מושל	NOUN	NOUN	Gender=Masc|Number=Sing	5	nmod	_	_
 11	,	,	PUNCT	PUNCT	_	12	punct	_	_
-12	התייצבו	התייצב	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
+12	התייצבו	התייצב	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=י.צ.ב|Tense=Past	0	root	_	_
 13-14	נגדה	_	_	_	_	_	_	_	_
 13	נגד_	נגד	ADP	ADP	_	14	case	_	_
 14	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	12	obl	_	_
@@ -12004,11 +12004,11 @@
 18	,	,	PUNCT	PUNCT	_	16	punct	_	_
 19-20	שהפיצו	_	_	_	_	_	_	_	_
 19	ש	ש	SCONJ	SCONJ	_	20	mark	_	_
-20	הפיצו	הפיץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	16	acl:relcl	_	_
+20	הפיצו	הפיץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=פ.ו.צ|Tense=Past|Voice=Act	16	acl:relcl	_	_
 21	ידיעות	ידיעה	NOUN	NOUN	Gender=Fem|Number=Plur	20	obj	_	_
 22	כי	כי	SCONJ	SCONJ	_	24	mark	_	_
 23	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	24	nsubj	_	_
-24	השתמשה	השתמש	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	21	acl:relcl	_	_
+24	השתמשה	השתמש	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ש.מ.ש|Tense=Past	21	acl:relcl	_	_
 25-27	בעבר	_	_	_	_	_	_	_	_
 25	ב	ב	ADP	ADP	_	27	case	_	_
 26	ה_	ה	DET	DET	PronType=Art	27	det:def	_	_
@@ -12022,7 +12022,7 @@
 # text = ריצארדס לא טמנה את ידה בצלחת.
 1	ריצארדס	ריצארדס	PROPN	PROPN	_	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	טמנה	טמן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	טמנה	טמן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ט.מ.נ|Tense=Past|Voice=Act	0	root	_	_
 4	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 5-7	ידה	_	_	_	_	_	_	_	_
 5	יד_	יד	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	3	obj	_	_
@@ -12038,7 +12038,7 @@
 # text = היא אמנם יצאה מן המערכה הדמוקרטית בניצחון, אבל גם בשן ועין.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	אמנם	אמנם	ADV	ADV	_	3	advmod	_	_
-3	יצאה	יצא	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	יצאה	יצא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=י.צ.א|Tense=Past	0	root	_	_
 4	מן	מן	ADP	ADP	_	6	case	_	_
 5-6	המערכה	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -12067,7 +12067,7 @@
 2	ב	ב	ADP	ADP	_	3	case	_	_
 3	טקסס	טקסס	PROPN	PROPN	_	1	nmod	_	_
 4	לא	לא	ADV	ADV	Polarity=Neg	5	advmod	_	_
-5	פיקפק	_	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	פיקפק	_	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=פ.ק.פ.ק|Tense=Past|Voice=Act	0	root	_	_
 6-9	שיריבה	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
 7	יריב_	יריב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	21	nsubj	_	_
@@ -12086,7 +12086,7 @@
 18	איש	איש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	conj	_	_
 19	נפט	נפט	NOUN	NOUN	Gender=Masc|Number=Sing	18	compound:smixut	_	SpaceAfter=No
 20	,	,	PUNCT	PUNCT	_	21	punct	_	_
-21	יביס	הביס	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	5	ccomp	_	_
+21	יביס	הביס	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ב.ו.ס|Tense=Fut|Voice=Act	5	ccomp	_	_
 22-23	אותה	_	_	_	_	_	_	_	_
 22	את_	את	ADP	ADP	Case=Acc	23	case:acc	_	_
 23	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	21	obj	_	_
@@ -12098,7 +12098,7 @@
 # sent_id = 358
 # text = הוא הופיע בתשדירי הבחירות שלו רכוב על סוס, עם מגבעת רחבת תיתורת, ופרט על נימי המאציזמו הטקסני.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	הופיע	הופיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	הופיע	הופיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.פ.ע|Tense=Past|Voice=Act	0	root	_	_
 3-4	בתשדירי	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	תשדירי	תשדיר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	2	obl	_	_
@@ -12108,7 +12108,7 @@
 7-8	שלו	_	_	_	_	_	_	_	_
 7	של_	של	ADP	ADP	Case=Gen	8	case:gen	_	_
 8	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nmod:poss	_	_
-9	רכוב	רכב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainLabel|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	advmod	_	_
+9	רכוב	רכב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainLabel|Number=Sing|Person=1,2,3|Root=ר.כ.ב|VerbForm=Part|Voice=Act	2	advmod	_	_
 10	על	על	ADP	ADP	_	11	case	_	_
 11	סוס	סוס	NOUN	NOUN	Gender=Masc|Number=Sing	9	advmod	_	SpaceAfter=No
 12	,	,	PUNCT	PUNCT	_	2	punct	_	_
@@ -12119,7 +12119,7 @@
 17	,	,	PUNCT	PUNCT	_	2	punct	_	_
 18-19	ופרט	_	_	_	_	_	_	_	_
 18	ו	ו	CCONJ	CCONJ	_	19	cc	_	_
-19	פרט	פרט	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	2	conj	_	_
+19	פרט	פרט	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ר.ט|Tense=Past	2	conj	_	_
 20	על	על	ADP	ADP	_	21	case	_	_
 21	נימי	נים	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	19	obl	_	_
 22-23	המאציזמו	_	_	_	_	_	_	_	_
@@ -12134,8 +12134,8 @@
 # text = הוא גם התחיל למעוד מעידות מילוליות שערורייתיות.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	גם	גם	ADV	ADV	_	3	advmod	_	_
-3	התחיל	התחיל	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
-4	למעוד	מעד	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
+3	התחיל	התחיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ת.ח.ל|Tense=Past	0	root	_	_
+4	למעוד	מעד	VERB	VERB	HebBinyan=PAAL|Root=מ.ע.ד|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 5	מעידות	מעידה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obj	_	_
 6	מילוליות	מילולי	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	_
 7	שערורייתיות	שערורייתי	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	SpaceAfter=No
@@ -12144,7 +12144,7 @@
 # sent_id = 360
 # text = הוא יעץ לנשים, שאם הן נופלות קרבן לאונס והן חסרות אונים, "מוטב לשתוק וליהנות".
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	יעץ	יעץ	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+2	יעץ	יעץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=י.ע.צ|Tense=Past	0	root	_	_
 3-5	לנשים	_	_	_	_	_	_	_	SpaceAfter=No
 3	ל	ל	ADP	ADP	_	5	case	_	_
 4	ה_	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -12154,7 +12154,7 @@
 7	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
 8	אם	אם	SCONJ	SCONJ	_	10	mark	_	_
 9	הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	10	nsubj	_	_
-10	נופלות	נפל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	ccomp	_	_
+10	נופלות	נפל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=נ.פ.ל|VerbForm=Part|Voice=Act	2	ccomp	_	_
 11	קרבן	קרבן	NOUN	NOUN	Gender=Masc|Number=Sing	10	obj	_	_
 12-13	לאונס	_	_	_	_	_	_	_	_
 12	ל	ל	ADP	ADP	_	13	case	_	_
@@ -12167,17 +12167,17 @@
 18	,	,	PUNCT	PUNCT	_	10	punct	_	_
 19	"	"	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 20	מוטב	מוטב	AUX	AUX	HebSource=ConvUncertainHead|VerbType=Mod	21	aux	_	_
-21	לשתוק	שתק	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	10	dep	_	_
+21	לשתוק	שתק	VERB	VERB	HebBinyan=PAAL|Root=ש.ת.ק|VerbForm=Inf|Voice=Act	10	dep	_	_
 22-23	וליהנות	_	_	_	_	_	_	_	SpaceAfter=No
 22	ו	ו	CCONJ	CCONJ	_	23	cc	_	_
-23	ליהנות	נהנה	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	21	conj	_	_
+23	ליהנות	נהנה	VERB	VERB	HebBinyan=NIFAL|Root=ה.נ.י|VerbForm=Inf|Voice=Mid	21	conj	_	_
 24	"	"	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 25	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 361
 # text = הוא דיבר בפומבי על ניסיונו כאיש צעיר בבתי-בושת מקסיקאיים.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	דיבר	דיבר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	דיבר	דיבר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ד.ב.ר|Tense=Past|Voice=Act	0	root	_	_
 3-4	בפומבי	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	פומבי	פומבי	NOUN	NOUN	Gender=Masc|Number=Sing	2	obl	_	_
@@ -12201,8 +12201,8 @@
 # sent_id = 362
 # text = הוא סירב ללחוץ את ידה של ריצארדס ברבים, וקרא לה בפניה שקרנית".
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	סירב	סירב	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-3	ללחוץ	לחץ	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
+2	סירב	סירב	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ס.ר.ב|Tense=Past|Voice=Act	0	root	_	_
+3	ללחוץ	לחץ	VERB	VERB	HebBinyan=PAAL|Root=ל.ח.צ|VerbForm=Inf|Voice=Act	2	xcomp	_	_
 4	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 5-7	ידה	_	_	_	_	_	_	_	_
 5	יד_	יד	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	3	obj	_	_
@@ -12213,11 +12213,11 @@
 10-12	ברבים	_	_	_	_	_	_	_	SpaceAfter=No
 10	ב	ב	ADP	ADP	_	12	case	_	_
 11	ה_	ה	DET	DET	PronType=Art	12	det:def	_	_
-12	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	3	obl	_	_
+12	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ר.ב.י|VerbForm=Part|Voice=Act	3	obl	_	_
 13	,	,	PUNCT	PUNCT	_	2	punct	_	_
 14-15	וקרא	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
-15	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+15	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ר.א|Tense=Past|Voice=Act	2	conj	_	_
 16-17	לה	_	_	_	_	_	_	_	_
 16	ל_	ל	ADP	ADP	_	17	case	_	_
 17	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	15	obl	_	_
@@ -12234,22 +12234,22 @@
 # text = פעם אחרת שאל בחיוך גדול, האם חזרה להיות אלכוהוליסטית (ריצארדס הודתה שעברה טיפול נגד אלכוהוליזם בתקופה מסוימת של חייה).
 1	פעם	פעם	NOUN	NOUN	Gender=Fem|Number=Sing	3	dep	_	_
 2	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	_
-3	שאל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	שאל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.א.ל|Tense=Past|Voice=Act	0	root	_	_
 4-5	בחיוך	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	חיוך	חיוך	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
 6	גדול	גדול	ADJ	ADJ	Gender=Masc|Number=Sing	5	amod	_	SpaceAfter=No
 7	,	,	PUNCT	PUNCT	_	3	punct	_	_
 8	האם	האם	ADV	ADV	PronType=Int	9	mark:q	_	_
-9	חזרה	חזר	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	3	advcl	_	_
+9	חזרה	חזר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Past	3	advcl	_	_
 10	להיות	היה	AUX	AUX	Polarity=Pos|VerbForm=Inf|VerbType=Cop	9	xcomp	_	_
 11	אלכוהוליסטית	אלכוהוליסט	NOUN	NOUN	Gender=Fem|Number=Sing	10	obj	_	_
 12	(	(	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 13	ריצארדס	ריצארדס	PROPN	PROPN	_	14	nsubj	_	_
-14	הודתה	הודה	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	parataxis	_	_
+14	הודתה	הודה	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ד.י|Tense=Past|Voice=Act	3	parataxis	_	_
 15-16	שעברה	_	_	_	_	_	_	_	_
 15	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
-16	עברה	עבר	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	14	ccomp	_	_
+16	עברה	עבר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past	14	ccomp	_	_
 17	טיפול	טיפול	NOUN	NOUN	Gender=Masc|Number=Sing	16	obj	_	_
 18	נגד	נגד	ADP	ADP	_	19	case	_	_
 19	אלכוהוליזם	אלכוהוליזם	NOUN	NOUN	Gender=Masc|Number=Sing	17	nmod	_	_
@@ -12280,16 +12280,16 @@
 8	ב	ב	ADP	ADP	_	10	case	_	_
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	סקרים	סקר	NOUN	NOUN	Gender=Masc|Number=Plur	1	nmod	_	_
-11	פחת	פחת	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+11	פחת	פחת	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ח.ת|Tense=Past	0	root	_	_
 12-13	והלך	_	_	_	_	_	_	_	SpaceAfter=No
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
-13	הלך	הלך	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	11	conj	_	_
+13	הלך	הלך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ה.ל.כ|Tense=Past	11	conj	_	_
 14	,	,	PUNCT	PUNCT	_	11	punct	_	_
 15-17	והרפובליקאים	_	_	_	_	_	_	_	_
 15	ו	_	CCONJ	CCONJ	_	18	cc	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	רפובליקאים	_	NOUN	NOUN	_	18	nsubj	_	_
-18	מרטו	מרט	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	11	conj	_	_
+18	מרטו	מרט	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=מ.ר.ט|Tense=Past|Voice=Act	11	conj	_	_
 19-20	בייאוש	_	_	_	_	_	_	_	_
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	ייאוש	ייאוש	NOUN	NOUN	Gender=Masc|Number=Sing	18	obl	_	_
@@ -12303,17 +12303,17 @@
 # sent_id = 365
 # text = הם התחננו לפני ויליאמס לשתוק.
 1	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	2	nsubj	_	_
-2	התחננו	התחנן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
+2	התחננו	התחנן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=ח.נ.נ|Tense=Past	0	root	_	_
 3	לפני	לפני	ADP	ADP	_	4	case	_	_
 4	ויליאמס	ויליאמס	PROPN	PROPN	_	2	obl	_	_
-5	לשתוק	שתק	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	xcomp	_	SpaceAfter=No
+5	לשתוק	שתק	VERB	VERB	HebBinyan=PAAL|Root=ש.ת.ק|VerbForm=Inf|Voice=Act	2	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 366
 # text = הוא לא הצליח.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+3	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ל.ח|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 367
@@ -12321,7 +12321,7 @@
 1-2	בינואר	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	ינואר	ינואר	PROPN	PROPN	_	3	obl	_	_
-3	תקבל	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+3	תקבל	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Fut|Voice=Act	0	root	_	_
 4-7	לידיה	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	5	case	_	_
 5	יד_	יד	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	3	obl	_	_
@@ -12341,7 +12341,7 @@
 16	ביותר	ביותר	ADV	ADV	_	15	advmod	_	_
 17-18	שנמסרה	_	_	_	_	_	_	_	_
 17	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
-18	נמסרה	נמסר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	11	acl:relcl	_	_
+18	נמסרה	נמסר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.ס.ר|Tense=Past|Voice=Mid	11	acl:relcl	_	_
 19	אי	אי	ADV	ADV	Prefix=Yes	18	compound:affix	_	SpaceAfter=No
 20	-	-	PUNCT	PUNCT	_	19	fixed	_	SpaceAfter=No
 21	פעם	פעם	ADV	ADV	_	19	fixed	_	_
@@ -12374,7 +12374,7 @@
 16	-	-	PUNCT	PUNCT	_	17	punct	_	SpaceAfter=No
 17	יהודיה	יהודי	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	1	dep	_	SpaceAfter=No
 18	,	,	PUNCT	PUNCT	_	19	punct	_	_
-19	נוצחה	נוצח	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+19	נוצחה	נוצח	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Root=נ.צ.ח|Tense=Past|Voice=Pass	0	root	_	_
 20-21	בהפרש	_	_	_	_	_	_	_	_
 20	ב	ב	ADP	ADP	_	21	case	_	_
 21	הפרש	הפרש	NOUN	NOUN	Gender=Masc|Number=Sing	19	obl	_	_
@@ -12407,7 +12407,7 @@
 4	קיי	קיי	PROPN	PROPN	_	1	appos	_	_
 5	אור	אור	PROPN	PROPN	_	4	flat:name	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	7	punct	_	_
-7	איבדה	איבד	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	איבדה	איבד	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=א.ב.ד|Tense=Past|Voice=Act	0	root	_	_
 8	את	את	ADP	ADP	Case=Acc	9	case:acc	_	_
 9	כהונת	כהונה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	obj	_	_
 10-11	המושלת	_	_	_	_	_	_	_	_
@@ -12436,7 +12436,7 @@
 7	יהודייה	יהודי	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	1	dep	_	_
 8	מלאה	מלא	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	10	punct	_	_
-10	סיימה	סיים	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+10	סיימה	סיים	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ס.י.מ|Tense=Past|Voice=Act	0	root	_	_
 11	שש	שש	NUM	NUM	Gender=Fem|Number=Sing	12	nummod	_	_
 12	שנות	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	10	obj	_	_
 13	כהונה	כהונה	NOUN	NOUN	Gender=Fem|Number=Sing	12	compound:smixut	_	_
@@ -12448,7 +12448,7 @@
 18-19	ולא	_	_	_	_	_	_	_	_
 18	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
 19	לא	לא	ADV	ADV	Polarity=Neg	20	advmod	_	_
-20	העמידה	העמיד	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	conj	_	_
+20	העמידה	העמיד	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ע.מ.ד|Tense=Past|Voice=Act	10	conj	_	_
 21	את	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 22	עצמה	עצמו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	20	obj	_	_
 23-24	לבחירה	_	_	_	_	_	_	_	_
@@ -12460,11 +12460,11 @@
 # sent_id = 371
 # text = נשים הפתיעו, ונבחרו למושלות במדינת קנזאס ובמדינת אורגון.
 1	נשים	איש	NOUN	NOUN	Gender=Fem|Number=Plur	2	nsubj	_	_
-2	הפתיעו	הפתיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+2	הפתיעו	הפתיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=פ.ת.ע|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	PUNCT	_	2	punct	_	_
 4-5	ונבחרו	_	_	_	_	_	_	_	_
 4	ו	ו	CCONJ	CCONJ	_	5	cc	_	_
-5	נבחרו	נבחר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	2	conj	_	_
+5	נבחרו	נבחר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ב.ח.ר|Tense=Past|Voice=Mid	2	conj	_	_
 6-7	למושלות	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	מושלות	מושל	NOUN	NOUN	Gender=Fem|Number=Plur	5	obl	_	_
@@ -12485,7 +12485,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	סך	סך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
 3	הכול	הכול	NOUN	NOUN	_	2	compound:smixut	_	_
-4	יהיו	היה	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
+4	יהיו	היה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	0	root	_	_
 5	איפוא	אפוא	ADV	ADV	_	4	advmod	_	_
 6-7	בינואר	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
@@ -12510,8 +12510,8 @@
 2	אשה	איש	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
 3	אחת	אחת	NUM	NUM	Gender=Fem|Number=Sing	2	nummod	_	_
 4	לא	לא	ADV	ADV	Polarity=Neg	5	advmod	_	_
-5	הצליחה	הצליח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-6	להיבחר	נבחר	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	5	xcomp	_	_
+5	הצליחה	הצליח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ל.ח|Tense=Past|Voice=Act	0	root	_	_
+6	להיבחר	נבחר	VERB	VERB	HebBinyan=NIFAL|Root=ב.ח.ר|VerbForm=Inf|Voice=Mid	5	xcomp	_	_
 7	השנה	השנה	ADV	ADV	_	6	advmod	_	_
 8-10	לסנאט	_	_	_	_	_	_	_	SpaceAfter=No
 8	ל	ל	ADP	ADP	_	10	case	_	_
@@ -12523,7 +12523,7 @@
 # text = לעומת זאת נשמרה רמת הייצוג היהודי.
 1	לעומת	לעומת	ADP	ADP	_	2	case	_	_
 2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	obl	_	_
-3	נשמרה	נשמר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+3	נשמרה	נשמר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.מ.ר|Tense=Past|Voice=Mid	0	root	_	_
 4	רמת	רמה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	nsubj	_	_
 5-6	הייצוג	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -12539,7 +12539,7 @@
 2-3	הבחירות	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	בחירות	בחירות	NOUN	NOUN	Gender=Fem|Number=Plur	4	obl	_	_
-4	היו	היה	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+4	היו	היה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 5	שבעה	שבעה	NUM	NUM	Gender=Masc|Number=Sing	6	nummod	_	_
 6	סנאטורים	סנטור	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	SpaceAfter=No
 7	,	,	PUNCT	PUNCT	_	4	punct	_	_
@@ -12570,7 +12570,7 @@
 10	מדינת	מדינה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	8	obl	_	_
 11	מינסוטה	מינסוטה	PROPN	PROPN	_	10	compound:smixut	_	SpaceAfter=No
 12	,	,	PUNCT	PUNCT	_	13	punct	_	_
-13	נוצח	נוצח	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+13	נוצח	נוצח	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=נ.צ.ח|Tense=Past|Voice=Pass	0	root	_	_
 14-16	בבחירות	_	_	_	_	_	_	_	SpaceAfter=No
 14	ב	ב	ADP	ADP	_	16	case	_	_
 15	ה_	ה	DET	DET	PronType=Art	16	det:def	_	_
@@ -12582,7 +12582,7 @@
 20	מקום_	מקום	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	23	obj	_	_
 21	_של_	של	ADP	ADP	_	22	case:gen	_	_
 22	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nmod:poss	_	_
-23	תופס	תפס	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	13	conj	_	_
+23	תופס	תפס	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ת.פ.ס|VerbForm=Part|Voice=Act	13	conj	_	_
 24	יהודי	יהודי	NOUN	NOUN	Gender=Masc|Number=Sing	23	nsubj	_	_
 25	אחר	אחר	ADJ	ADJ	Gender=Masc|Number=Sing	24	amod	_	_
 26-27	ממינסוטה	_	_	_	_	_	_	_	SpaceAfter=No
@@ -12601,7 +12601,7 @@
 3	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	nmod:poss	_	_
 4	של	של	ADP	ADP	Case=Gen	5	case:gen	_	_
 5	וולסטון	וולסטון	PROPN	PROPN	_	1	nmod:poss	_	_
-6	נעשתה	נעשה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+6	נעשתה	נעשה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Mid	0	root	_	_
 7	נושא	נושא	NOUN	NOUN	Gender=Masc|Number=Sing	6	obl	_	_
 8	מרכזי	מרכזי	ADJ	ADJ	Gender=Masc|Number=Sing	7	amod	_	_
 9-10	בשלושת	_	_	_	_	_	_	_	_
@@ -12623,13 +12623,13 @@
 # sent_id = 378
 # text = בושוויץ ניסה לשכנע יהודים במינסוטה להצביע נגד וולסטון, באשר אין הוא יהודי נאמן, וילדיו אינם גדלים כיהודים.
 1	בושוויץ	בושוויץ	PROPN	PROPN	_	2	nsubj	_	_
-2	ניסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-3	לשכנע	שכנע	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
+2	ניסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.ס.י|Tense=Past|Voice=Act	0	root	_	_
+3	לשכנע	שכנע	VERB	VERB	HebBinyan=PIEL|Root=ש.כ.נ.ע|VerbForm=Inf|Voice=Act	2	xcomp	_	_
 4	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	3	obj	_	_
 5-6	במינסוטה	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	מינסוטה	מינסוטה	PROPN	PROPN	_	4	nmod	_	_
-7	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	3	dep	_	_
+7	להצביע	הצביע	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|Root=צ.ב.ע|VerbForm=Inf|Voice=Act	3	dep	_	_
 8	נגד	נגד	ADP	ADP	_	9	case	_	_
 9	וולסטון	וולסטון	PROPN	PROPN	HebSource=ConvUncertainHead	7	dep	_	SpaceAfter=No
 10	,	,	PUNCT	PUNCT	HebSource=ConvUncertainHead	7	dep	_	_
@@ -12645,7 +12645,7 @@
 19	_של_	של	ADP	ADP	_	20	case:gen	_	_
 20	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	nmod:poss	_	_
 21	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	22	advmod	_	_
-22	גדלים	גדל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	14	conj	_	_
+22	גדלים	גדל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ג.ד.ל|VerbForm=Part|Voice=Act	14	conj	_	_
 23-24	כיהודים	_	_	_	_	_	_	_	SpaceAfter=No
 23	כ	כ	ADP	ADP	_	24	case	_	_
 24	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	22	obl	_	_
@@ -12658,7 +12658,7 @@
 3-4	במינסוטה	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	מינסוטה	מינסוטה	PROPN	PROPN	_	1	nmod	_	_
-5	העריכו	העריך	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	העריכו	העריך	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ע.ר.כ|Tense=Past|Voice=Act	0	root	_	_
 6-7	ביום	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	יום	יום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
@@ -12692,7 +12692,7 @@
 2-3	ההתקפה	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	התקפה	התקפה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
-4	הוביל	הוביל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	הוביל	הוביל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ב.ל|Tense=Past|Voice=Act	0	root	_	_
 5	בושוויץ	בושוויץ	PROPN	PROPN	_	4	nsubj	_	_
 6-7	ביתרון	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
@@ -12707,7 +12707,7 @@
 1	בתוך	בתוך	ADP	ADP	_	3	case	_	_
 2	84	84	NUM	NUM	_	3	nummod	_	_
 3	שעות	שעה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obl	_	_
-4	התפוגג	התפוגג	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+4	התפוגג	התפוגג	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=פ.ו.ג|Tense=Past	0	root	_	_
 5-6	היתרון	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	יתרון	יתרון	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
@@ -12725,14 +12725,14 @@
 6	לפני	לפני	ADP	ADP	_	8	mark	_	_
 7-8	שהודה	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	6	fixed	_	_
-8	הודה	הודה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	14	advcl	_	_
+8	הודה	הודה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ד.י|Tense=Past|Voice=Act	14	advcl	_	_
 9-12	בתבוסתו	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	תבוסה_	תבוסה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	8	obl	_	_
 11	_של_	של	ADP	ADP	_	12	case:gen	_	_
 12	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nmod:poss	_	_
 13	,	,	PUNCT	PUNCT	_	14	punct	_	_
-14	הופיע	הופיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+14	הופיע	הופיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.פ.ע|Tense=Past|Voice=Act	0	root	_	_
 15	בושוויץ	בושוויץ	PROPN	PROPN	_	14	nsubj	_	_
 16-17	בשידור	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
@@ -12740,7 +12740,7 @@
 18	טלוויזיה	טלוויזיה	NOUN	NOUN	Gender=Fem|Number=Sing	17	compound:smixut	_	_
 19-20	והטיל	_	_	_	_	_	_	_	_
 19	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
-20	הטיל	הטיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	14	conj	_	_
+20	הטיל	הטיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ט.ל|Tense=Past|Voice=Act	14	conj	_	_
 21	את	את	ADP	ADP	Case=Acc	23	case:acc	_	_
 22-23	האשמה	_	_	_	_	_	_	_	_
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
@@ -12761,10 +12761,10 @@
 # text = הוא לא חשב שהיה משהו פגום בהתנהגותו שלו.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	חשב	חשב	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	חשב	חשב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ש.ב|Tense=Past	0	root	_	_
 4-5	שהיה	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	היה	היה	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	ccomp	_	_
+5	היה	היה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	3	ccomp	_	_
 6	משהו	משהו	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
 7	פגום	פגום	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
 8-11	בהתנהגותו	_	_	_	_	_	_	_	_
@@ -12793,8 +12793,8 @@
 9	אוניברסיטה	אוניברסיטה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nmod	_	_
 10	מקומית	מקומי	ADJ	ADJ	Gender=Fem|Number=Sing	9	amod	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	12	punct	_	_
-12	השכיל	השכיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-13	לנצל	ניצל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	12	xcomp	_	_
+12	השכיל	השכיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ש.כ.ל|Tense=Past|Voice=Act	0	root	_	_
+13	לנצל	ניצל	VERB	VERB	HebBinyan=PIEL|Root=נ.צ.ל|VerbForm=Inf|Voice=Act	12	xcomp	_	_
 14	מצב	מצב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	13	obj	_	_
 15	רוח	רוח	NOUN	NOUN	Gender=Fem|Number=Sing	14	compound:smixut	_	_
 16	לאומי	לאומי	ADJ	ADJ	Gender=Masc|Number=Sing	14	amod	_	_
@@ -12816,7 +12816,7 @@
 4-5	שלו	_	_	_	_	_	_	_	_
 4	של_	של	ADP	ADP	Case=Gen	5	case:gen	_	_
 5	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	nmod:poss	_	_
-6	תוארו	תואר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+6	תוארו	תואר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=ת.א.ר|Tense=Past|Voice=Pass	0	root	_	_
 7-9	כשנונים	_	_	_	_	_	_	_	_
 7	כ	כ	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -12843,9 +12843,9 @@
 1-2	באחד	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	אחד	אחד	NUM	NUM	Gender=Masc|Number=Sing	3	obl	_	_
-3	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+3	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ר.א.י|Tense=Past|Voice=Mid	0	root	_	_
 4	וולסטון	וולסטון	PROPN	PROPN	_	3	nsubj	_	_
-5	מחפש	חיפש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	advcl	_	_
+5	מחפש	חיפש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ח.פ.ש|VerbForm=Part|Voice=Act	3	advcl	_	_
 6	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 7	רודי	רודי	PROPN	PROPN	_	5	obj	_	_
 8	בושוויץ	בושוויץ	PROPN	PROPN	_	7	flat:name	_	_
@@ -12857,7 +12857,7 @@
 14-15	בניסיון	_	_	_	_	_	_	_	_
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	ניסיון	ניסיון	NOUN	NOUN	Gender=Masc|Number=Sing	5	obl	_	_
-16	לקיים	קיים	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	15	acl	_	_
+16	לקיים	קיים	VERB	VERB	HebBinyan=PIEL|Root=ק.י.מ|VerbForm=Inf|Voice=Act	15	acl	_	_
 17-18	אתו	_	_	_	_	_	_	_	_
 17	אתו	את	ADP	ADP	_	18	case	_	_
 18	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	obl	_	_
@@ -12872,8 +12872,8 @@
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	שני	שני	NOUN	NOUN	Gender=Masc|Number=Sing	5	obl	_	_
 4	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
-5	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
-6	רץ	רץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	obl	_	_
+5	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ר.א.י|Tense=Past|Voice=Mid	0	root	_	_
+6	רץ	רץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.ו.צ|VerbForm=Part|Voice=Act	5	obl	_	_
 7-8	בקפיצות	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	קפיצות	קפיצה	NOUN	NOUN	Gender=Fem|Number=Plur	6	obl	_	_
@@ -12890,7 +12890,7 @@
 18	,	,	PUNCT	PUNCT	_	6	punct	_	_
 19-20	ומתנצל	_	_	_	_	_	_	_	_
 19	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
-20	מתנצל	התנצל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	6	conj	_	_
+20	מתנצל	התנצל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=נ.צ.ל|VerbForm=Part	6	conj	_	_
 21-22	שאין	_	_	_	_	_	_	_	_
 21	ש	ש	SCONJ	SCONJ	_	22	mark	_	_
 22	אין	אין	VERB	VERB	HebExistential=True	20	ccomp	_	_
@@ -12898,7 +12898,7 @@
 23	ל_	ל	ADP	ADP	_	24	case	_	_
 24	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	22	obl	_	_
 25	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	22	nsubj	_	_
-26	ללכת	הלך	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	25	acl	_	_
+26	ללכת	הלך	VERB	VERB	HebBinyan=PAAL|Root=ה.ל.כ|VerbForm=Inf|Voice=Act	25	acl	_	_
 27-28	בנחת	_	_	_	_	_	_	_	_
 27	ב	ב	ADP	ADP	_	28	case	_	_
 28	נחת	נחת	NOUN	NOUN	Gender=Fem|Number=Sing	26	obl	_	_
@@ -12912,15 +12912,15 @@
 34-35	שלו	_	_	_	_	_	_	_	_
 34	של_	של	ADP	ADP	Case=Gen	35	case:gen	_	_
 35	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	31	nmod:poss	_	_
-36	עומד	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	22	advcl	_	_
-37	להיגמר	נגמר	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	36	xcomp	_	SpaceAfter=No
+36	עומד	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ע.מ.ד|VerbForm=Part|Voice=Act	22	advcl	_	_
+37	להיגמר	נגמר	VERB	VERB	HebBinyan=NIFAL|Root=ג.מ.ר|VerbForm=Inf|Voice=Mid	36	xcomp	_	SpaceAfter=No
 38	.	.	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 389
 # text = בושוויץ לא סבל מבעיות כאלה.
 1	בושוויץ	בושוויץ	PROPN	PROPN	_	3	dep	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	סבל	סבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	סבל	סבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ס.ב.ל|Tense=Past|Voice=Act	0	root	_	_
 4-5	מבעיות	_	_	_	_	_	_	_	_
 4	מ	מ	ADP	ADP	_	5	case	_	_
 5	בעיות	בעיה	NOUN	NOUN	Gender=Fem|Number=Plur	3	obl	_	_
@@ -12941,7 +12941,7 @@
 6	ה	ה	SCONJ	SCONJ	_	7	mark	_	_
 7	מסוגל	מסוגל	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	9	aux	_	_
 8	תמיד	תמיד	ADV	ADV	_	7	advmod	_	_
-9	להלוות	הלווה	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	4	acl:relcl	_	_
+9	להלוות	הלווה	VERB	VERB	HebBinyan=HIFIL|Root=ל.ו.י|VerbForm=Inf|Voice=Act	4	acl:relcl	_	_
 10-11	לעצמו	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	11	case	_	_
 11	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	9	obl	_	_
@@ -12965,8 +12965,8 @@
 10-11	כסנאטור	_	_	_	_	_	_	_	_
 10	כ	כ	ADP	ADP	_	11	case	_	_
 11	סנאטור	סנטור	NOUN	NOUN	Gender=Masc|Number=Sing	7	nmod	_	_
-12	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-13	לאסוף	אסף	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	12	xcomp	_	_
+12	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ל.ח|Tense=Past|Voice=Act	0	root	_	_
+13	לאסוף	אסף	VERB	VERB	HebBinyan=PAAL|Root=א.ס.פ|VerbForm=Inf|Voice=Act	12	xcomp	_	_
 14	תרומות	תרומה	NOUN	NOUN	Gender=Fem|Number=Plur	13	obj	_	_
 15	של	של	ADP	ADP	Case=Gen	18	case:gen	_	_
 16	7	7	NUM	NUM	_	17	nummod	_	_
@@ -12991,10 +12991,10 @@
 10	השבוע	השבוע	ADV	ADV	_	4	advmod	_	_
 11-12	שהצליח	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-12	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	acl:relcl	_	_
-13	להביס	הביס	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	12	xcomp	_	_
+12	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ל.ח|Tense=Past|Voice=Act	4	acl:relcl	_	_
+13	להביס	הביס	VERB	VERB	HebBinyan=HIFIL|Root=ב.ו.ס|VerbForm=Inf|Voice=Act	12	xcomp	_	_
 14	סנאטור	סנטור	NOUN	NOUN	Gender=Masc|Number=Sing	13	obj	_	_
-15	מכהן	כיהן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	14	amod	_	SpaceAfter=No
+15	מכהן	כיהן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=כ.ה.נ|VerbForm=Part|Voice=Act	14	amod	_	SpaceAfter=No
 16	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 393
@@ -13018,14 +13018,14 @@
 15	כמה	כמה	DET	DET	Definite=Cons	16	det	_	_
 16	מירוצים	מירוץ	NOUN	NOUN	Gender=Masc|Number=Plur	18	obl	_	_
 17	לא	לא	ADV	ADV	Polarity=Neg	18	advmod	_	_
-18	טרחה	טרח	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	advcl	_	_
+18	טרחה	טרח	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ט.ר.ח|Tense=Past|Voice=Act	10	advcl	_	_
 19-20	המפלגה	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	מפלגה	מפלגה	NOUN	NOUN	Gender=Fem|Number=Sing	18	nsubj	_	_
 21-22	היריבה	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	יריבה	יריב	ADJ	ADJ	Gender=Fem|Number=Sing	20	amod	_	_
-23	להציג	הציג	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	18	xcomp	_	_
+23	להציג	הציג	VERB	VERB	HebBinyan=HIFIL|Root=י.צ.ג|VerbForm=Inf|Voice=Act	18	xcomp	_	_
 24	אפילו	אפילו	CCONJ	CCONJ	_	25	det	_	_
 25	מועמד	מועמד	NOUN	NOUN	Gender=Masc|Number=Sing	23	obj	_	_
 26	נומינלי	נומינלי	ADJ	ADJ	Gender=Masc|Number=Sing	25	amod	_	SpaceAfter=No
@@ -13039,13 +13039,13 @@
 3	צירי	ציר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	1	conj	_	_
 4	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	3	compound:smixut	_	_
 5	נבחרים	נבחר	NOUN	NOUN	Gender=Masc|Number=Plur	4	compound:smixut	_	_
-6	מנצלים	ניצל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+6	מנצלים	ניצל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=נ.צ.ל|VerbForm=Part|Voice=Act	0	root	_	_
 7	את	את	ADP	ADP	Case=Acc	9	case:acc	_	_
 8-9	הכהונה	_	_	_	_	_	_	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	כהונה	כהונה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obj	_	_
 10	כדי	כדי	ADP	ADP	_	11	case	_	_
-11	לאסוף	אסף	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	6	advcl	_	_
+11	לאסוף	אסף	VERB	VERB	HebBinyan=PAAL|Root=א.ס.פ|VerbForm=Inf|Voice=Act	6	advcl	_	_
 12	כמויות	כמות	NOUN	NOUN	Gender=Fem|Number=Plur	11	obj	_	_
 13	עצומות	עצום	ADJ	ADJ	Gender=Fem|Number=Plur	12	amod	_	_
 14	של	של	ADP	ADP	Case=Gen	15	case:gen	_	_
@@ -13053,7 +13053,7 @@
 16	,	,	PUNCT	PUNCT	_	11	punct	_	_
 17-18	ולהטביע	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
-18	להטביע	הטביע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	11	conj	_	_
+18	להטביע	הטביע	VERB	VERB	HebBinyan=HIFIL|Root=ט.ב.ע|VerbForm=Inf|Voice=Act	11	conj	_	_
 19-20	בהן	_	_	_	_	_	_	_	_
 19	ב_	ב	ADP	ADP	_	20	case	_	_
 20	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	18	obl	_	_
@@ -13100,7 +13100,7 @@
 29-30	לדין	_	_	_	_	_	_	_	_
 29	ל	ל	ADP	ADP	_	30	case	_	_
 30	דין	דין	NOUN	NOUN	Gender=Masc|Number=Sing	24	nmod	_	_
-31	תגרום	גרם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	7	acl:relcl	_	_
+31	תגרום	גרם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ג.ר.מ|Tense=Fut|Voice=Act	7	acl:relcl	_	_
 32	נזק	נזק	NOUN	NOUN	Gender=Masc|Number=Sing	31	obj	_	_
 33	ציבורי	ציבורי	ADJ	ADJ	Gender=Masc|Number=Sing	32	amod	_	SpaceAfter=No
 34	.	.	PUNCT	PUNCT	_	1	punct	_	_
@@ -13136,7 +13136,7 @@
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	20	compound:smixut	_	_
 23	,	,	PUNCT	PUNCT	_	24	punct	_	_
-24	נמלט	נמלט	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+24	נמלט	נמלט	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.ל.ט|Tense=Past|Voice=Mid	0	root	_	_
 25-28	מארצו	_	_	_	_	_	_	_	_
 25	מ	מ	ADP	ADP	_	26	case	_	_
 26	ארץ_	ארץ	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	24	obl	_	_
@@ -13157,7 +13157,7 @@
 3	פנים_	פנים	NOUN	NOUN	Definite=Def|Gender=Fem,Masc|Number=Plur	6	obl	_	_
 4	_של_	של	ADP	ADP	_	5	case:gen	_	_
 5	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nmod:poss	_	_
-6	נידון	נידון	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+6	נידון	נידון	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ד.ו.נ|Tense=Past|Voice=Mid	0	root	_	_
 7-9	למוות	_	_	_	_	_	_	_	SpaceAfter=No
 7	ל	ל	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -13168,11 +13168,11 @@
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	15	nsubj	_	_
 14	לא	לא	ADV	ADV	Polarity=Neg	15	advmod	_	_
-15	הפריע	הפריע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	conj	_	_
+15	הפריע	הפריע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=פ.ר.ע|Tense=Past|Voice=Act	6	conj	_	_
 16-17	לו	_	_	_	_	_	_	_	_
 16	ל_	ל	ADP	ADP	_	17	case	_	_
 17	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	obl	_	_
-18	לחיות	חי	VERB	VERB	VerbForm=Inf	15	xcomp	_	_
+18	לחיות	חי	VERB	VERB	HebBinyan=PAAL|Root=ח.י.י|VerbForm=Inf	15	xcomp	_	_
 19-20	בגלות	_	_	_	_	_	_	_	_
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	גלות	גלות	NOUN	NOUN	Gender=Fem|Number=Sing	18	obl	_	_
@@ -13187,7 +13187,7 @@
 1-2	ב8791	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	8791	8791	NUM	NUM	_	3	obl	_	_
-3	הכריז	הכריז	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הכריז	הכריז	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=כ.ר.ז|Tense=Past|Voice=Act	0	root	_	_
 4-5	בראיון	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	ראיון	ראיון	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
@@ -13206,13 +13206,13 @@
 16-17	באושוויץ	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	אושוויץ	אושוויץ	PROPN	PROPN	_	18	obl	_	_
-18	עסקו	עסק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	3	ccomp	_	_
+18	עסקו	עסק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ס.ק|Tense=Past|Voice=Act	3	ccomp	_	_
 19-20	הנאצים	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	נאצים	נאצי	NOUN	NOUN	Gender=Masc|Number=Plur	18	nsubj	_	_
 21-22	בהגזה	_	_	_	_	_	_	_	SpaceAfter=No
 21	ב	ב	ADP	ADP	_	22	case	_	_
-22	הגזה	_	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	18	obl	_	_
+22	הגזה	_	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=_|VerbForm=Part|Voice=Act	18	obl	_	_
 23	,	,	PUNCT	PUNCT	_	22	punct	_	_
 24	אך	אך	CCONJ	CCONJ	_	27	cc	_	_
 25	לא	לא	ADV	ADV	Polarity=Neg	26	advmod	_	_
@@ -13233,7 +13233,7 @@
 # sent_id = 399
 # text = הוא מת לפני כמה שנים בספרד.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	מת	מת	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	מת	מת	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.ו.ת|Tense=Past|Voice=Act	0	root	_	_
 3	לפני	לפני	ADP	ADP	_	5	case	_	_
 4	כמה	כמה	DET	DET	Definite=Cons	5	det	_	_
 5	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	2	obl	_	_
@@ -13246,7 +13246,7 @@
 # text = הוא לא הטריד את הממסד הצרפתי בהצהרות מביכות, ושלטונות צרפת לא טרחו שיוסגר לידיהם לצורך העמדתו לדין.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	הטריד	הטריד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הטריד	הטריד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ט.ר.ד|Tense=Past|Voice=Act	0	root	_	_
 4	את	את	ADP	ADP	Case=Acc	6	case:acc	_	_
 5-6	הממסד	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -13264,10 +13264,10 @@
 14	שלטונות	שלטון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	17	nsubj	_	_
 15	צרפת	צרפת	PROPN	PROPN	_	14	compound:smixut	_	_
 16	לא	לא	ADV	ADV	Polarity=Neg	17	advmod	_	_
-17	טרחו	טרח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	3	conj	_	_
+17	טרחו	טרח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ט.ר.ח|Tense=Past|Voice=Act	3	conj	_	_
 18-19	שיוסגר	_	_	_	_	_	_	_	_
 18	ש	ש	SCONJ	SCONJ	_	19	mark	_	_
-19	יוסגר	הוסגר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	17	ccomp	_	_
+19	יוסגר	הוסגר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ס.ג.ר|Tense=Fut|Voice=Pass	17	ccomp	_	_
 20-23	לידיהם	_	_	_	_	_	_	_	_
 20	ל	ל	ADP	ADP	_	21	case	_	_
 21	יד_	יד	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	19	obl	_	_
@@ -13291,14 +13291,14 @@
 2	פרשיות	פרשייה	NOUN	NOUN	Gender=Fem|Number=Plur	12	nsubj	_	_
 3	אחרות	אחר	ADJ	ADJ	Gender=Fem|Number=Plur	2	amod	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	2	punct	_	_
-5	נוסף	נוסף	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	7	case	_	_
+5	נוסף	נוסף	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=י.ס.פ|VerbForm=Part	7	case	_	_
 6	על	על	ADP	ADP	_	5	fixed	_	_
 7	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	nmod	_	_
 8	של	של	ADP	ADP	Case=Gen	9	case:gen	_	_
 9	רנה	רנה	PROPN	PROPN	_	7	nmod:poss	_	_
 10	בוסקה	בוסקה	PROPN	PROPN	_	9	flat:name	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	12	punct	_	_
-12	נמצאות	נמצא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+12	נמצאות	נמצא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=מ.צ.א|VerbForm=Part|Voice=Mid	0	root	_	_
 13	אף	אף	CCONJ	CCONJ	_	14	det	_	_
 14	הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	12	dep	_	_
 15	כיום	כיום	ADV	ADV	_	12	advmod	_	_
@@ -13309,7 +13309,7 @@
 19	מוקדם	מוקדם	ADJ	ADJ	Gender=Masc|Number=Sing	17	amod	_	_
 20-21	שנמשך	_	_	_	_	_	_	_	_
 20	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
-21	נמשך	נמשך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	17	acl:relcl	_	_
+21	נמשך	נמשך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.ש.כ|Tense=Past|Voice=Mid	17	acl:relcl	_	_
 22	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	21	obj	_	_
 23	רב	רב	ADJ	ADJ	Gender=Masc|Number=Sing	22	amod	_	SpaceAfter=No
 24	:	:	PUNCT	PUNCT	_	12	punct	_	_
@@ -13332,7 +13332,7 @@
 3-4	שכאמור	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
 4	כאמור	_	ADV	ADV	_	5	advmod	_	_
-5	שימש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	1	acl:relcl	_	_
+5	שימש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.מ.ש|Tense=Past|Voice=Act	1	acl:relcl	_	_
 6	ממונה	ממונה	NOUN	NOUN	Gender=Masc|Number=Sing	5	obj	_	_
 7	על	על	ADP	ADP	_	8	case	_	_
 8	מחוז	מחוז	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	nmod	_	_
@@ -13344,7 +13344,7 @@
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	מלחמה	מלחמה	NOUN	NOUN	Gender=Fem|Number=Sing	11	compound:smixut	_	_
 14	,	,	PUNCT	PUNCT	_	15	punct	_	_
-15	הורה	הורה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+15	הורה	הורה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ר.י|Tense=Past|Voice=Act	0	root	_	_
 16	על	על	ADP	ADP	_	17	case	_	_
 17	ביצוע	ביצוע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	15	obl	_	_
 18-19	האקציות	_	_	_	_	_	_	_	_
@@ -13384,7 +13384,7 @@
 # text = מאוחר יותר שימש שר בממשלת ריימון באר בימי נשיאותו של ואלרי זיסקאר-דאסטאן.
 1	מאוחר	מאוחר	ADV	ADV	_	3	advmod	_	_
 2	יותר	יותר	ADV	ADV	HebSource=ConvUncertainHead	1	fixed	_	_
-3	שימש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	שימש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.מ.ש|Tense=Past|Voice=Act	0	root	_	_
 4	שר	שר	NOUN	NOUN	Gender=Masc|Number=Sing	3	obj	_	_
 5-6	בממשלת	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
@@ -13415,11 +13415,11 @@
 5	חקירה	חקירה	NOUN	NOUN	Gender=Fem|Number=Sing	8	obl	_	_
 6	מחודשת	מחודש	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	SpaceAfter=No
 7	,	,	PUNCT	PUNCT	_	8	punct	_	_
-8	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+8	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ק.ב.ע|Tense=Past|Voice=Mid	0	root	_	_
 9	כי	כי	SCONJ	SCONJ	_	10	mark	_	_
 10	יש	יש	VERB	VERB	HebExistential=True	8	ccomp	_	_
 11	מקום	מקום	NOUN	NOUN	Gender=Masc|Number=Sing	10	nsubj	_	_
-12	להגיש	הגיש	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	11	acl	_	_
+12	להגיש	הגיש	VERB	VERB	HebBinyan=HIFIL|Root=נ.ג.ש|VerbForm=Inf|Voice=Act	11	acl	_	_
 13-14	נגדו	_	_	_	_	_	_	_	_
 13	נגד_	נגד	ADP	ADP	_	14	case	_	_
 14	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	obl	_	_
@@ -13447,7 +13447,7 @@
 1-2	ב4891	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	4891	4891	NUM	NUM	_	3	obl	_	_
-3	הודיע	הודיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הודיע	הודיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ד.ע|Tense=Past|Voice=Act	0	root	_	_
 4-5	לו	_	_	_	_	_	_	_	_
 4	ל_	ל	ADP	ADP	_	5	case	_	_
 5	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	obl	_	_
@@ -13455,7 +13455,7 @@
 7	-	-	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 8	חוקר	חוקר	NOUN	NOUN	Gender=Masc|Number=Sing	6	nmod	_	_
 9	כי	כי	SCONJ	SCONJ	_	10	mark	_	_
-10	הוגשו	הוגש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	3	ccomp	_	_
+10	הוגשו	הוגש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Pass	3	ccomp	_	_
 11-12	נגדו	_	_	_	_	_	_	_	_
 11	נגד_	נגד	ADP	ADP	_	12	case	_	_
 12	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obl	_	_
@@ -13467,7 +13467,7 @@
 # text = עד היום נמצאות תלונות הללו בשלב מוקדם של דיון בפני שופט-חוקר.
 1	עד	עד	ADP	ADP	_	2	case	_	_
 2	היום	היום	ADV	ADV	_	3	obl	_	_
-3	נמצאות	נמצא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+3	נמצאות	נמצא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=מ.צ.א|VerbForm=Part|Voice=Mid	0	root	_	_
 4	תלונות	תלונה	NOUN	NOUN	Gender=Fem|Number=Plur	3	nsubj	_	_
 5	הללו	הללו	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	4	det	_	_
 6-7	בשלב	_	_	_	_	_	_	_	_
@@ -13500,7 +13500,7 @@
 11	קלאוס	קלאוס	PROPN	PROPN	_	5	appos	_	_
 12	ברבי	ברבי	PROPN	PROPN	_	11	flat:name	_	SpaceAfter=No
 13	,	,	PUNCT	PUNCT	_	14	punct	_	_
-14	עלה	עלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+14	עלה	עלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ל.י|Tense=Past|Voice=Act	0	root	_	_
 15	מחדש	מחדש	ADV	ADV	_	14	advmod	_	_
 16-18	שמו	_	_	_	_	_	_	_	_
 16	שם_	שם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
@@ -13534,7 +13534,7 @@
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	ליון	ליון	PROPN	PROPN	_	6	nmod	_	_
 15	,	,	PUNCT	PUNCT	_	4	punct	_	_
-16	נטל	נטל	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	4	conj	_	_
+16	נטל	נטל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ט.ל|Tense=Past	4	conj	_	_
 17	חלק	חלק	NOUN	NOUN	Gender=Masc|Number=Sing	16	obj	_	_
 18	פעיל	פעיל	ADJ	ADJ	Gender=Masc|Number=Sing	17	amod	_	_
 19-21	באקציות	_	_	_	_	_	_	_	_
@@ -13552,10 +13552,10 @@
 28	ו	ו	CCONJ	CCONJ	_	29	cc	_	_
 29	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	26	conj	_	_
 30	,	,	PUNCT	PUNCT	_	4	punct	_	_
-31	עינה	עינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	conj	_	_
-32	עצורים	עצר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	31	obj	_	SpaceAfter=No
+31	עינה	עינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ע.נ.י|Tense=Past|Voice=Act	4	conj	_	_
+32	עצורים	עצר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ע.צ.ר|VerbForm=Part|Voice=Act	31	obj	_	SpaceAfter=No
 33	,	,	PUNCT	PUNCT	_	4	punct	_	_
-34	שדד	שדד	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	4	conj	_	_
+34	שדד	שדד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.ד.ד|Tense=Past	4	conj	_	_
 35	את	את	ADP	ADP	Case=Acc	36	case:acc	_	_
 36-38	רכושם	_	_	_	_	_	_	_	SpaceAfter=No
 36	רכוש_	רכוש	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	34	obj	_	_
@@ -13564,7 +13564,7 @@
 39	,	,	PUNCT	PUNCT	_	4	punct	_	_
 40-41	והורה	_	_	_	_	_	_	_	_
 40	ו	ו	CCONJ	CCONJ	_	41	cc	_	_
-41	הורה	הורה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	conj	_	_
+41	הורה	הורה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ר.י|Tense=Past|Voice=Act	4	conj	_	_
 42	על	על	ADP	ADP	_	43	case	_	_
 43-45	הוצאתם	_	_	_	_	_	_	_	_
 43	הוצאה_	הוצאה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	41	obl	_	_
@@ -13573,7 +13573,7 @@
 46-48	להורג	_	_	_	_	_	_	_	_
 46	ל	ל	ADP	ADP	_	48	case	_	_
 47	ה_	ה	DET	DET	PronType=Art	48	det:def	_	_
-48	הורג	הרג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	43	nmod	_	_
+48	הורג	הרג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ה.ר.ג|VerbForm=Part|Voice=Act	43	nmod	_	_
 49	של	של	ADP	ADP	Case=Gen	52	case:gen	_	_
 50	כמה	כמה	DET	DET	Definite=Cons	52	det	_	_
 51-54	מקורבנותיו	_	_	_	_	_	_	_	_
@@ -13591,7 +13591,7 @@
 2-3	השחרור	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	שחרור	שחרור	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
-4	נעלמו	נעלם	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+4	נעלמו	נעלם	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ע.ל.מ|Tense=Past|Voice=Mid	0	root	_	_
 5-7	עקבותיו	_	_	_	_	_	_	_	SpaceAfter=No
 5	עקבה_	עקבה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	4	nsubj	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
@@ -13605,7 +13605,7 @@
 3-4	בליון	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	ליון	ליון	PROPN	PROPN	_	1	nmod	_	_
-5	דן	דן	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	דן	דן	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ד.ו.נ|Tense=Past|Voice=Act	0	root	_	_
 6-7	אותו	_	_	_	_	_	_	_	_
 6	את_	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 7	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	obj	_	_
@@ -13627,7 +13627,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	שנת	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	obl	_	_
 3	1972	1972	NUM	NUM	_	2	compound:smixut	_	_
-4	גילה	גילה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	גילה	גילה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ג.ל.י|Tense=Past|Voice=Act	0	root	_	_
 5	תחקיר	תחקיר	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 6	עיתונאי	עיתונאי	ADJ	ADJ	Gender=Masc|Number=Sing	5	amod	_	_
 7-9	שבנובמבר	_	_	_	_	_	_	_	_
@@ -13635,7 +13635,7 @@
 8	ב	ב	ADP	ADP	_	9	case	_	_
 9	נובמבר	נובמבר	PROPN	PROPN	_	11	obl	_	_
 10	1971	1971	NUM	NUM	_	9	nummod	_	_
-11	העניק	העניק	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	ccomp	_	_
+11	העניק	העניק	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ע.נ.ק|Tense=Past|Voice=Act	4	ccomp	_	_
 12-13	לו	_	_	_	_	_	_	_	_
 12	ל_	ל	ADP	ADP	_	13	case	_	_
 13	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	obl	_	_
@@ -13654,7 +13654,7 @@
 24-25	השנים	_	_	_	_	_	_	_	_
 24	ה	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	26	obl	_	_
-26	נהנה	נהנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	11	conj	_	_
+26	נהנה	נהנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ה.נ.י|Tense=Past|Voice=Mid	11	conj	_	_
 27-28	הפושע	_	_	_	_	_	_	_	_
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	פושע	פושע	NOUN	NOUN	Gender=Masc|Number=Sing	26	nsubj	_	_
@@ -13683,7 +13683,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	שנת	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	obl	_	_
 3	3891	3891	NUM	NUM	_	2	compound:smixut	_	_
-4	נתחדשה	התחדש	VERB	VERB	_	0	root	_	_
+4	נתחדשה	התחדש	VERB	VERB	HebBinyan=HITPAEL|Root=ח.ד.ש	0	root	_	_
 5-6	החקירה	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	חקירה	חקירה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
@@ -13693,7 +13693,7 @@
 10	אך	אך	CCONJ	CCONJ	_	13	cc	_	_
 11	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
 12	שוב	שוב	ADV	ADV	_	13	advmod	_	_
-13	נעלם	נעלם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	conj	_	SpaceAfter=No
+13	נעלם	נעלם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ע.ל.מ|Tense=Past|Voice=Mid	4	conj	_	SpaceAfter=No
 14	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 414
@@ -13702,7 +13702,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	ספטמבר	ספטמבר	PROPN	PROPN	_	4	obl	_	_
 3	1984	1984	NUM	NUM	_	2	nummod	_	_
-4	פורסמה	פורסם	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	פורסמה	פורסם	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Root=פ.ר.ס.מ|Tense=Past|Voice=Pass	0	root	_	_
 5-6	בעיתון	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	עיתון	עיתון	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
@@ -13718,7 +13718,7 @@
 15-16	ואף	_	_	_	_	_	_	_	_
 15	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
 16	אף	אף	ADV	ADV	_	17	advmod	_	_
-17	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	conj	_	_
+17	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.צ.א|Tense=Past|Voice=Mid	4	conj	_	_
 18	"	"	PUNCT	PUNCT	_	19	punct	_	SpaceAfter=No
 19	מקום	מקום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	17	nsubj	_	_
 20-22	קבורתו	_	_	_	_	_	_	_	SpaceAfter=No
@@ -13732,7 +13732,7 @@
 # text = אך עדיין מחפשים אחרי טובייה החי.
 1	אך	אך	CCONJ	CCONJ	_	3	cc	_	_
 2	עדיין	עדיין	ADV	ADV	_	3	advmod	_	_
-3	מחפשים	חיפש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+3	מחפשים	חיפש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ח.פ.ש|VerbForm=Part|Voice=Act	0	root	_	_
 4	אחרי	אחרי	ADP	ADP	_	5	case	_	_
 5	טובייה	טובייה	PROPN	PROPN	_	3	obl	_	_
 6-7	החי	_	_	_	_	_	_	_	SpaceAfter=No
@@ -13748,7 +13748,7 @@
 3	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
 4	פרשת	פרשה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	nsubj	_	_
 5	בוסקה	בוסקה	PROPN	PROPN	_	4	compound:smixut	_	_
-6	הזכירה	הזכיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	acl:relcl	_	_
+6	הזכירה	הזכיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ז.כ.ר|Tense=Past|Voice=Act	2	acl:relcl	_	_
 7	גם	גם	ADV	ADV	_	9	det	_	_
 8	את	את	ADP	ADP	Case=Acc	9	case:acc	_	_
 9	פרשיות	פרשייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	6	obj	_	_
@@ -13766,7 +13766,7 @@
 3	עיתונאים	עיתונאי	NOUN	NOUN	Gender=Masc|Number=Plur	2	compound:smixut	_	_
 4-5	שנערכה	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	נערכה	נערך	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	2	acl:relcl	_	_
+5	נערכה	נערך	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ע.ר.כ|Tense=Past|Voice=Mid	2	acl:relcl	_	_
 6-8	ב81	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -13778,7 +13778,7 @@
 12-13	בפאריס	_	_	_	_	_	_	_	_
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	פאריס	פריז	PROPN	PROPN	_	5	obl	_	_
-14	דיבר	דיבר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+14	דיבר	דיבר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ד.ב.ר|Tense=Past|Voice=Act	0	root	_	_
 15	נשיא	נשיא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	nsubj	_	_
 16-17	הליגה	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
@@ -13803,7 +13803,7 @@
 32-33	הפוליטי	_	_	_	_	_	_	_	_
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	פוליטי	פוליטי	ADJ	ADJ	Gender=Masc|Number=Sing	29	amod	_	_
-34	להביא	הביא	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	29	acl	_	_
+34	להביא	הביא	VERB	VERB	HebBinyan=HIFIL|Root=ב.ו.א|VerbForm=Inf|Voice=Act	29	acl	_	_
 35	לידי	לידי	ADP	ADP	_	36	case	_	_
 36	בירור	בירור	NOUN	NOUN	Gender=Masc|Number=Sing	34	obl	_	_
 37	את	את	ADP	ADP	Case=Acc	40	case:acc	_	_
@@ -13824,13 +13824,13 @@
 # sent_id = 418
 # text = הוא אמר: "שלושה תיקים אלה נמצאים בנקודה מתה.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+2	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 3	:	:	PUNCT	PUNCT	_	8	punct	_	_
 4	"	"	PUNCT	PUNCT	_	8	punct	_	SpaceAfter=No
 5	שלושה	שלושה	NUM	NUM	Gender=Masc|Number=Sing	6	nummod	_	_
 6	תיקים	תיק	NOUN	NOUN	Gender=Masc|Number=Plur	8	nsubj	_	_
 7	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	6	det	_	_
-8	נמצאים	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	2	ccomp	_	_
+8	נמצאים	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=מ.צ.א|VerbForm=Part|Voice=Mid	2	ccomp	_	_
 9-10	בנקודה	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	נקודה	נקודה	NOUN	NOUN	Gender=Fem|Number=Sing	8	obl	_	_
@@ -13850,7 +13850,7 @@
 7	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	10	nsubj	_	_
 8	הללו	הללו	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	7	det	_	_
 9	לא	לא	ADV	ADV	Polarity=Neg	10	advmod	_	_
-10	נשפטו	נשפט	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	3	ccomp	_	_
+10	נשפטו	נשפט	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ש.פ.ט|Tense=Past|Voice=Mid	3	ccomp	_	_
 11	עד	עד	ADP	ADP	_	12	case	_	_
 12	כה	כה	ADV	ADV	_	10	obl	_	SpaceAfter=No
 13	.	.	PUNCT	PUNCT	_	3	punct	_	_
@@ -13859,7 +13859,7 @@
 # text = אישים אלה מילאו תפקידים רמים ובעלי חשיבות בפוליטיקה, במינהל ובעולם העסקים.
 1	אישים	אישים	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
 2	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	1	det	_	_
-3	מילאו	מילא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	מילאו	מילא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=מ.ל.א|Tense=Past|Voice=Act	0	root	_	_
 4	תפקידים	תפקיד	NOUN	NOUN	Gender=Masc|Number=Plur	3	obj	_	_
 5	רמים	רם	ADJ	ADJ	Gender=Masc|Number=Plur	4	amod	_	_
 6-7	ובעלי	_	_	_	_	_	_	_	_
@@ -13887,11 +13887,11 @@
 # sent_id = 421
 # text = אני סבור שהם נהנים מהזדהות מעמדית אמיתית.
 1	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
-2	סבור	סבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	סבור	סבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ס.ב.ר|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	שהם	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
 4	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	5	nsubj	_	_
-5	נהנים	נהנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	2	ccomp	_	_
+5	נהנים	נהנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=ה.נ.י|VerbForm=Part|Voice=Mid	2	ccomp	_	_
 6-7	מהזדהות	_	_	_	_	_	_	_	_
 6	מ	מ	ADP	ADP	_	7	case	_	_
 7	הזדהות	הזדהות	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
@@ -13902,7 +13902,7 @@
 # sent_id = 422
 # text = לא תובעים לדין שר או ממונה על המשטרה, משום שהוא שייך לחוג של אנשים שאינו רוצה שיכבסו את הכביסה המלוכלכת".
 1	לא	לא	ADV	ADV	Polarity=Neg	2	advmod	_	_
-2	תובעים	תבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	תובעים	תבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ת.ב.ע|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	לדין	_	_	_	_	_	_	_	_
 3	ל	ל	ADP	ADP	_	4	case	_	_
 4	דין	דין	NOUN	NOUN	Gender=Masc|Number=Sing	2	obl	_	_
@@ -13927,10 +13927,10 @@
 20-21	שאינו	_	_	_	_	_	_	_	_
 20	ש	ש	SCONJ	SCONJ	_	22	mark	_	_
 21	אינו	אינו	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	22	advmod	_	_
-22	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	17	acl:relcl	_	_
+22	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.צ.י|VerbForm=Part|Voice=Act	17	acl:relcl	_	_
 23-24	שיכבסו	_	_	_	_	_	_	_	_
 23	ש	ש	SCONJ	SCONJ	_	24	mark	_	_
-24	יכבסו	כיבס	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Fut|Voice=Act	22	ccomp	_	_
+24	יכבסו	כיבס	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=כ.ב.ס|Tense=Fut|Voice=Act	22	ccomp	_	_
 25	את	את	ADP	ADP	Case=Acc	27	case:acc	_	_
 26-27	הכביסה	_	_	_	_	_	_	_	_
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
@@ -13967,7 +13967,7 @@
 3-4	מהם	_	_	_	_	_	_	_	_
 3	מהם	מן	ADP	ADP	_	2	dep	_	_
 4	_הם	הוא	PRON	PRON	Gender=Masc|HebSource=ConvUncertainHead|Number=Plur|Person=3|PronType=Prs	2	dep	_	_
-5	מתקרב	התקרב	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+5	מתקרב	התקרב	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ק.ר.ב|VerbForm=Part	0	root	_	_
 6-7	לגיל	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	גיל	גיל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
@@ -13987,10 +13987,10 @@
 7-8	הצרפתי	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	צרפתי	צרפתי	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
-9	מצפה	ציפה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+9	מצפה	ציפה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=צ.פ.י|VerbForm=Part|Voice=Act	0	root	_	_
 10-11	שימותו	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	ימותו	מת	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Fut|Voice=Act	9	ccomp	_	_
+11	ימותו	מת	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=מ.ו.ת|Tense=Fut|Voice=Act	9	ccomp	_	_
 12-13	בשקט	_	_	_	_	_	_	_	SpaceAfter=No
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	שקט	שקט	NOUN	NOUN	Gender=Masc|Number=Sing	11	obl	_	_
@@ -14022,7 +14022,7 @@
 # sent_id = 428
 # text = הוא חושש מחשיפת סודות החבויים בכספות, מפני עדויות חדשות, ומפני זכרונות העלולים לגלות שלדים החבויים שנים כה רבות בארונות שונים.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	חושש	חשש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	חושש	חשש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ח.ש.ש|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	מחשיפת	_	_	_	_	_	_	_	_
 3	מ	מ	ADP	ADP	_	4	case	_	_
 4	חשיפת	חשיפה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	2	obl	_	_
@@ -14045,7 +14045,7 @@
 18-19	העלולים	_	_	_	_	_	_	_	_
 18	ה	ה	SCONJ	SCONJ	_	19	mark	_	_
 19	עלולים	עלול	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbType=Mod	20	aux	_	_
-20	לגלות	גילה	VERB	VERB	VerbForm=Inf	17	acl:relcl	_	_
+20	לגלות	גילה	VERB	VERB	HebBinyan=PIEL|Root=ג.ל.י|VerbForm=Inf	17	acl:relcl	_	_
 21	שלדים	שלד	NOUN	NOUN	Gender=Masc|Number=Plur	20	obj	_	_
 22-23	החבויים	_	_	_	_	_	_	_	_
 22	ה	ה	SCONJ	SCONJ	_	23	mark	_	_
@@ -14066,7 +14066,7 @@
 2	ו	ו	CCONJ	CCONJ	_	3	cc	_	_
 3	חצי	חץ	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	1	conj	_	_
 4	שעות	שעה	NOUN	NOUN	Gender=Fem|Number=Plur	5	dep	_	_
-5	צעדו	צעד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	צעדו	צעד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=צ.ע.ד|Tense=Past|Voice=Act	0	root	_	_
 6	אתמול	אתמול	ADV	ADV	_	5	advmod	_	_
 7-8	בירושלים	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
@@ -14115,13 +14115,13 @@
 4	,	,	PUNCT	PUNCT	_	11	punct	_	_
 5-6	כשהחל	_	_	_	_	_	_	_	_
 5	כש	כש	SCONJ	SCONJ	Case=Tem	6	mark	_	_
-6	החל	החל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	advcl	_	_
+6	החל	החל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ל.ל|Tense=Past|Voice=Act	11	advcl	_	_
 7-8	הקהל	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	קהל	קהל	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
-9	להתפזר	התפזר	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	6	xcomp	_	SpaceAfter=No
+9	להתפזר	התפזר	VERB	VERB	HebBinyan=HITPAEL|Root=פ.ז.ר|VerbForm=Inf	6	xcomp	_	SpaceAfter=No
 10	,	,	PUNCT	PUNCT	_	11	punct	_	_
-11	מנתה	מנה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+11	מנתה	מנה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.נ.י|Tense=Past|Voice=Act	0	root	_	_
 12-13	המשטרה	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	11	nsubj	_	_
@@ -14139,12 +14139,12 @@
 23	ו	ו	CCONJ	CCONJ	_	25	cc	_	_
 24	ארבעה	ארבעה	NUM	NUM	Gender=Masc|Number=Sing	25	nummod	_	_
 25	ערבים	ערבי	NOUN	NOUN	Gender=Masc|Number=Plur	15	conj	_	_
-26	עוברי	עבר	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	25	amod	_	SpaceAfter=No
+26	עוברי	עבר	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ע.ב.ר|VerbForm=Part|Voice=Act	25	amod	_	SpaceAfter=No
 27	-	-	PUNCT	PUNCT	_	26	punct	_	SpaceAfter=No
 28	אורח	אורח	NOUN	NOUN	Gender=Masc|Number=Sing	26	obl	_	_
 29-30	שנפצעו	_	_	_	_	_	_	_	_
 29	ש	ש	SCONJ	SCONJ	_	30	mark	_	_
-30	נפצעו	נפצע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	25	acl:relcl	_	_
+30	נפצעו	נפצע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=פ.צ.ע|Tense=Past|Voice=Mid	25	acl:relcl	_	_
 31	אף	אף	CCONJ	CCONJ	_	32	det	_	_
 32	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	30	dep	_	SpaceAfter=No
 33	.	.	PUNCT	PUNCT	_	11	punct	_	_
@@ -14156,7 +14156,7 @@
 2	שעה	שעה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
 3	1400	1400	NUM	NUM	_	2	nummod	_	_
 4	עדיין	עדיין	ADV	ADV	_	5	advmod	_	_
-5	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+5	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.צ.א|Tense=Past|Voice=Mid	0	root	_	_
 6	קהל	קהל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	nsubj	_	_
 7-8	הרבבות	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -14177,7 +14177,7 @@
 4-5	הצהרים	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	צהרים	צהריים	NOUN	NOUN	Gender=Masc|Number=Plur	3	compound:smixut	_	_
-6	התקבצו	התקבץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
+6	התקבצו	התקבץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=ק.ב.צ|Tense=Past	0	root	_	_
 7	אלפים	אלפים	NUM	NUM	Gender=Masc|Number=Plur	6	nsubj	_	_
 8	סביב	סביב	ADP	ADP	_	9	case	_	_
 9	ישיבת	ישיבה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	obl	_	_
@@ -14201,12 +14201,12 @@
 1	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	משפחת	משפחה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3	כהנא	כהנא	PROPN	PROPN	_	2	compound:smixut	_	_
-4	ישבו	ישב	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	0	root	_	_
+4	ישבו	ישב	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.ש.ב|Tense=Past	0	root	_	_
 5	על	על	ADP	ADP	_	6	case	_	_
 6	מרפסת	מרפסת	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
 7-8	המשקיפה	_	_	_	_	_	_	_	_
 7	ה	ה	SCONJ	SCONJ	_	8	mark	_	_
-8	משקיפה	השקיף	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
+8	משקיפה	השקיף	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ש.ק.פ|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
 9	על	על	ADP	ADP	_	10	case	_	_
 10	פתח	פתח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	8	obl	_	_
 11-12	הישיבה	_	_	_	_	_	_	_	SpaceAfter=No
@@ -14219,7 +14219,7 @@
 1	צלמי	צלם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	עיתונות	עיתונות	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3	רבים	רב	ADJ	ADJ	Gender=Masc|Number=Plur	1	amod	_	_
-4	נדחקו	נדחק	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+4	נדחקו	נדחק	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ד.ח.ק|Tense=Past|Voice=Mid	0	root	_	_
 5	על	על	ADP	ADP	_	6	case	_	_
 6	גג	גג	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
 7	בטון	בטון	NOUN	NOUN	_	6	compound:smixut	_	_
@@ -14231,7 +14231,7 @@
 1	צוותי	צוות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	4	nsubj	_	_
 2	תקשורת	תקשורת	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 3	אחרים	אחר	ADJ	ADJ	Gender=Masc|Number=Plur	1	amod	_	_
-4	הושמו	הושם	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	הושמו	הושם	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=ש.ו.מ|Tense=Past|Voice=Pass	0	root	_	_
 5	מאחורי	מאחורי	ADP	ADP	_	6	case	_	_
 6	גדירות	גדירות	NOUN	NOUN	Definite=Cons	4	obl	_	_
 7	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	6	compound:smixut	_	SpaceAfter=No
@@ -14243,7 +14243,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	שעה	שעה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
 3	1500	1500	NUM	NUM	_	2	nummod	_	_
-4	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ע|Tense=Past|Voice=Act	0	root	_	_
 5-6	הארון	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	ארון	ארון	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
@@ -14259,7 +14259,7 @@
 1	מ	מ	ADP	ADP	_	3	case	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	רמקול	רמקול	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
-4	בקע	בקע	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+4	בקע	בקע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ב.ק.ע|Tense=Past	0	root	_	_
 5-7	קולו	_	_	_	_	_	_	_	_
 5	קול_	קול	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
@@ -14275,7 +14275,7 @@
 14	,	,	PUNCT	PUNCT	_	11	punct	_	_
 15-16	שקרא	_	_	_	_	_	_	_	_
 15	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
-16	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	acl:relcl	_	_
+16	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ר.א|Tense=Past|Voice=Act	11	acl:relcl	_	_
 17	פסוקי	פסוק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	16	obj	_	_
 18	תהילים	תהילים	PROPN	PROPN	_	17	compound:smixut	_	SpaceAfter=No
 19	.	.	PUNCT	PUNCT	_	4	punct	_	_
@@ -14285,7 +14285,7 @@
 1-2	הציבור	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	ציבור	ציבור	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
-3	חזר	חזר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	חזר	חזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Past	0	root	_	_
 4-5	אחריו	_	_	_	_	_	_	_	_
 4	אחרי_	אחרי	ADP	ADP	_	5	case	_	_
 5	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	obl	_	_
@@ -14300,7 +14300,7 @@
 2-3	הרבבות	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	רבבות	רבבות	NUM	NUM	Definite=Cons	1	compound:smixut	_	_
-4	כלל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	כלל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ל.ל|Tense=Past|Voice=Act	0	root	_	_
 5	כיפות	כיפה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obj	_	_
 6	סרוגות	סרוג	ADJ	ADJ	Gender=Fem|Number=Plur	5	amod	_	SpaceAfter=No
 7	,	,	PUNCT	PUNCT	_	5	punct	_	_
@@ -14324,8 +14324,8 @@
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 4	קדישא	קדישא	PROPN	PROPN	_	3	flat:name	_	_
-5	ביקשו	ביקש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
-6	להעביר	העביר	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
+5	ביקשו	ביקש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ב.ק.ש|Tense=Past|Voice=Act	0	root	_	_
+6	להעביר	העביר	VERB	VERB	HebBinyan=HIFIL|Root=ע.ב.ר|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 7	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 8	אלונקת	אלונקה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	obj	_	_
 9-10	הנפטר	_	_	_	_	_	_	_	_
@@ -14349,8 +14349,8 @@
 3	חצי	חץ	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	6	dep	_	_
 4	שעה	שעה	NOUN	NOUN	Gender=Fem|Number=Sing	3	compound:smixut	_	_
 5	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	6	nsubj	_	_
-6	ניסו	ניסה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
-7	לעשות	עשה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
+6	ניסו	ניסה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=נ.ס.י|Tense=Past|Voice=Act	0	root	_	_
+7	לעשות	עשה	VERB	VERB	HebBinyan=PAAL|Root=ע.ש.י|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 8	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	7	obj	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	6	punct	_	_
 10	אך	אך	CCONJ	CCONJ	_	6	cc	_	_
@@ -14396,14 +14396,14 @@
 25	מרדכי	מרדכי	PROPN	PROPN	_	24	flat:name	_	_
 26	אליהו	אליהו	PROPN	PROPN	_	24	flat:name	_	SpaceAfter=No
 27	,	,	PUNCT	PUNCT	_	1	punct	_	_
-28	התחננו	התחנן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
+28	התחננו	התחנן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=ח.נ.נ|Tense=Past	0	root	_	_
 29-30	בפני	_	_	_	_	_	_	_	_
 29	ב	ב	ADP	ADP	_	30	case	_	_
 30	פני	פנים	NOUN	NOUN	Definite=Cons|Gender=Fem,Masc|Number=Plur	28	obl	_	_
 31-32	הקהל	_	_	_	_	_	_	_	_
 31	ה	ה	DET	DET	PronType=Art	32	det:def	_	_
 32	קהל	קהל	NOUN	NOUN	Gender=Masc|Number=Sing	30	compound:smixut	_	_
-33	לפנות	פינה	VERB	VERB	VerbForm=Inf	28	xcomp	_	_
+33	לפנות	פינה	VERB	VERB	HebBinyan=PIEL|Root=פ.נ.י|VerbForm=Inf	28	xcomp	_	_
 34	מעט	מעט	DET	DET	Definite=Cons	35	det	_	_
 35	דרך	דרך	NOUN	NOUN	Gender=Fem|Number=Sing	33	obj	_	SpaceAfter=No
 36	,	,	PUNCT	PUNCT	_	28	punct	_	_
@@ -14414,7 +14414,7 @@
 # sent_id = 443
 # text = מאות צרו על רכב החברה קדישא, תוך שהם דוחפים איש את רעהו ומשלחים קללות וגידופים לעבר אנשי התקשורת הרבים.
 1	מאות	מאות	NUM	NUM	Gender=Fem|Number=Plur	2	nsubj	_	_
-2	צרו	צר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	צרו	צר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=צ.ו.ר|Tense=Past|Voice=Act	0	root	_	_
 3	על	על	ADP	ADP	_	4	case	_	_
 4	רכב	רכב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	obl	_	_
 5-6	החברה	_	_	_	_	_	_	_	_
@@ -14426,13 +14426,13 @@
 10-11	שהם	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
 11	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	12	nsubj	_	_
-12	דוחפים	דחף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	obl	_	_
+12	דוחפים	דחף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ד.ח.פ|VerbForm=Part|Voice=Act	2	obl	_	_
 13	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	12	obj	_	_
 14	את	את	ADP	ADP	Case=Acc	13	dep	_	_
 15	רעהו	רעהו	NOUN	NOUN	HebSource=ConvUncertainHead	13	dep	_	_
 16-17	ומשלחים	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
-17	משלחים	שילח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	12	conj	_	_
+17	משלחים	שילח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ש.ל.ח|VerbForm=Part|Voice=Act	12	conj	_	_
 18	קללות	קללה	NOUN	NOUN	Gender=Fem|Number=Plur	17	obj	_	_
 19-20	וגידופים	_	_	_	_	_	_	_	_
 19	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
@@ -14464,15 +14464,15 @@
 11	,	,	PUNCT	PUNCT	_	2	punct	_	_
 12-13	שביקשו	_	_	_	_	_	_	_	_
 12	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
-13	ביקשו	ביקש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	2	acl:relcl	_	_
-14	להספיד	הספיד	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	13	xcomp	_	_
+13	ביקשו	ביקש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ב.ק.ש|Tense=Past|Voice=Act	2	acl:relcl	_	_
+14	להספיד	הספיד	VERB	VERB	HebBinyan=HIFIL|Root=ס.פ.ד|VerbForm=Inf|Voice=Act	13	xcomp	_	_
 15	את	את	ADP	ADP	Case=Acc	17	case:acc	_	_
 16-17	הרב	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	רב	רב	NOUN	NOUN	Gender=Masc|Number=Sing	14	obj	_	_
 18	כהנא	כהנא	PROPN	PROPN	_	17	flat:name	_	SpaceAfter=No
 19	,	,	PUNCT	PUNCT	_	20	punct	_	_
-20	גורשו	גורש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+20	גורשו	גורש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=ג.ר.ש|Tense=Past|Voice=Pass	0	root	_	_
 21-23	מהמקום	_	_	_	_	_	_	_	SpaceAfter=No
 21	מ	מ	ADP	ADP	_	23	case	_	_
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
@@ -14485,7 +14485,7 @@
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	קהל	קהל	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
-4	נראו	נראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+4	נראו	נראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ר.א.י|Tense=Past|Voice=Mid	0	root	_	_
 5	חבר	חבר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	nsubj	_	_
 6-7	הכנסת	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -14528,20 +14528,20 @@
 1-2	ב2115	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	2115	2115	NUM	NUM	_	3	obl	_	_
-3	ניסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	ניסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.ס.י|Tense=Past|Voice=Act	0	root	_	_
 4	רכב	רכב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	3	nsubj	_	_
 5-6	החברה	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	4	compound:smixut	_	_
 7	קדישא	קדישא	PROPN	PROPN	_	6	flat:name	_	_
-8	לדחוף	דחף	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
+8	לדחוף	דחף	VERB	VERB	HebBinyan=PAAL|Root=ד.ח.פ|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 9-10	בעדינות	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	עדינות	עדינות	NOUN	NOUN	Gender=Fem|Number=Sing	8	obl	_	_
 11	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 12-13	הצרים	_	_	_	_	_	_	_	_
 12	ה	ה	SCONJ	SCONJ	_	13	mark	_	_
-13	צרים	צר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	8	obj	_	_
+13	צרים	צר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=צ.ו.ר|VerbForm=Part|Voice=Act	8	obj	_	_
 14-15	עליו	_	_	_	_	_	_	_	SpaceAfter=No
 14	על_	על	ADP	ADP	_	15	case	_	_
 15	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	obl	_	_
@@ -14556,7 +14556,7 @@
 4	פצוע	פצוע	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 5-6	שנדרס	_	_	_	_	_	_	_	SpaceAfter=No
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	נדרס	נדרס	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	acl:relcl	_	_
+6	נדרס	נדרס	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ד.ר.ס|Tense=Past|Voice=Mid	4	acl:relcl	_	_
 7	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 448
@@ -14570,7 +14570,7 @@
 5	אמבולנס	אמבולנס	NOUN	NOUN	Gender=Masc|Number=Sing	3	compound:smixut	_	_
 6-7	שמיהר	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
-7	מיהר	מיהר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	acl:relcl	_	_
+7	מיהר	מיהר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=מ.ה.ר|Tense=Past|Voice=Act	5	acl:relcl	_	_
 8-9	עמו	_	_	_	_	_	_	_	_
 8	עם_	עם	ADP	ADP	_	9	case	_	_
 9	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	obl	_	_
@@ -14579,9 +14579,9 @@
 11	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obl	_	_
 12-13	החולים	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
-13	חולים	חלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	11	compound:smixut	_	_
+13	חולים	חלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ח.ל.י|VerbForm=Part|Voice=Act	11	compound:smixut	_	_
 14	,	,	PUNCT	PUNCT	_	15	punct	_	_
-15	פתח	פתח	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+15	פתח	פתח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ת.ח|Tense=Past	0	root	_	_
 16-17	הרב	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	רב	רב	NOUN	NOUN	Gender=Masc|Number=Sing	15	nsubj	_	_
@@ -14603,7 +14603,7 @@
 3-4	הראשי	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	ראשי	ראשי	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-5	עמד	עמד	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+5	עמד	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.מ.ד|Tense=Past	0	root	_	_
 6	על	על	ADP	ADP	_	7	case	_	_
 7-9	תכונותיו	_	_	_	_	_	_	_	_
 7	תכונה_	תכונה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	5	obl	_	_
@@ -14641,7 +14641,7 @@
 31	ו	ו	CCONJ	CCONJ	_	34	cc	_	_
 32	אחר	אחר	ADP	ADP	_	33	case	_	_
 33	כך	כך	PRON	PRON	Person=3|PronType=Dem	34	obl	_	_
-34	פונה	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	conj	_	_
+34	פונה	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=פ.נ.י|VerbForm=Part|Voice=Act	5	conj	_	_
 35-37	לקהל	_	_	_	_	_	_	_	SpaceAfter=No
 35	ל	ל	ADP	ADP	_	37	case	_	_
 36	ה_	ה	DET	DET	PronType=Art	37	det:def	_	_
@@ -14651,7 +14651,7 @@
 40-41	הקב"ה	_	_	_	_	_	_	_	_
 40	ה	ה	DET	DET	PronType=Art	41	det:def	_	_
 41	קב"ה	קב"ה	PROPN	PROPN	Abbr=Yes	42	nsubj	_	_
-42	יקום	קם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	34	advcl	_	_
+42	יקום	קם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ק.מ|Tense=Fut|Voice=Act	34	advcl	_	_
 43-45	דמו	_	_	_	_	_	_	_	SpaceAfter=No
 43	דם_	דם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	42	obj	_	_
 44	_של_	של	ADP	ADP	_	45	case:gen	_	_
@@ -14661,7 +14661,7 @@
 # sent_id = 450
 # text = לא להפריע לכוחות הביטחון.
 1	לא	לא	ADV	ADV	Polarity=Neg	0	root	_	_
-2	להפריע	הפריע	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	1	dep	_	_
+2	להפריע	הפריע	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|Root=פ.ר.ע|VerbForm=Inf|Voice=Act	1	dep	_	_
 3-4	לכוחות	_	_	_	_	_	_	_	_
 3	ל	ל	ADP	ADP	_	4	case	_	_
 4	כוחות	כוח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	2	obl	_	_
@@ -14672,7 +14672,7 @@
 
 # sent_id = 451
 # text = להשאיר את הנקמה לאלוקים".
-1	להשאיר	השאיר	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+1	להשאיר	השאיר	VERB	VERB	HebBinyan=HIFIL|Root=ש.א.ר|VerbForm=Inf|Voice=Act	0	root	_	_
 2	את	את	ADP	ADP	Case=Acc	4	case:acc	_	_
 3-4	הנקמה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
@@ -14699,7 +14699,7 @@
 10	מאיר	מאיר	PROPN	PROPN	_	6	nmod:poss	_	_
 11	כהנא	כהנא	PROPN	PROPN	_	10	flat:name	_	SpaceAfter=No
 12	,	,	PUNCT	PUNCT	_	2	punct	_	_
-13	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+13	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ז.כ.ר|Tense=Past|Voice=Act	0	root	_	_
 14-16	לציבור	_	_	_	_	_	_	_	_
 14	ל	ל	ADP	ADP	_	16	case	_	_
 15	ה_	ה	DET	DET	PronType=Art	16	det:def	_	_
@@ -14715,7 +14715,7 @@
 24	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	22	nmod:poss	_	_
 25	של	של	ADP	ADP	Case=Gen	26	case:gen	_	_
 26	כהנא	כהנא	PROPN	PROPN	_	22	nmod:poss	_	_
-27	נשפך	נשפך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	13	ccomp	_	_
+27	נשפך	נשפך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.פ.כ|Tense=Past|Voice=Mid	13	ccomp	_	_
 28	על	על	ADP	ADP	_	29	case	_	_
 29	רקע	רקע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	27	obl	_	_
 30	הר	הר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	29	compound:smixut	_	SpaceAfter=No
@@ -14733,7 +14733,7 @@
 3-4	הזה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	2	det	_	_
-5	רותח	רתח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
+5	רותח	רתח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.ת.ח|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 454
@@ -14788,14 +14788,14 @@
 26	ה_	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	כנסת	כנסת	PROPN	PROPN	_	23	nmod	_	_
 28	,	,	PUNCT	PUNCT	_	29	punct	_	_
-29	היו	היה	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+29	היו	היה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 30	כבר	כבר	ADV	ADV	_	29	advmod	_	_
 31	הוראות	הוראה	NOUN	NOUN	Gender=Fem|Number=Plur	29	nsubj	_	_
 32	מעשיות	מעשי	ADJ	ADJ	Gender=Fem|Number=Plur	31	amod	_	SpaceAfter=No
 33	:	:	PUNCT	PUNCT	_	36	punct	_	_
 34	"	"	PUNCT	PUNCT	_	36	punct	_	SpaceAfter=No
 35	אלוקים	אלוקים	NOUN	NOUN	Gender=Masc|Number=Sing	36	nsubj	_	_
-36	ייקום	נקם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	31	appos	_	_
+36	ייקום	נקם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ק.מ|Tense=Fut|Voice=Act	31	appos	_	_
 37-39	דמו	_	_	_	_	_	_	_	_
 37	דם_	דם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	36	obj	_	_
 38	_של_	של	ADP	ADP	_	39	case:gen	_	_
@@ -14803,7 +14803,7 @@
 40-41	ואנו	_	_	_	_	_	_	_	_
 40	ו	ו	CCONJ	CCONJ	_	42	cc	_	_
 41	אנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	42	nsubj	_	_
-42	ניקום	נקם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Fut|Voice=Act	36	conj	_	_
+42	ניקום	נקם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=נ.ק.מ|Tense=Fut|Voice=Act	36	conj	_	_
 43-44	אותו	_	_	_	_	_	_	_	SpaceAfter=No
 43	את_	את	ADP	ADP	Case=Acc	44	case:acc	_	_
 44	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	42	obj	_	_
@@ -14820,7 +14820,7 @@
 # text = עכשיו עת להרוג.
 1	עכשיו	עכשיו	ADV	ADV	_	2	advmod	_	_
 2	עת	עת	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
-3	להרוג	הרג	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	acl	_	SpaceAfter=No
+3	להרוג	הרג	VERB	VERB	HebBinyan=PAAL|Root=ה.ר.ג|VerbForm=Inf|Voice=Act	2	acl	_	SpaceAfter=No
 4	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 458
@@ -14829,7 +14829,7 @@
 2-3	העת	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	עת	עת	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
-4	להרוג	הרג	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	acl	_	_
+4	להרוג	הרג	VERB	VERB	HebBinyan=PAAL|Root=ה.ר.ג|VerbForm=Inf|Voice=Act	3	acl	_	_
 5-7	רבותי	_	_	_	_	_	_	_	SpaceAfter=No
 5	__	_	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	3	nmod	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
@@ -14838,7 +14838,7 @@
 
 # sent_id = 459
 # text = נצפה לשלום, אך אינך יכול להגיע לשלום, שלא דרך המלחמה.
-1	נצפה	ציפה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=1|Tense=Fut	0	root	_	_
+1	נצפה	ציפה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Root=צ.פ.י|Tense=Fut	0	root	_	_
 2-3	לשלום	_	_	_	_	_	_	_	SpaceAfter=No
 2	ל	ל	ADP	ADP	_	3	case	_	_
 3	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	1	obl	_	_
@@ -14846,7 +14846,7 @@
 5	אך	אך	CCONJ	CCONJ	_	7	cc	_	_
 6	אינך	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	7	advmod	_	_
 7	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	8	aux	_	_
-8	להגיע	הגיע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	1	conj	_	_
+8	להגיע	הגיע	VERB	VERB	HebBinyan=HIFIL|Root=נ.ג.ע|VerbForm=Inf|Voice=Act	1	conj	_	_
 9-10	לשלום	_	_	_	_	_	_	_	SpaceAfter=No
 9	ל	ל	ADP	ADP	_	10	case	_	_
 10	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	_
@@ -14873,7 +14873,7 @@
 8	:	:	PUNCT	PUNCT	_	3	punct	_	_
 9	אינך	_	AUX	AUX	Gender=Fem|Number=Sing|Person=2|Polarity=Neg|VerbForm=Part|VerbType=Cop	3	parataxis	_	_
 10	יכול	_	AUX	AUX	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	9	dep	_	_
-11	להגיע	הגיע	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	9	dep	_	_
+11	להגיע	הגיע	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|Root=נ.ג.ע|VerbForm=Inf|Voice=Act	9	dep	_	_
 12-14	לטוב	_	_	_	_	_	_	_	SpaceAfter=No
 12	ל	ל	ADP	ADP	_	14	case	_	_
 13	ה_	ה	DET	DET	PronType=Art	14	det:def	_	_
@@ -14882,7 +14882,7 @@
 16	אם	אם	SCONJ	SCONJ	_	19	mark	_	_
 17	אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	19	nsubj	_	_
 18	לא	לא	ADV	ADV	Polarity=Neg	19	advmod	_	_
-19	מבער	ביער	VERB	VERB	Gender=Masc|HebBinyan=PIEL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	9	dep	_	_
+19	מבער	ביער	VERB	VERB	Gender=Masc|HebBinyan=PIEL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|Root=ב.ע.ר|VerbForm=Part|Voice=Act	9	dep	_	_
 20	את	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 21-22	הרע	_	_	_	_	_	_	_	SpaceAfter=No
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
@@ -14903,7 +14903,7 @@
 2-3	הזמן	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
-4	לנקום	נקם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	acl	_	_
+4	לנקום	נקם	VERB	VERB	HebBinyan=PAAL|Root=נ.ק.מ|VerbForm=Inf|Voice=Act	3	acl	_	_
 5-7	נקמתו	_	_	_	_	_	_	_	_
 5	נקמה_	נקמה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	4	obj	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
@@ -14947,7 +14947,7 @@
 25-26	והוא	_	_	_	_	_	_	_	_
 25	ו	ו	CCONJ	CCONJ	_	27	cc	_	_
 26	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	27	nsubj	_	_
-27	פנה	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	22	conj	_	_
+27	פנה	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.נ.י|Tense=Past|Voice=Act	22	conj	_	_
 28	אל	אל	ADP	ADP	_	29	case	_	_
 29-31	רבו	_	_	_	_	_	_	_	SpaceAfter=No
 29	רב_	רב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	27	obl	_	_
@@ -14957,14 +14957,14 @@
 33	כאילו	כאילו	CCONJ	CCONJ	_	36	mark	_	_
 34	עוד	עוד	ADV	ADV	_	36	advmod	_	_
 35	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	36	cop	_	_
-36	חי	חי	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	27	advcl	_	SpaceAfter=No
+36	חי	חי	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ח.י.י|VerbForm=Part|Voice=Act	27	advcl	_	SpaceAfter=No
 37	:	:	PUNCT	PUNCT	_	22	punct	_	_
 38	"	"	PUNCT	PUNCT	_	40	punct	_	SpaceAfter=No
 39-40	הרב	_	_	_	_	_	_	_	_
 39	ה	ה	DET	DET	PronType=Art	40	det:def	_	_
 40	רב	רב	NOUN	NOUN	Gender=Masc|Number=Sing	22	conj	_	_
 41	כהנא	כהנא	PROPN	PROPN	_	40	flat:name	_	_
-42	רצחו	רצח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Plur|Person=3|Tense=Past|Voice=Act	40	dep	_	_
+42	רצחו	רצח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Plur|Person=3|Root=ר.צ.ח|Tense=Past|Voice=Act	40	dep	_	_
 43-44	אותך	_	_	_	_	_	_	_	_
 43	את_	את	ADP	ADP	Case=Acc	44	case:acc	_	_
 44	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	40	obj	_	_
@@ -14978,7 +14978,7 @@
 2	ב	ב	ADP	ADP	_	4	case	_	_
 3	ה_	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	ארץ	ארץ	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
-5	פסלו	פסל	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	0	root	_	_
+5	פסלו	פסל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=פ.ס.ל|Tense=Past	0	root	_	_
 6-7	אותך	_	_	_	_	_	_	_	_
 6	את_	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 7	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	5	obj	_	_
@@ -14986,7 +14986,7 @@
 8	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	11	obl	_	_
-11	רצחו	רצח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	5	conj	_	_
+11	רצחו	רצח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ר.צ.ח|Tense=Past|Voice=Act	5	conj	_	_
 12-13	אותך	_	_	_	_	_	_	_	SpaceAfter=No
 12	את_	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 13	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	11	obj	_	_
@@ -15000,8 +15000,8 @@
 3-4	העויינת	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	עויינת	עוין	ADJ	ADJ	Gender=Fem|Number=Sing	2	amod	_	_
-5	ממשיכה	המשיך	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
-6	לרצוח	רצח	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
+5	ממשיכה	המשיך	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=מ.ש.כ|VerbForm=Part|Voice=Act	0	root	_	_
+6	לרצוח	רצח	VERB	VERB	HebBinyan=PAAL|Root=ר.צ.ח|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 7-8	אותך	_	_	_	_	_	_	_	_
 7	את_	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 8	_אתה	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2|PronType=Prs	6	obj	_	_
@@ -15011,21 +15011,21 @@
 
 # sent_id = 466
 # text = נבכה ונפסיק לבכות ונקיים את התורה שלימדת אותנו נקמה.
-1	נבכה	בכה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=1|Tense=Fut	0	root	_	_
+1	נבכה	בכה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=ב.כ.י|Tense=Fut	0	root	_	_
 2-3	ונפסיק	_	_	_	_	_	_	_	_
 2	ו	ו	CCONJ	CCONJ	_	3	cc	_	_
-3	נפסיק	הפסיק	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Tense=Fut|Voice=Act	1	conj	_	_
-4	לבכות	בכה	VERB	VERB	VerbForm=Inf	3	xcomp	_	_
+3	נפסיק	הפסיק	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Root=פ.ס.ק|Tense=Fut|Voice=Act	1	conj	_	_
+4	לבכות	בכה	VERB	VERB	HebBinyan=PAAL|Root=ב.כ.י|VerbForm=Inf	3	xcomp	_	_
 5-6	ונקיים	_	_	_	_	_	_	_	_
 5	ו	ו	CCONJ	CCONJ	_	6	cc	_	_
-6	נקיים	קיים	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Tense=Fut|Voice=Act	1	conj	_	_
+6	נקיים	קיים	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Root=ק.י.מ|Tense=Fut|Voice=Act	1	conj	_	_
 7	את	את	ADP	ADP	Case=Acc	9	case:acc	_	_
 8-9	התורה	_	_	_	_	_	_	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	תורה	תורה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obj	_	_
 10-11	שלימדת	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	לימדת	לימד	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=2|Tense=Past|Voice=Act	9	acl:relcl	_	_
+11	לימדת	לימד	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=2|Root=ל.מ.ד|Tense=Past|Voice=Act	9	acl:relcl	_	_
 12-13	אותנו	_	_	_	_	_	_	_	_
 12	את_	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 13	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	11	obj	_	_
@@ -15034,7 +15034,7 @@
 
 # sent_id = 467
 # text = ניתן את רשות הדיבור לחבר תת-מקלע לחבר סכין.
-1	ניתן	נתן	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Fut|Voice=Act	0	root	_	_
+1	ניתן	נתן	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=נ.ת.נ|Tense=Fut|Voice=Act	0	root	_	_
 2	את	את	ADP	ADP	Case=Acc	3	case:acc	_	_
 3	רשות	רשות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	obj	_	_
 4-5	הדיבור	_	_	_	_	_	_	_	_
@@ -15068,11 +15068,11 @@
 # text = אט אט התחיל ההמון לצעוד אל מחוץ לסמטאות לעבר הכביש הראשי.
 1	אט	אט	ADV	ADV	_	3	advmod	_	_
 2	אט	אט	ADV	ADV	_	1	fixed	_	_
-3	התחיל	התחיל	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	התחיל	התחיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ת.ח.ל|Tense=Past	0	root	_	_
 4-5	ההמון	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	המון	המון	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
-6	לצעוד	צעד	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
+6	לצעוד	צעד	VERB	VERB	HebBinyan=PAAL|Root=צ.ע.ד|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 7	אל	אל	ADP	ADP	_	12	case	_	_
 8-9	מחוץ	_	_	_	_	_	_	_	_
 8	מ	מ	ADP	ADP	_	12	case	_	_
@@ -15102,10 +15102,10 @@
 6	כך	כך	PRON	PRON	Person=3|PronType=Dem	3	conj	_	_
 7	תוך	תוך	ADP	ADP	_	8	case	_	_
 8	קריאות	קריאה	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainHead|Number=Plur	6	dep	_	_
-9	גוברות	גבר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	8	amod	_	_
+9	גוברות	גבר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ג.ב.ר|VerbForm=Part|Voice=Act	8	amod	_	_
 10-11	והולכות	_	_	_	_	_	_	_	SpaceAfter=No
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
-11	הולכות	הלך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	9	conj	_	_
+11	הולכות	הלך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ה.ל.כ|VerbForm=Part|Voice=Act	9	conj	_	_
 12	:	:	PUNCT	PUNCT	_	14	punct	_	_
 13	"	"	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 14	מוות	מוות	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
@@ -15145,7 +15145,7 @@
 9-10	והוא	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
 10	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
-11	חיפש	חיפש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	conj	_	_
+11	חיפש	חיפש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ח.פ.ש|Tense=Past|Voice=Act	6	conj	_	_
 12	ערבים	ערבי	NOUN	NOUN	Gender=Masc|Number=Plur	11	obj	_	SpaceAfter=No
 13	.	.	PUNCT	PUNCT	_	6	punct	_	_
 
@@ -15156,18 +15156,18 @@
 3-4	בפעם	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	HebSource=ConvUncertainHead	1	fixed	_	_
 4	פעם	פעם	ADV	ADV	HebSource=ConvUncertainHead	1	fixed	_	_
-5	פרצה	פרץ	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	פרצה	פרץ	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ר.צ|Tense=Past|Voice=Act	0	root	_	_
 6	קבוצה	קבוצה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
 7	של	של	ADP	ADP	Case=Gen	9	case:gen	_	_
 8	כמה	כמה	DET	DET	Definite=Cons	9	det	_	_
 9	מאות	מאות	NUM	NUM	Gender=Fem|Number=Plur	6	nmod:poss	_	_
 10	הצידה	הצידה	ADV	ADV	_	5	advmod	_	_
 11	כאשר	כאשר	SCONJ	SCONJ	_	12	mark	_	_
-12	נדמה	נדמה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	5	advcl	_	_
+12	נדמה	נדמה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ד.מ.י|VerbForm=Part|Voice=Mid	5	advcl	_	_
 13	היה	היה	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	12	cop	_	_
 14-15	שגילתה	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
-15	גילתה	גילה	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	12	ccomp	_	_
+15	גילתה	גילה	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ג.ל.י|Tense=Past|Voice=Act	12	ccomp	_	_
 16	ערבי	ערבי	NOUN	NOUN	Gender=Masc|Number=Sing	15	obj	_	SpaceAfter=No
 17	.	.	PUNCT	PUNCT	_	5	punct	_	_
 
@@ -15190,7 +15190,7 @@
 6-7	ההלווייה	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	הלווייה	הלוויה	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
-8	נעלו	נעל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+8	נעלו	נעל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=נ.ע.ל|Tense=Past|Voice=Act	0	root	_	_
 9	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 10-12	פועליהם	_	_	_	_	_	_	_	_
 10	פועל_	פועל	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	8	obj	_	_
@@ -15209,11 +15209,11 @@
 2-3	מהם	_	_	_	_	_	_	_	_
 2	מן_	מן	ADP	ADP	_	3	case	_	_
 3	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
-4	עשו	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	עשו	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	0	root	_	_
 5	שטות	שטות	NOUN	NOUN	Gender=Fem|Number=Sing	4	obj	_	_
 6-7	והציצו	_	_	_	_	_	_	_	_
 6	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
-7	הציצו	הציץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	4	conj	_	_
+7	הציצו	הציץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=צ.ו.צ|Tense=Past|Voice=Act	4	conj	_	_
 8	מבעד	מבעד	ADP	ADP	_	11	case	_	_
 9-11	לחלונות	_	_	_	_	_	_	_	SpaceAfter=No
 9	ל	ל	ADP	ADP	_	8	fixed	_	_
@@ -15222,14 +15222,14 @@
 12	;	;	PUNCT	PUNCT	_	15	cc	_	_
 13	בתוך	בתוך	ADP	ADP	_	14	case	_	_
 14	דקות	דקה	NOUN	NOUN	Gender=Fem|Number=Plur	15	obl	_	_
-15	נופצו	נופץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	4	conj	_	_
+15	נופצו	נופץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=פ.ו.צ|Tense=Past|Voice=Pass	4	conj	_	_
 16	שמשות	שמשה	NOUN	NOUN	Gender=Fem|Number=Plur	15	nsubj	_	SpaceAfter=No
 17	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 476
 # text = מאחור צרו מאות על בניין הטלוויזיה.
 1	מאחור	מאחור	ADV	ADV	_	2	advmod	_	_
-2	צרו	צר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	צרו	צר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=צ.ו.ר|Tense=Past|Voice=Act	0	root	_	_
 3	מאות	מאות	NUM	NUM	Gender=Fem|Number=Plur	2	nsubj	_	_
 4	על	על	ADP	ADP	_	5	case	_	_
 5	בניין	בניין	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	obl	_	_
@@ -15242,7 +15242,7 @@
 # text = פרשי משטרה דחקו אותם לאחור.
 1	פרשי	פרש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	3	nsubj	_	_
 2	משטרה	משטרה	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
-3	דחקו	דחק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	דחקו	דחק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ד.ח.ק|Tense=Past|Voice=Act	0	root	_	_
 4-5	אותם	_	_	_	_	_	_	_	_
 4	את_	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 5	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	3	obj	_	_
@@ -15252,7 +15252,7 @@
 # sent_id = 478
 # text = שוטר נפגע מאבן בראשו.
 1	שוטר	שוטר	NOUN	NOUN	Gender=Masc|Number=Sing	2	nsubj	_	_
-2	נפגע	נפגע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+2	נפגע	נפגע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=פ.ג.ע|Tense=Past|Voice=Mid	0	root	_	_
 3-4	מאבן	_	_	_	_	_	_	_	_
 3	מ	מ	ADP	ADP	_	4	case	_	_
 4	אבן	אבן	NOUN	NOUN	Gender=Fem|Number=Sing	2	obl	_	_
@@ -15269,7 +15269,7 @@
 2	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	_
 3	של	של	ADP	ADP	Case=Gen	4	case:gen	_	_
 4	מפגינים	מפגין	NOUN	NOUN	Gender=Masc|Number=Plur	1	nmod	_	_
-5	פרצה	פרץ	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	פרצה	פרץ	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ר.צ|Tense=Past|Voice=Act	0	root	_	_
 6-8	למרכז	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -15296,7 +15296,7 @@
 3-4	הקפה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	קפה	קפה	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
-5	נבעתו	נבעת	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
+5	נבעתו	נבעת	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ב.ע.ת|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 481
@@ -15307,7 +15307,7 @@
 3	תינוק_	תינוק	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	_
 4	_של_	של	ADP	ADP	_	5	case:gen	_	_
 5	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nmod:poss	_	_
-6	פרצה	פרץ	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	פרצה	פרץ	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ר.צ|Tense=Past|Voice=Act	0	root	_	_
 7-8	בזעקות	_	_	_	_	_	_	_	SpaceAfter=No
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	זעקות	זעקה	NOUN	NOUN	Gender=Fem|Number=Plur	6	obl	_	_
@@ -15318,7 +15318,7 @@
 1	מיד	מייד	ADV	ADV	_	2	advmod	_	_
 2	אחר	אחר	ADP	ADP	_	3	case	_	_
 3	כך	כך	PRON	PRON	Person=3|PronType=Dem	4	obl	_	_
-4	נופצו	נופץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	נופצו	נופץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=נ.פ.צ|Tense=Past|Voice=Pass	0	root	_	_
 5	חלונות	חלון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	nsubj	_	_
 6	ראווה	ראווה	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
 7	של	של	ADP	ADP	Case=Gen	8	case:gen	_	_
@@ -15334,7 +15334,7 @@
 1-2	השוטרים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	שוטרים	שוטר	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
-3	הגיעו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הגיעו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=נ.ג.ע|Tense=Past|Voice=Act	0	root	_	_
 4	רק	רק	ADV	ADV	_	5	advmod	_	_
 5	אחרי	אחרי	ADP	ADP	_	7	case	_	_
 6	כמה	כמה	DET	DET	Definite=Cons	7	det	_	_

--- a/he_htb-ud-dev.conllu
+++ b/he_htb-ud-dev.conllu
@@ -5589,7 +5589,7 @@
 # text = וישנם גם הזוכים המיוחדים במובן היותר שנוי במחלוקת של המלה.
 1-2	וישנם	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	2	cc	_	_
-2	ישנם	יש	VERB	VERB	HebBinyan=_|HebExistential=True|Root=_	0	root	_	_
+2	ישנם	יש	VERB	VERB	HebExistential=True	0	root	_	_
 3	גם	גם	ADV	ADV	_	5	det	_	_
 4-5	הזוכים	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -13212,7 +13212,7 @@
 20	נאצים	נאצי	NOUN	NOUN	Gender=Masc|Number=Plur	18	nsubj	_	_
 21-22	בהגזה	_	_	_	_	_	_	_	SpaceAfter=No
 21	ב	ב	ADP	ADP	_	22	case	_	_
-22	הגזה	_	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=_|VerbForm=Part|Voice=Act	18	obl	_	_
+22	הגזה	_	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	18	obl	_	_
 23	,	,	PUNCT	PUNCT	_	22	punct	_	_
 24	אך	אך	CCONJ	CCONJ	_	27	cc	_	_
 25	לא	לא	ADV	ADV	Polarity=Neg	26	advmod	_	_

--- a/he_htb-ud-test.conllu
+++ b/he_htb-ud-test.conllu
@@ -2,7 +2,7 @@
 # text = הולקומב לא הזכיר את יכולתו, קרטר וסמית שהיו אמורים לעזור בריבאונד, נתקלו בקמבל ובורמור שקטפו את מרבית הכדורים החוזרים עובדה שאיפשרה לגליל לצאת להתקפות מתפרצות בורמור הוביל, גורדון ומטלון סיימו במרבית המקרים בסל.
 1	הולקומב	הולקומב	PROPN	PROPN	_	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ז.כ.ר|Tense=Past|Voice=Act	0	root	_	_
 4	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 5-7	יכולתו	_	_	_	_	_	_	_	SpaceAfter=No
 5	יכולת_	יכולת	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	3	obj	_	_
@@ -17,12 +17,12 @@
 12	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
 13	היו	_	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	14	cop	_	_
 14	אמורים	אמור	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbType=Mod	9	acl:relcl	_	_
-15	לעזור	עזר	VERB	VERB	HebBinyan=PAAL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	14	dep	_	_
+15	לעזור	עזר	VERB	VERB	HebBinyan=PAAL|HebSource=ConvUncertainHead|Root=ע.ז.ר|VerbForm=Inf|Voice=Act	14	dep	_	_
 16-17	בריבאונד	_	_	_	_	_	_	_	SpaceAfter=No
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	ריבאונד	ריבאונד	NOUN	NOUN	Gender=Masc|Number=Sing	14	obl	_	_
 18	,	,	PUNCT	PUNCT	_	19	punct	_	_
-19	נתקלו	נתקל	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	3	parataxis	_	_
+19	נתקלו	נתקל	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ת.ק.ל|Tense=Past|Voice=Mid	3	parataxis	_	_
 20-21	בקמבל	_	_	_	_	_	_	_	_
 20	ב	ב	ADP	ADP	_	21	case	_	_
 21	קמבל	קמבל	PROPN	PROPN	_	19	obl	_	_
@@ -31,7 +31,7 @@
 23	בורמור	בורמור	PROPN	PROPN	_	21	conj	_	_
 24-25	שקטפו	_	_	_	_	_	_	_	_
 24	ש	ש	SCONJ	SCONJ	_	25	mark	_	_
-25	קטפו	קטף	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	21	acl:relcl	_	_
+25	קטפו	קטף	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ק.ט.פ|Tense=Past|Voice=Act	21	acl:relcl	_	_
 26	את	את	ADP	ADP	Case=Acc	29	case:acc	_	_
 27	מרבית	מרבית	DET	DET	Definite=Cons	29	det	_	_
 28-29	הכדורים	_	_	_	_	_	_	_	_
@@ -43,24 +43,24 @@
 32	עובדה	עובדה	NOUN	NOUN	Gender=Fem|Number=Sing	21	nmod	_	_
 33-34	שאיפשרה	_	_	_	_	_	_	_	_
 33	ש	ש	SCONJ	SCONJ	_	34	mark	_	_
-34	איפשרה	אפשר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	32	acl:relcl	_	_
+34	איפשרה	אפשר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=א.פ.ש.ר|Tense=Past|Voice=Act	32	acl:relcl	_	_
 35-37	לגליל	_	_	_	_	_	_	_	_
 35	ל	ל	ADP	ADP	_	37	case	_	_
 36	ה_	ה	DET	DET	PronType=Art	37	det:def	_	_
 37	גליל	גליל	NOUN	NOUN	Gender=Masc|Number=Sing	34	obl	_	_
-38	לצאת	יצא	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	34	xcomp	_	_
+38	לצאת	יצא	VERB	VERB	HebBinyan=PAAL|Root=י.צ.א|VerbForm=Inf|Voice=Act	34	xcomp	_	_
 39-40	להתקפות	_	_	_	_	_	_	_	_
 39	ל	ל	ADP	ADP	_	40	case	_	_
 40	התקפות	התקפה	NOUN	NOUN	Gender=Fem|Number=Plur	34	obl	_	_
-41	מתפרצות	התפרץ	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	40	amod	_	_
+41	מתפרצות	התפרץ	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=פ.ר.צ|VerbForm=Part	40	amod	_	_
 42	בורמור	בורמור	PROPN	PROPN	_	43	nsubj	_	_
-43	הוביל	הוביל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	40	acl	_	SpaceAfter=No
+43	הוביל	הוביל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ב.ל|Tense=Past|Voice=Act	40	acl	_	SpaceAfter=No
 44	,	,	PUNCT	PUNCT	_	43	punct	_	_
 45	גורדון	גורדון	PROPN	PROPN	_	48	nsubj	_	_
 46-47	ומטלון	_	_	_	_	_	_	_	_
 46	ו	ו	CCONJ	CCONJ	_	47	cc	_	_
 47	מטלון	מטלון	PROPN	PROPN	_	45	conj	_	_
-48	סיימו	סיים	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	43	parataxis	_	_
+48	סיימו	סיים	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ס.י.מ|Tense=Past|Voice=Act	43	parataxis	_	_
 49-50	במרבית	_	_	_	_	_	_	_	_
 49	ב	ב	ADP	ADP	_	52	case	_	_
 50	מרבית	מרבית	DET	DET	Definite=Cons	52	det	_	_
@@ -98,7 +98,7 @@
 3	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	nmod:poss	_	_
 4	של	של	ADP	ADP	Case=Gen	5	case:gen	_	_
 5	ליף	ליף	PROPN	PROPN	_	1	nmod:poss	_	_
-6	גררה	גרר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	גררה	גרר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ג.ר.ר|Tense=Past|Voice=Act	0	root	_	_
 7	בתוך	בתוך	ADP	ADP	_	8	case	_	_
 8	דקה	דקה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
 9	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
@@ -119,7 +119,7 @@
 3-4	וגורדון	_	_	_	_	_	_	_	_
 3	ו	ו	CCONJ	CCONJ	_	4	cc	_	_
 4	גורדון	גורדון	PROPN	PROPN	_	2	conj	_	_
-5	דייקו	דייק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	דייקו	דייק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ד.י.ק|Tense=Past|Voice=Act	0	root	_	_
 6-9	בקליעותיהם	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	קליעה_	קליעה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	5	obl	_	_
@@ -127,7 +127,7 @@
 9	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	7	nmod:poss	_	_
 10-11	והבטיחו	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
-11	הבטיחו	הבטיח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	5	conj	_	_
+11	הבטיחו	הבטיח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ב.ט.ח|Tense=Past|Voice=Act	5	conj	_	_
 12	את	את	ADP	ADP	Case=Acc	14	case:acc	_	_
 13-14	הניצחון	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
@@ -142,14 +142,14 @@
 # text = מלכתחילה היה ברור שתוצאת המשחק תלוייה אך ורק בהפועל חולון.
 1	מלכתחילה	מלכתחילה	ADV	ADV	_	3	advmod	_	_
 2	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	3	cop	_	_
-3	ברור	ברר	VERB	VERB	Gender=Masc|Mood=Imp|Number=Sing|Person=2	0	root	_	_
+3	ברור	ברר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Mood=Imp|Number=Sing|Person=2|Root=ב.ר.ר	0	root	_	_
 4-5	שתוצאת	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
 5	תוצאת	תוצאה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	8	nsubj	_	_
 6-7	המשחק	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	משחק	משחק	NOUN	NOUN	Gender=Masc|Number=Sing	5	compound:smixut	_	_
-8	תלוייה	תלוי	VERB	VERB	VerbForm=Part	3	ccomp	_	_
+8	תלוייה	תלוי	VERB	VERB	HebBinyan=PAAL|Root=ת.ל.י|VerbForm=Part	3	ccomp	_	_
 9	אך	אך	ADV	ADV	_	12	advmod	_	_
 10-11	ורק	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
@@ -164,9 +164,9 @@
 # sent_id = 5731
 # text = הוא הצליח לא לאבד אותו.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	הצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ל.ח|Tense=Past|Voice=Act	0	root	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	2	advmod	_	_
-4	לאבד	איבד	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
+4	לאבד	איבד	VERB	VERB	HebBinyan=PIEL|Root=א.ב.ד|VerbForm=Inf|Voice=Act	2	xcomp	_	_
 5-6	אותו	_	_	_	_	_	_	_	SpaceAfter=No
 5	את_	את_	ADP	ADP	Case=Acc	6	case:acc	_	_
 6	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	obj	_	_
@@ -174,7 +174,7 @@
 
 # sent_id = 5732
 # text = עזרו לו שחקני בית"ר שהחלו את ההתמודדות בצורה גרועה, עם מייקל האקט כרכז עובדה שהותירה את סל חולון לא מאויים, כי לא היה בבית"ר מי שיקלע.
-1	עזרו	עזר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+1	עזרו	עזר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ז.ר|Tense=Past|Voice=Act	0	root	_	_
 2-3	לו	_	_	_	_	_	_	_	_
 2	ל_	ל	ADP	ADP	_	3	case	_	_
 3	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	obl	_	_
@@ -182,7 +182,7 @@
 5	בית"ר	בית"ר	PROPN	PROPN	Abbr=Yes	4	compound:smixut	_	_
 6-7	שהחלו	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
-7	החלו	החל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	4	acl:relcl	_	_
+7	החלו	החל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ח.ל.ל|Tense=Past|Voice=Act	4	acl:relcl	_	_
 8	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 9-10	ההתמודדות	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -201,7 +201,7 @@
 20	עובדה	עובדה	NOUN	NOUN	Gender=Fem|Number=Sing	16	nmod	_	_
 21-22	שהותירה	_	_	_	_	_	_	_	_
 21	ש	ש	SCONJ	SCONJ	_	22	mark	_	_
-22	הותירה	הותיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	20	acl:relcl	_	_
+22	הותירה	הותיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ת.ר|Tense=Past|Voice=Act	20	acl:relcl	_	_
 23	את	את	ADP	ADP	Case=Acc	24	case:acc	_	_
 24	סל	סל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	22	obj	_	_
 25	חולון	חולון	PROPN	PROPN	_	24	compound:smixut	_	_
@@ -210,20 +210,20 @@
 28	,	,	PUNCT	PUNCT	_	22	punct	_	_
 29	כי	כי	SCONJ	SCONJ	_	31	mark	_	_
 30	לא	לא	ADV	ADV	Polarity=Neg	31	advmod	_	_
-31	היה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	22	ccomp	_	_
+31	היה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	22	ccomp	_	_
 32-33	בבית"ר	_	_	_	_	_	_	_	_
 32	ב	ב	ADP	ADP	_	33	case	_	_
 33	בית"ר	בית"ר	PROPN	PROPN	Abbr=Yes	31	obl	_	_
 34	מי	מי	ADV	ADV	PronType=Int	31	nsubj	_	_
 35-36	שיקלע	_	_	_	_	_	_	_	SpaceAfter=No
 35	ש	ש	SCONJ	SCONJ	_	36	mark	_	_
-36	יקלע	קלע	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	34	acl:relcl	_	_
+36	יקלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ל.ע|Tense=Fut	34	acl:relcl	_	_
 37	.	.	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 5733
 # text = חולון ניצלה זאת ל-212 (דקה 3) ו-617 (דקה 5).
 1	חולון	חולון	PROPN	PROPN	_	2	nsubj	_	_
-2	ניצלה	ניצל	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
+2	ניצלה	ניצל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.צ.ל|Tense=Past	0	root	_	_
 3	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	obj	_	_
 4	ל	ל	ADP	ADP	_	6	case	_	SpaceAfter=No
 5	-	-	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
@@ -273,7 +273,7 @@
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	סל	סל	NOUN	NOUN	Gender=Masc|Number=Sing	20	compound:smixut	_	_
 23	,	,	PUNCT	PUNCT	_	24	punct	_	_
-24	החזירה	החזיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+24	החזירה	החזיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Past|Voice=Act	0	root	_	_
 25	את	את	ADP	ADP	Case=Acc	26	case:acc	_	_
 26	בית"ר	בית"ר	PROPN	PROPN	Abbr=Yes	24	obj	_	_
 27-29	למשחק	_	_	_	_	_	_	_	SpaceAfter=No
@@ -285,7 +285,7 @@
 # sent_id = 5735
 # text = האקט החל בצבירת נקודות (33 בסך הכל) שגרדו חלק מהפער לזכות חולון עד כדי שלוש נקודות בלבד, 53 50 בדקה ה-25.
 1	האקט	האקט	PROPN	PROPN	_	2	nsubj	_	_
-2	החל	החל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	החל	החל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ל.ל|Tense=Past|Voice=Act	0	root	_	_
 3-4	בצבירת	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	צבירת	צבירה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	2	obl	_	_
@@ -299,7 +299,7 @@
 11	)	)	PUNCT	PUNCT	_	7	punct	_	_
 12-13	שגרדו	_	_	_	_	_	_	_	_
 12	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
-13	גרדו	גירד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	5	acl:relcl	_	_
+13	גרדו	גירד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ג.ר.ד|Tense=Past|Voice=Act	5	acl:relcl	_	_
 14	חלק	חלק	NOUN	NOUN	Gender=Masc|Number=Sing	17	det	_	_
 15-17	מהפער	_	_	_	_	_	_	_	_
 15	מ	מ	ADP	ADP	HebSource=ConvUncertainLabel	17	case	_	_
@@ -347,7 +347,7 @@
 14	סך	סך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	obl	_	_
 15	הכל	הכיל	NOUN	NOUN	_	14	compound:smixut	_	SpaceAfter=No
 16	)	)	PUNCT	PUNCT	_	12	punct	_	_
-17	החזירה	החזיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+17	החזירה	החזיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Past|Voice=Act	0	root	_	_
 18	את	את	ADP	ADP	Case=Acc	19	case:acc	_	_
 19	חולון	חולון	PROPN	PROPN	_	17	obj	_	_
 20-21	ליתרון	_	_	_	_	_	_	_	_
@@ -365,7 +365,7 @@
 4-5	בו	_	_	_	_	_	_	_	_
 4	ב_	ב	ADP	ADP	_	5	case	_	_
 5	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	obl	_	_
-6	קלט	קלט	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	acl	_	_
+6	קלט	קלט	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ל.ט|Tense=Past|Voice=Act	3	acl	_	_
 7	ויליאמס	ויליאמס	PROPN	PROPN	_	6	nsubj	_	_
 8	ריבאונדים	ריבאונד	NOUN	NOUN	Gender=Masc|Number=Plur	6	obj	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	6	punct	_	_
@@ -389,7 +389,7 @@
 25-26	למה	_	_	_	_	_	_	_	_
 25	ל	ל	ADP	ADP	_	26	case	_	_
 26	מה	מה	ADV	ADV	PronType=Int	21	obl	_	_
-27	לצפות	ציפה	VERB	VERB	VerbForm=Inf	26	dep	_	SpaceAfter=No
+27	לצפות	ציפה	VERB	VERB	HebBinyan=PIEL|Root=צ.פ.י|VerbForm=Inf	26	dep	_	SpaceAfter=No
 28	.	.	PUNCT	PUNCT	_	21	punct	_	_
 
 # sent_id = 5738
@@ -406,7 +406,7 @@
 8-9	וויליאמס	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
 9	ויליאמס	ויליאמס	PROPN	PROPN	_	7	conj	_	_
-10	חיפה	חיפה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+10	חיפה	חיפה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ח.פ.י|Tense=Past|Voice=Act	0	root	_	_
 11	על	על	ADP	ADP	_	12	case	_	_
 12	מחצית	מחצית	NOUN	NOUN	Gender=Fem|Number=Sing	10	obl	_	_
 13	שניה	שניה	NUM	NUM	Gender=Fem|Number=Sing	12	amod	_	_
@@ -437,7 +437,7 @@
 34	דלזל	דלזל	PROPN	PROPN	_	16	conj	_	_
 35-36	שהסתפק	_	_	_	_	_	_	_	_
 35	ש	ש	SCONJ	SCONJ	_	36	mark	_	_
-36	הסתפק	הסתפק	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	34	acl:relcl	_	_
+36	הסתפק	הסתפק	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ס.פ.ק|Tense=Past	34	acl:relcl	_	_
 37-38	בשלשה	_	_	_	_	_	_	_	_
 37	ב	ב	ADP	ADP	_	38	case	_	_
 38	שלשה	שלשה	NOUN	NOUN	Gender=Fem|Number=Sing	36	obl	_	_
@@ -451,7 +451,7 @@
 2	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	ליגה	ליגה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
-5	יוצאת	יצא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	1	ccomp	_	_
+5	יוצאת	יצא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=י.צ.א|VerbForm=Part|Voice=Act	1	ccomp	_	_
 6-7	לפגרה	_	_	_	_	_	_	_	SpaceAfter=No
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	פגרה	פגרה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
@@ -482,7 +482,7 @@
 16	להיט	להיט	NOUN	NOUN	Gender=Masc|Number=Sing	11	obl	_	_
 17	אמיתי	אמיתי	ADJ	ADJ	Gender=Masc|Number=Sing	16	amod	_	SpaceAfter=No
 18	,	,	PUNCT	PUNCT	_	19	punct	_	_
-19	תצא	יצא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	2	ccomp	_	_
+19	תצא	יצא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=י.צ.א|Tense=Fut|Voice=Act	2	ccomp	_	_
 20-21	להפסקה	_	_	_	_	_	_	_	_
 20	ל	ל	ADP	ADP	_	21	case	_	_
 21	הפסקה	הפסקה	NOUN	NOUN	Gender=Fem|Number=Sing	19	obl	_	_
@@ -500,7 +500,7 @@
 1	מי	מי	ADV	ADV	PronType=Int	15	nsubj:cop	_	_
 2-3	שיהנה	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	3	mark	_	_
-3	יהנה	נהנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	1	acl:relcl	_	_
+3	יהנה	נהנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ה.נ.י|Tense=Fut|Voice=Mid	1	acl:relcl	_	_
 4-5	מכך	_	_	_	_	_	_	_	SpaceAfter=No
 4	מ	מ	ADP	ADP	_	5	case	_	_
 5	כך	כך	PRON	PRON	Person=3|PronType=Dem	3	obl	_	_
@@ -532,7 +532,7 @@
 4	של	של	ADP	ADP	Case=Gen	5	case:gen	_	_
 5	משה	משה	PROPN	PROPN	_	1	nmod:poss	_	_
 6	ויינקרנץ	ויינקרנץ	PROPN	PROPN	_	5	flat:name	_	_
-7	ישקיפו	השקיף	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+7	ישקיפו	השקיף	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ש.ק.פ|Tense=Fut|Voice=Act	0	root	_	_
 8	על	על	ADP	ADP	_	10	case	_	_
 9-10	הליגה	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -555,7 +555,7 @@
 2	חידוש_	חידוש	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 3	_של_	של	ADP	ADP	_	4	case:gen	_	_
 4	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nmod:poss	_	_
-5	יארחו	אירח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+5	יארחו	אירח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=א.ר.ח|Tense=Fut|Voice=Act	0	root	_	_
 6	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 7	מכבי	מכבי	PROPN	PROPN	_	5	obj	_	_
 8	תל	תל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	flat:name	_	_
@@ -566,7 +566,7 @@
 # text = אפשר כבר להכין את הכרטיסים.
 1	אפשר	אפשר	AUX	AUX	VerbType=Mod	3	aux	_	_
 2	כבר	כבר	ADV	ADV	_	1	advmod	_	_
-3	להכין	הכין	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+3	להכין	הכין	VERB	VERB	HebBinyan=HIFIL|Root=כ.ו.נ|VerbForm=Inf|Voice=Act	0	root	_	_
 4	את	את	ADP	ADP	Case=Acc	6	case:acc	_	_
 5-6	הכרטיסים	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -579,7 +579,7 @@
 2	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	9	obl	_	_
 3-4	שהיה	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	היה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	2	acl:relcl	_	_
+4	היה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	2	acl:relcl	_	_
 5-6	להם	_	_	_	_	_	_	_	_
 5	ל_	ל	ADP	ADP	_	6	case	_	_
 6	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	4	obl	_	_
@@ -590,7 +590,7 @@
 10	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
 11	אמש	אמש	ADV	ADV	_	13	advmod	_	_
 12	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
-13	הוסר	הוסר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	9	advcl	_	SpaceAfter=No
+13	הוסר	הוסר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ס.ו.ר|Tense=Past|Voice=Pass	9	advcl	_	SpaceAfter=No
 14	.	.	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 5746
@@ -599,7 +599,7 @@
 2-3	לציון	_	_	_	_	_	_	_	_
 2	ל	ל	ADP	ADP	_	3	case	_	_
 3	ציון	ציון	PROPN	PROPN	_	1	flat:name	_	_
-4	באה	בא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	באה	בא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ב.ו.א|Tense=Past|Voice=Act	0	root	_	_
 5-7	לאולם	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -609,7 +609,7 @@
 9	אוסישקין	אוסישקין	PROPN	PROPN	_	7	nmod	_	_
 10-11	ותבעה	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
-11	תבעה	תבע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	conj	_	_
+11	תבעה	תבע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ת.ב.ע|Tense=Past|Voice=Act	4	conj	_	_
 12	קורבן	קורבן	NOUN	NOUN	Gender=Masc|Number=Sing	11	obj	_	_
 13	נוסף	נוסף	ADJ	ADJ	Gender=Masc|Number=Sing	12	amod	_	_
 14-15	הפועל	_	_	_	_	_	_	_	_
@@ -630,7 +630,7 @@
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	סיום	סיום	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod	_	_
-8	אומרת	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+8	אומרת	אמר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=א.מ.ר|VerbForm=Part|Voice=Act	0	root	_	_
 9	הכל	הכיל	NOUN	NOUN	_	8	obj	_	SpaceAfter=No
 10	,	,	PUNCT	PUNCT	_	8	punct	_	_
 11	גם	גם	ADV	ADV	_	8	advmod	_	_
@@ -655,7 +655,7 @@
 # text = ראשל"ץ יכולה לראות עצמה עתה, חזק בתמונת המאבק על 41.
 1	ראשל"ץ	ראשל"ץ	PROPN	PROPN	Abbr=Yes	2	nsubj	_	_
 2	יכולה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	3	aux	_	_
-3	לראות	ראה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+3	לראות	ראה	VERB	VERB	HebBinyan=PAAL|Root=ר.א.י|VerbForm=Inf|Voice=Act	0	root	_	_
 4	עצמה	עצמו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
 5	עתה	עתה	ADV	ADV	_	2	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	2	punct	_	_
@@ -712,7 +712,7 @@
 # sent_id = 5751
 # text = גבת החמיצה הזדמנות נדירה.
 1	גבת	גבת	PROPN	PROPN	_	2	nsubj	_	_
-2	החמיצה	החמיץ	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	החמיצה	החמיץ	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.מ.צ|Tense=Past|Voice=Act	0	root	_	_
 3	הזדמנות	הזדמנות	NOUN	NOUN	Gender=Fem|Number=Sing	2	obj	_	_
 4	נדירה	נדיר	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	SpaceAfter=No
 5	.	.	PUNCT	PUNCT	_	2	punct	_	_
@@ -724,7 +724,7 @@
 2	מכבי	מכבי	PROPN	PROPN	_	5	obl	_	_
 3	פגרה	פגרה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
 4	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	det	_	_
-5	באה	בא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	באה	בא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ב.ו.א|Tense=Past|Voice=Act	0	root	_	_
 6	בדיוק	בדיוק	ADV	ADV	_	7	advmod	_	_
 7-9	בזמן	_	_	_	_	_	_	_	SpaceAfter=No
 7	ב	ב	ADP	ADP	_	9	case	_	_
@@ -760,7 +760,7 @@
 3	הורטון	הורטון	PROPN	PROPN	_	2	flat:name	_	_
 4-5	ששיחק	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	שיחק	שיחק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	acl:relcl	_	_
+5	שיחק	שיחק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.ח.ק|Tense=Past|Voice=Act	2	acl:relcl	_	_
 6	רק	רק	ADV	ADV	_	8	det	_	_
 7	שתי	שתי	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	8	nummod	_	_
 8	דקות	דקה	NOUN	NOUN	Gender=Fem|Number=Plur	5	dep	_	_
@@ -798,7 +798,7 @@
 3-4	המקומית	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	מקומית	מקומי	ADJ	ADJ	Gender=Fem|Number=Sing	2	amod	_	_
-5	הדהימה	הדהים	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	הדהימה	הדהים	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ד.ה.מ|Tense=Past|Voice=Act	0	root	_	_
 6	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 7-8	המוביל	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -811,7 +811,7 @@
 13	83	83	NUM	NUM	_	12	nummod	_	_
 14-15	והנחילה	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
-15	הנחילה	הנחיל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	conj	_	_
+15	הנחילה	הנחיל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ח.ל|Tense=Past|Voice=Act	5	conj	_	_
 16-17	לו	_	_	_	_	_	_	_	_
 16	ל_	ל	ADP	ADP	_	17	case	_	_
 17	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	obl	_	_
@@ -819,7 +819,7 @@
 19	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	18	compound:smixut	_	_
 20	ראשון	_	ADJ	ADJ	Gender=Masc|Number=Sing	18	amod	_	_
 21	אשר	אשר	SCONJ	SCONJ	_	22	mark	_	_
-22	הוריד	הוריד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	18	acl:relcl	_	_
+22	הוריד	הוריד	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ר.ד|Tense=Past|Voice=Act	18	acl:relcl	_	_
 23-24	אותו	_	_	_	_	_	_	_	_
 23	את_	את_	ADP	ADP	Case=Acc	24	case:acc	_	_
 24	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	22	obj	_	_
@@ -838,7 +838,7 @@
 2-3	השרון	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	שרון	שרון	PROPN	PROPN	_	1	compound:smixut	_	_
-4	קפצה	קפץ	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
+4	קפצה	קפץ	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.פ.צ|Tense=Past	0	root	_	_
 5	שני	שני	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	6	nummod	_	_
 6	שלבים	שלב	NOUN	NOUN	Gender=Masc|Number=Plur	4	dep	_	_
 7-9	מהמקום	_	_	_	_	_	_	_	_
@@ -850,7 +850,7 @@
 11	אחרון	אחרון	ADJ	ADJ	Gender=Masc|Number=Sing	9	amod	_	_
 12-13	והותירה	_	_	_	_	_	_	_	_
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
-13	הותירה	הותיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	conj	_	_
+13	הותירה	הותיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ת.ר|Tense=Past|Voice=Act	4	conj	_	_
 14	מאחור	מאחור	ADV	ADV	_	13	advmod	_	_
 15	את	את	ADP	ADP	Case=Acc	16	case:acc	_	_
 16	גבת	גבת	PROPN	PROPN	_	13	obj	_	_
@@ -866,7 +866,7 @@
 2	ניצחונות	ניצחון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	nsubj	_	_
 3	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
 4	צפויים	צפוי	ADJ	ADJ	Gender=Masc|Number=Plur	2	amod	_	_
-5	הושגו	הושג	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+5	הושגו	הושג	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=נ.שׂ.ג|Tense=Past|Voice=Pass	0	root	_	_
 6-7	בכפר	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	כפר	כפר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
@@ -884,7 +884,7 @@
 2	פועל	פועל	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
 3	גליל	גליל	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod	_	_
 4	עליון	עליון	ADJ	ADJ	Gender=Masc|Number=Sing	3	amod	_	_
-5	שכח	שכח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	שכח	שכח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.כ.ח|Tense=Past|Voice=Act	0	root	_	_
 6	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 7-8	התקריות	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -894,13 +894,13 @@
 10	שבוע	שבוע	NOUN	NOUN	Gender=Masc|Number=Sing	8	nmod	_	_
 11-12	שעבר	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-12	עבר	עבר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	10	acl:relcl	_	_
+12	עבר	עבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past	10	acl:relcl	_	_
 13-14	בירושלים	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	ירושלים	ירושלים	PROPN	PROPN	_	8	nmod	_	_
 15-16	וניצח	_	_	_	_	_	_	_	_
 15	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
-16	ניצח	ניצח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	conj	_	_
+16	ניצח	ניצח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.צ.ח|Tense=Past|Voice=Act	5	conj	_	_
 17	את	את	ADP	ADP	Case=Acc	18	case:acc	_	_
 18	מכבי	מכבי	PROPN	PROPN	_	16	obj	_	_
 19	רמת	רמה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	18	flat:name	_	_
@@ -940,7 +940,7 @@
 2	מלמיליאן	מלמיליאן	PROPN	PROPN	_	1	flat:name	_	_
 3-4	הסובל	_	_	_	_	_	_	_	_
 3	ה	ה	SCONJ	SCONJ	_	4	mark	_	_
-4	סובל	סבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
+4	סובל	סבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ס.ב.ל|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
 5-6	מפציעה	_	_	_	_	_	_	_	_
 5	מ	מ	ADP	ADP	_	6	case	_	_
 6	פציעה	פציעה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
@@ -949,7 +949,7 @@
 8	ברך_	ברך	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	6	nmod	_	_
 9	_של_	של	ADP	ADP	_	10	case:gen	_	_
 10	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nmod:poss	_	_
-11	עבר	עבר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+11	עבר	עבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past	0	root	_	_
 12	אתמול	אתמול	ADV	ADV	_	11	advmod	_	_
 13	ניתוח	ניתוח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	obj	_	_
 14	ארתרוסקופיה	ארתרוסקופיה	NOUN	NOUN	_	13	compound:smixut	_	SpaceAfter=No
@@ -969,7 +969,7 @@
 8	שבועות	שבוע	NOUN	NOUN	Gender=Masc|Number=Plur	5	dep	_	_
 9-10	ויחזור	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	10	cc	_	_
-10	יחזור	חזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	5	conj	_	_
+10	יחזור	חזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Fut|Voice=Act	5	conj	_	_
 11-12	בהדרגה	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	הדרגה	הדרגה	NOUN	NOUN	Gender=Fem|Number=Sing	10	obl	_	_
@@ -982,8 +982,8 @@
 # sent_id = 5764
 # text = הוא ישוב לשחק רק בעוד שישה שבועות.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	ישוב	שב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
-3	לשחק	שיחק	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
+2	ישוב	שב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.ו.ב|Tense=Fut|Voice=Act	0	root	_	_
+3	לשחק	שיחק	VERB	VERB	HebBinyan=PIEL|Root=ש.ח.ק|VerbForm=Inf|Voice=Act	2	xcomp	_	_
 4	רק	רק	ADV	ADV	_	5	advmod	_	_
 5	בעוד	בעוד	ADP	ADP	_	7	case	_	_
 6	שישה	שישה	NUM	NUM	Gender=Masc|Number=Sing	7	nummod	_	_
@@ -993,13 +993,13 @@
 # sent_id = 5765
 # text = הנהלה תדון עם המאמן כיצד להוציא את הפועל כפ"ס מן המצב הקשה אליו נקלעה.
 1	הנהלה	הנהלה	NOUN	NOUN	Gender=Fem|Number=Sing	2	nsubj	_	_
-2	תדון	דן	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Fut	0	root	_	_
+2	תדון	דן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ד.ו.נ|Tense=Fut	0	root	_	_
 3	עם	עם	ADP	ADP	_	5	case	_	_
 4-5	המאמן	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	מאמן	מאמן	NOUN	NOUN	Gender=Masc|Number=Sing	2	obl	_	_
 6	כיצד	כיצד	ADV	ADV	PronType=Int	7	advmod	_	_
-7	להוציא	הוציא	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
+7	להוציא	הוציא	VERB	VERB	HebBinyan=HIFIL|Root=י.צ.א|VerbForm=Inf|Voice=Act	2	xcomp	_	_
 8	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 9-10	הפועל	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -1015,7 +1015,7 @@
 17-18	אליו	_	_	_	_	_	_	_	_
 17	אל_	אל	ADP	ADP	_	18	case	_	_
 18	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	19	obl	_	_
-19	נקלעה	נקלע	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	14	acl	_	SpaceAfter=No
+19	נקלעה	נקלע	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ק.ל.ע|Tense=Past|Voice=Mid	14	acl	_	SpaceAfter=No
 20	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 5766
@@ -1023,14 +1023,14 @@
 1-2	בכפ"ס	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	כפ"ס	כפ"ס	PROPN	PROPN	Abbr=Yes	3	obl	_	_
-3	הכחישו	הכחיש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הכחישו	הכחיש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=כ.ח.ש|Tense=Past|Voice=Act	0	root	_	_
 4	אמש	אמש	ADV	ADV	_	3	advmod	_	_
 5-6	שנוהלו	_	_	_	_	_	_	_	SpaceAfter=No
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	נוהלו	נוהל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	3	ccomp	_	_
+6	נוהלו	נוהל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=נ.ה.ל|Tense=Past|Voice=Pass	3	ccomp	_	_
 7	,	,	PUNCT	PUNCT	_	6	punct	_	_
 8	או	או	CCONJ	CCONJ	_	9	cc	_	_
-9	מתנהלים	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	6	conj	_	SpaceAfter=No
+9	מתנהלים	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=נ.ה.ל|VerbForm=Part	6	conj	_	SpaceAfter=No
 10	,	,	PUNCT	PUNCT	_	6	punct	_	_
 11	מגעים	מגע	NOUN	NOUN	Gender=Masc|Number=Plur	6	nsubj	_	_
 12	עם	עם	ADP	ADP	_	13	case	_	_
@@ -1045,7 +1045,7 @@
 2	דיעה	דעה	NOUN	NOUN	Gender=Fem|Number=Sing	17	nsubj:cop	_	_
 3-4	הרווחת	_	_	_	_	_	_	_	_
 3	ה	ה	SCONJ	SCONJ	_	4	mark	_	_
-4	רווחת	רווח	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	acl:relcl	_	_
+4	רווחת	רווח	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.ו.ח|VerbForm=Part|Voice=Act	2	acl:relcl	_	_
 5-6	בחוגי	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	חוגי	חוג	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	obl	_	_
@@ -1061,7 +1061,7 @@
 14	עכשיו	עכשיו	ADV	ADV	_	17	advmod	_	_
 15	וויטאק	וויטאק	PROPN	PROPN	_	17	nsubj	_	_
 16	לאזארק	לאזארק	PROPN	PROPN	_	15	flat:name	_	_
-17	יישאר	נשאר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	0	root	_	_
+17	יישאר	נשאר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.א.ר|Tense=Fut|Voice=Mid	0	root	_	_
 18	מאמן	מאמן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	17	nsubj	_	_
 19-20	הקבוצה	_	_	_	_	_	_	_	SpaceAfter=No
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
@@ -1074,14 +1074,14 @@
 2	עם	עם	ADP	ADP	_	1	fixed	_	_
 3	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	1	fixed	_	_
 4	אין	אין	ADV	ADV	Polarity=Neg	5	advmod	_	_
-5	מכחישים	הכחיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
+5	מכחישים	הכחיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=כ.ח.ש|VerbForm=Part|Voice=Act	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	5	punct	_	_
 7	כי	כי	SCONJ	SCONJ	_	17	mark	_	_
 8	כל	כול	DET	DET	Definite=Cons	9	det	_	_
 9	צעד	צעד	NOUN	NOUN	Gender=Masc|Number=Sing	17	nsubj	_	_
 10-11	שיביא	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	יביא	הביא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	9	acl:relcl	_	_
+11	יביא	הביא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ב.ו.א|Tense=Fut|Voice=Act	9	acl:relcl	_	_
 12-13	להבראת	_	_	_	_	_	_	_	_
 12	ל	ל	ADP	ADP	_	13	case	_	_
 13	הבראת	הבראה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	11	obl	_	_
@@ -1099,8 +1099,8 @@
 # sent_id = 5769
 # text = בינתיים הוחלט לרכוש חלוץ חדש.
 1	בינתיים	בינתיים	ADV	ADV	_	2	advmod	_	_
-2	הוחלט	הוחלט	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
-3	לרכוש	רכש	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
+2	הוחלט	הוחלט	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ח.ל.ט|Tense=Past|Voice=Pass	0	root	_	_
+3	לרכוש	רכש	VERB	VERB	HebBinyan=PAAL|Root=ר.כ.ש|VerbForm=Inf|Voice=Act	2	xcomp	_	_
 4	חלוץ	חלוץ	NOUN	NOUN	Gender=Masc|Number=Sing	3	obj	_	_
 5	חדש	חדש	ADJ	ADJ	Gender=Masc|Number=Sing	4	amod	_	SpaceAfter=No
 6	.	.	PUNCT	PUNCT	_	2	punct	_	_
@@ -1110,7 +1110,7 @@
 1-2	החיפושים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	חיפושים	חיפוש	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
-3	מתנהלים	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	0	root	_	_
+3	מתנהלים	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=נ.ה.ל|VerbForm=Part	0	root	_	_
 4-5	בשני	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	6	case	_	_
 5	שני	שני	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	6	nummod	_	_
@@ -1164,7 +1164,7 @@
 # sent_id = 5772
 # text = אתמול ערך לאזארק אימון והיום אמור להיות אימון נוסף.
 1	אתמול	אתמול	ADV	ADV	_	2	advmod	_	_
-2	ערך	ערך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	ערך	ערך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ר.כ|Tense=Past|Voice=Act	0	root	_	_
 3	לאזארק	לאזארק	PROPN	PROPN	_	2	nsubj	_	_
 4	אימון	אימון	NOUN	NOUN	Gender=Masc|Number=Sing	2	obj	_	_
 5-6	והיום	_	_	_	_	_	_	_	_
@@ -1181,8 +1181,8 @@
 1-2	ההנהלה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	הנהלה	הנהלה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	תתכנס	התכנס	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	0	root	_	_
-4	להחליט	החליט	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
+3	תתכנס	התכנס	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=כ.נ.ס|Tense=Fut	0	root	_	_
+4	להחליט	החליט	VERB	VERB	HebBinyan=HIFIL|Root=ח.ל.ט|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 5	על	על	ADP	ADP	_	6	case	_	_
 6	המשך	המשך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
 7-9	דרכו	_	_	_	_	_	_	_	_
@@ -1212,8 +1212,8 @@
 
 # sent_id = 5774
 # text = מקווים לסיים את המו"ם עם אופיר שמואלי עד סוף השבוע.
-1	מקווים	קיווה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
-2	לסיים	סיים	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	1	xcomp	_	_
+1	מקווים	קיווה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ק.ו.י|VerbForm=Part|Voice=Act	0	root	_	_
+2	לסיים	סיים	VERB	VERB	HebBinyan=PIEL|Root=ס.י.מ|VerbForm=Inf|Voice=Act	1	xcomp	_	_
 3	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 4-5	המו"ם	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -1231,14 +1231,14 @@
 # sent_id = 5775
 # text = בינתיים ממשיך השחקן, שחזר לאימוני הקבוצה בשבוע שעבר, להתאמן.
 1	בינתיים	בינתיים	ADV	ADV	_	2	advmod	_	_
-2	ממשיך	המשיך	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	ממשיך	המשיך	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=מ.ש.כ|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	השחקן	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	שחקן	שחקן	NOUN	NOUN	Gender=Masc|Number=Sing	2	nsubj	_	_
 5	,	,	PUNCT	PUNCT	_	4	punct	_	_
 6-7	שחזר	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
-7	חזר	חזר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	4	acl:relcl	_	_
+7	חזר	חזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Past	4	acl:relcl	_	_
 8-9	לאימוני	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	אימוני	אימון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	7	obl	_	_
@@ -1251,9 +1251,9 @@
 14	שבוע	שבוע	NOUN	NOUN	Gender=Masc|Number=Sing	7	obl	_	_
 15-16	שעבר	_	_	_	_	_	_	_	SpaceAfter=No
 15	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
-16	עבר	עבר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	14	acl:relcl	_	_
+16	עבר	עבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past	14	acl:relcl	_	_
 17	,	,	PUNCT	PUNCT	_	2	punct	_	_
-18	להתאמן	התאמן	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	2	xcomp	_	SpaceAfter=No
+18	להתאמן	התאמן	VERB	VERB	HebBinyan=HITPAEL|Root=א.מ.נ|VerbForm=Inf	2	xcomp	_	SpaceAfter=No
 19	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 5776
@@ -1266,18 +1266,18 @@
 5	לא	לא	ADV	ADV	Polarity=Neg	6	advmod	_	_
 6	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	8	aux	_	_
 7	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	6	cop	_	_
-8	להעריך	העריך	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	SpaceAfter=No
+8	להעריך	העריך	VERB	VERB	HebBinyan=HIFIL|Root=ע.ר.כ|VerbForm=Inf|Voice=Act	0	root	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	8	punct	_	_
 10	כמה	כמה	DET	DET	Definite=Cons	11	det	_	_
 11	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	12	nsubj	_	_
-12	ידרש	נדרש	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	8	advcl	_	_
+12	ידרש	נדרש	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ד.ר.ש|Tense=Fut|Voice=Mid	8	advcl	_	_
 13-14	לשחקן	_	_	_	_	_	_	_	_
 13	ל	ל	ADP	ADP	_	14	case	_	_
 14	שחקן	שחקן	NOUN	NOUN	Gender=Masc|Number=Sing	12	obl	_	_
 15	עד	עד	ADP	ADP	_	17	mark	_	_
 16-17	שיחזור	_	_	_	_	_	_	_	_
 16	ש	ש	SCONJ	SCONJ	_	15	fixed	_	_
-17	יחזור	חזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	12	advcl	_	_
+17	יחזור	חזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Fut|Voice=Act	12	advcl	_	_
 18-19	לכושר	_	_	_	_	_	_	_	_
 18	ל	ל	ADP	ADP	_	19	case	_	_
 19	כושר	כושר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	17	obl	_	_
@@ -1288,14 +1288,14 @@
 # text = "אנו פתוחים לכל בקורת לא נתבייש להחליף שחקנים", אלו חלק מהדברים שאמר אתמול המאמן הלאומי יעקב גרונדמן, בדיון על הנבחרת האולימפית בועדה המקצועית של ההתאחדות לכדורגל.
 1	"	"	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 2	אנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
-3	פתוחים	פתח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	17	advcl	_	_
+3	פתוחים	פתח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=פ.ת.ח|VerbForm=Part|Voice=Act	17	advcl	_	_
 4-5	לכל	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	6	case	_	_
 5	כל	כול	DET	DET	Definite=Cons	6	det	_	_
 6	בקורת	בקורת	NOUN	NOUN	_	3	obl	_	_
 7	לא	לא	ADV	ADV	Polarity=Neg	8	advmod	_	_
-8	נתבייש	התבייש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=1|Tense=Fut	3	parataxis	_	_
-9	להחליף	החליף	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	8	xcomp	_	_
+8	נתבייש	התבייש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=1|Root=ב.י.ש|Tense=Fut	3	parataxis	_	_
+9	להחליף	החליף	VERB	VERB	HebBinyan=HIFIL|Root=ח.ל.פ|VerbForm=Inf|Voice=Act	8	xcomp	_	_
 10	שחקנים	שחקן	NOUN	NOUN	Gender=Masc|Number=Plur	9	obj	_	SpaceAfter=No
 11	"	"	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 12	,	,	PUNCT	PUNCT	_	17	punct	_	_
@@ -1307,7 +1307,7 @@
 17	דברים	דבר	NOUN	NOUN	Gender=Masc|Number=Plur	0	root	_	_
 18-19	שאמר	_	_	_	_	_	_	_	_
 18	ש	ש	SCONJ	SCONJ	_	19	mark	_	_
-19	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	17	acl:relcl	_	_
+19	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	17	acl:relcl	_	_
 20	אתמול	אתמול	ADV	ADV	_	19	advmod	_	_
 21-22	המאמן	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
@@ -1361,7 +1361,7 @@
 9	ב	ב	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	מזכירות	מזכירות	NOUN	NOUN	Gender=Fem|Number=Sing	5	conj	_	_
-12	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+12	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=נ.ה.ל|Tense=Past	0	root	_	_
 13	בעקבות	בעקבות	ADP	ADP	_	14	case	_	_
 14	מישחקי	משחק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	12	obl	_	_
 15-16	ההכנה	_	_	_	_	_	_	_	_
@@ -1414,7 +1414,7 @@
 1-2	הדוברים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	דוברים	דובר	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
-3	התייחסו	התייחס	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
+3	התייחסו	התייחס	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=י.ח.ס|Tense=Past	0	root	_	_
 4-5	לשני	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	7	case	_	_
 5	שני	שני	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	7	nummod	_	_
@@ -1457,12 +1457,12 @@
 33	ד	ד	PROPN	PROPN	_	32	compound:smixut	_	_
 34-35	שעבר	_	_	_	_	_	_	_	SpaceAfter=No
 34	ש	ש	SCONJ	SCONJ	_	35	mark	_	_
-35	עבר	עבר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	32	acl:relcl	_	_
+35	עבר	עבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past	32	acl:relcl	_	_
 36	,	,	PUNCT	PUNCT	_	28	punct	_	_
 37-38	בו	_	_	_	_	_	_	_	_
 37	ב_	ב	ADP	ADP	_	38	case	_	_
 38	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	39	obl	_	_
-39	ניצחה	ניצח	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	28	acl	_	_
+39	ניצחה	ניצח	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.צ.ח|Tense=Past|Voice=Act	28	acl	_	_
 40	ישראל	ישראל	PROPN	PROPN	_	39	nsubj	_	_
 41	1	1	NUM	NUM	_	39	dep	_	_
 42	3	3	NUM	NUM	_	41	nummod	_	_
@@ -1476,10 +1476,10 @@
 # sent_id = 5780
 # text = גרונדמן שב ואמר, כי לכדורגל הישראלי בעיה עקרונית.
 1	גרונדמן	גרונדמן	PROPN	PROPN	_	2	nsubj	_	_
-2	שב	שב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	שב	שב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.ו.ב|Tense=Past|Voice=Act	0	root	_	_
 3-4	ואמר	_	_	_	_	_	_	_	SpaceAfter=No
 3	ו	ו	CCONJ	CCONJ	_	4	cc	_	_
-4	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+4	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	2	conj	_	_
 5	,	,	PUNCT	PUNCT	_	2	punct	_	_
 6	כי	כי	SCONJ	SCONJ	_	9	mark	_	_
 7-9	לכדורגל	_	_	_	_	_	_	_	_
@@ -1502,7 +1502,7 @@
 4-5	האולימפית	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	אולימפית	אולימפי	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
-6	הוכנה	הוכן	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+6	הוכנה	הוכן	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=כ.ו.נ|Tense=Past|Voice=Pass	0	root	_	_
 7-9	כראוי	_	_	_	_	_	_	_	SpaceAfter=No
 7	כ	כ	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -1529,7 +1529,7 @@
 3-4	האירופי	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	אירופי	אירופי	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-5	בורח	ברח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	בורח	ברח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ב.ר.ח|VerbForm=Part|Voice=Act	0	root	_	_
 6-7	לנו	_	_	_	_	_	_	_	_
 6	ל_	ל	ADP	ADP	_	7	case	_	_
 7	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	5	obl	_	_
@@ -1547,7 +1547,7 @@
 3-4	האירופים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	אירופים	אירופי	ADJ	ADJ	Gender=Masc|Number=Plur	2	amod	_	_
-5	משתלבים	השתלב	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	0	root	_	_
+5	משתלבים	השתלב	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ש.ל.ב|VerbForm=Part	0	root	_	_
 6-8	בליגות	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -1557,7 +1557,7 @@
 10	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	8	nmod:poss	_	_
 11-12	ונוצר	_	_	_	_	_	_	_	_
 11	ו	ו	CCONJ	CCONJ	_	12	cc	_	_
-12	נוצר	נוצר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	5	conj	_	_
+12	נוצר	נוצר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.צ.ר|Tense=Past|Voice=Mid	5	conj	_	_
 13	פער	פער	NOUN	NOUN	Gender=Masc|Number=Sing	12	nsubj	_	SpaceAfter=No
 14	,	,	PUNCT	PUNCT	_	12	punct	_	_
 15	בעיקר	בעיקר	ADV	ADV	_	18	advmod	_	_
@@ -1582,7 +1582,7 @@
 2	ניצחון	ניצחון	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
 3	על	על	ADP	ADP	_	4	case	_	_
 4	פולין	פולין	PROPN	PROPN	_	2	nmod	_	_
-5	החזיר	החזיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	החזיר	החזיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Past|Voice=Act	0	root	_	_
 6-7	לנו	_	_	_	_	_	_	_	_
 6	ל_	ל	ADP	ADP	_	7	case	_	_
 7	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	5	obl	_	_
@@ -1602,7 +1602,7 @@
 # sent_id = 5785
 # text = אם נשיג תוצאה טובה ביוון יהיה לנו זמן לעבוד על המהירות.
 1	אם	אם	SCONJ	SCONJ	_	2	mark	_	_
-2	נשיג	השיג	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Tense=Fut|Voice=Act	7	advcl	_	_
+2	נשיג	השיג	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Root=נ.שׂ.ג|Tense=Fut|Voice=Act	7	advcl	_	_
 3	תוצאה	תוצאה	NOUN	NOUN	Gender=Fem|Number=Sing	2	obj	_	_
 4	טובה	טוב	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
 5-6	ביוון	_	_	_	_	_	_	_	_
@@ -1613,7 +1613,7 @@
 8	ל_	ל	ADP	ADP	_	9	case	_	_
 9	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	7	obl	_	_
 10	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	7	dep	_	_
-11	לעבוד	עבד	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	10	acl	_	_
+11	לעבוד	עבד	VERB	VERB	HebBinyan=PAAL|Root=ע.ב.ד|VerbForm=Inf|Voice=Act	10	acl	_	_
 12	על	על	ADP	ADP	_	14	case	_	_
 13-14	המהירות	_	_	_	_	_	_	_	SpaceAfter=No
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
@@ -1623,14 +1623,14 @@
 # sent_id = 5786
 # text = אנחנו משחקים לאט, אך נעשה הכל כדי להצליח.
 1	אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
-2	משחקים	שיחק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	משחקים	שיחק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ש.ח.ק|VerbForm=Part|Voice=Act	0	root	_	_
 3	לאט	לאט	ADV	ADV	_	2	advmod	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	2	punct	_	_
 5	אך	אך	CCONJ	CCONJ	_	6	cc	_	_
-6	נעשה	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Fut|Voice=Act	2	conj	_	_
+6	נעשה	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=ע.ש.י|Tense=Fut|Voice=Act	2	conj	_	_
 7	הכל	הכיל	NOUN	NOUN	_	6	obj	_	_
 8	כדי	כדי	ADP	ADP	_	9	case	_	_
-9	להצליח	הצליח	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	6	advcl	_	SpaceAfter=No
+9	להצליח	הצליח	VERB	VERB	HebBinyan=HIFIL|Root=צ.ל.ח|VerbForm=Inf|Voice=Act	6	advcl	_	SpaceAfter=No
 10	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 5787
@@ -1638,7 +1638,7 @@
 1-2	ההתאחדות	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	התאחדות	התאחדות	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	נותנת	נתן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+3	נותנת	נתן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ת.נ|VerbForm=Part|Voice=Act	0	root	_	_
 4-5	לנו	_	_	_	_	_	_	_	_
 4	ל_	ל	ADP	ADP	_	5	case	_	_
 5	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	3	obl	_	_
@@ -1656,9 +1656,9 @@
 5	התאחדות	התאחדות	NOUN	NOUN	Gender=Fem|Number=Sing	3	compound:smixut	_	_
 6	עזריקם	עזריקם	PROPN	PROPN	HebSource=ConvUncertainHead	1	dep	_	_
 7	מילצן	מילצן	PROPN	PROPN	_	6	flat:name	_	_
-8	שאל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+8	שאל	שאל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.א.ל|Tense=Past|Voice=Act	0	root	_	_
 9	מדוע	מדוע	ADV	ADV	PronType=Int	10	advmod	_	_
-10	נוצחנו	נוצח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=1|Tense=Past|Voice=Pass	8	advcl	_	_
+10	נוצחנו	נוצח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=1|Root=נ.צ.ח|Tense=Past|Voice=Pass	8	advcl	_	_
 11-12	בהפרשים	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	הפרשים	הפרש	NOUN	NOUN	Gender=Masc|Number=Plur	10	obl	_	_
@@ -1669,7 +1669,7 @@
 # sent_id = 5789
 # text = הוא טען, כי לא צריך להיות פער כה גדול מהרמה האירופית כמו לפני 10 שנים.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+2	טען	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ט.ע.נ|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	PUNCT	_	2	punct	_	_
 4	כי	כי	SCONJ	SCONJ	_	6	mark	_	_
 5	לא	לא	ADV	ADV	Polarity=Neg	6	advmod	_	_
@@ -1695,7 +1695,7 @@
 # text = דוד לויאן אמר ששום נבחרת שלנו לא ניצחה בטמפרטורה של מינוס אפס ולא הצליחה בקור.
 1	דוד	דוד	PROPN	PROPN	_	3	nsubj	_	_
 2	לויאן	לויאן	PROPN	PROPN	_	1	flat:name	_	_
-3	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 4-5	ששום	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
 5	שום	שום	DET	DET	Definite=Cons	6	det	_	_
@@ -1704,7 +1704,7 @@
 7	של_	של_	ADP	ADP	Case=Gen	8	case:gen	_	_
 8	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	6	nmod:poss	_	_
 9	לא	לא	ADV	ADV	Polarity=Neg	10	advmod	_	_
-10	ניצחה	ניצח	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	ccomp	_	_
+10	ניצחה	ניצח	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.צ.ח|Tense=Past|Voice=Act	3	ccomp	_	_
 11-12	בטמפרטורה	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	טמפרטורה	טמפרטורה	NOUN	NOUN	Gender=Fem|Number=Sing	10	obl	_	_
@@ -1714,7 +1714,7 @@
 16-17	ולא	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 17	לא	לא	ADV	ADV	Polarity=Neg	18	advmod	_	_
-18	הצליחה	הצליח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	conj	_	_
+18	הצליחה	הצליח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ל.ח|Tense=Past|Voice=Act	10	conj	_	_
 19-20	בקור	_	_	_	_	_	_	_	SpaceAfter=No
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	קור	קור	NOUN	NOUN	Gender=Masc|Number=Sing	18	obl	_	_
@@ -1728,8 +1728,8 @@
 3	התאחדות	התאחדות	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 4	שלמה	שלמה	PROPN	PROPN	_	1	flat:name	_	_
 5	סופר	סופר	PROPN	PROPN	_	1	flat:name	_	_
-6	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-7	לתת	נתן	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
+6	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ר.א|Tense=Past|Voice=Act	0	root	_	_
+7	לתת	נתן	VERB	VERB	HebBinyan=PAAL|Root=נ.ת.נ|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 8	כתף	כתף	NOUN	NOUN	Gender=Fem|Number=Sing	7	obj	_	_
 9-11	לנבחרת	_	_	_	_	_	_	_	_
 9	ל	ל	ADP	ADP	_	11	case	_	_
@@ -1737,12 +1737,12 @@
 11	נבחרת	נבחרת	NOUN	NOUN	Gender=Fem|Number=Sing	7	obl	_	_
 12-13	והזכיר	_	_	_	_	_	_	_	_
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
-13	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	conj	_	_
+13	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ז.כ.ר|Tense=Past|Voice=Act	6	conj	_	_
 14-15	שאפילו	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
 15	אפילו	אפילו	ADV	ADV	_	16	det	_	_
 16	יוון	יוון	PROPN	PROPN	_	17	nsubj	_	_
-17	נכנעה	נכנע	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	13	ccomp	_	_
+17	נכנעה	נכנע	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=כ.נ.ע|Tense=Past|Voice=Mid	13	ccomp	_	_
 18	0	0	NUM	NUM	_	17	dep	_	_
 19	5	5	NUM	NUM	_	18	nummod	_	_
 20-21	בשוודיה	_	_	_	_	_	_	_	SpaceAfter=No
@@ -1758,7 +1758,7 @@
 3	התאחדות	התאחדות	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 4	יעקב	יעקב	PROPN	PROPN	_	1	flat:name	_	_
 5	אראל	אראל	PROPN	PROPN	_	1	flat:name	_	_
-6	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 7-8	שישראל	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
 8	ישראל	ישראל	PROPN	PROPN	_	10	nsubj:cop	_	_
@@ -1797,7 +1797,7 @@
 # sent_id = 5794
 # text = כדאי להתייחס לרמה שלנו בדרגה של מדינות כמו פינלנד, איסלנד ורק אחרי שנרכוש ניסיון נוכל להתמודד בהצלחה עם אחרים".
 1	כדאי	כדאי	AUX	AUX	VerbType=Mod	2	aux	_	_
-2	להתייחס	התייחס	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	0	root	_	_
+2	להתייחס	התייחס	VERB	VERB	HebBinyan=HITPAEL|Root=י.ח.ס|VerbForm=Inf	0	root	_	_
 3-5	לרמה	_	_	_	_	_	_	_	_
 3	ל	ל	ADP	ADP	_	5	case	_	_
 4	ה_	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -1820,10 +1820,10 @@
 18	אחרי	אחרי	ADP	ADP	_	20	mark	_	_
 19-20	שנרכוש	_	_	_	_	_	_	_	_
 19	ש	ש	SCONJ	SCONJ	_	18	fixed	_	_
-20	נרכוש	רכש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Fut|Voice=Act	1	advcl	_	_
+20	נרכוש	רכש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=ר.כ.ש|Tense=Fut|Voice=Act	1	advcl	_	_
 21	ניסיון	ניסיון	NOUN	NOUN	Gender=Masc|Number=Sing	20	obj	_	_
 22	נוכל	יכול	AUX	AUX	HebSource=ConvUncertainHead|VerbType=Mod	20	dep	_	_
-23	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	20	xcomp	_	_
+23	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|Root=מ.ד.ד|VerbForm=Inf	20	xcomp	_	_
 24-25	בהצלחה	_	_	_	_	_	_	_	_
 24	ב	ב	ADP	ADP	_	25	case	_	_
 25	הצלחה	הצלחה	NOUN	NOUN	Gender=Fem|Number=Sing	20	obl	_	_
@@ -1841,7 +1841,7 @@
 4	נוער	נוער	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
 5	נתן	נתן	PROPN	PROPN	_	1	flat:name	_	_
 6	סלובטיק	סלובטיק	PROPN	PROPN	_	1	flat:name	_	_
-7	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 8-10	שהשחקנים	_	_	_	_	_	_	_	_
 8	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -1850,7 +1850,7 @@
 11	של_	של_	ADP	ADP	Case=Gen	12	case:gen	_	_
 12	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	10	nmod:poss	_	_
 13	לא	לא	ADV	ADV	Polarity=Neg	14	advmod	_	_
-14	משתלבים	השתלב	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	7	ccomp	_	_
+14	משתלבים	השתלב	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ש.ל.ב|VerbForm=Part	7	ccomp	_	_
 15-16	באירופה	_	_	_	_	_	_	_	SpaceAfter=No
 15	ב	ב	ADP	ADP	_	16	case	_	_
 16	אירופה	אירופה	PROPN	PROPN	_	14	obl	_	_
@@ -1861,8 +1861,8 @@
 1	ארצי	ארצי	PROPN	PROPN	_	4	nsubj	_	_
 2	בן	בן	PROPN	PROPN	_	1	flat:name	_	_
 3	יעקב	יעקב	PROPN	PROPN	_	2	flat:name	_	_
-4	הציע	הציע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-5	לתת	נתן	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	4	xcomp	_	_
+4	הציע	הציע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.צ.ע|Tense=Past|Voice=Act	0	root	_	_
+5	לתת	נתן	VERB	VERB	HebBinyan=PAAL|Root=נ.ת.נ|VerbForm=Inf|Voice=Act	4	xcomp	_	_
 6	גיבוי	גיבוי	NOUN	NOUN	Gender=Masc|Number=Sing	4	obj	_	_
 7-9	למאמנים	_	_	_	_	_	_	_	_
 7	ל	ל	ADP	ADP	_	9	case	_	_
@@ -1885,7 +1885,7 @@
 3-4	האולימפי	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	אולימפי	אולימפי	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-5	יתכנס	התכנס	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	0	root	_	_
+5	יתכנס	התכנס	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=כ.נ.ס|Tense=Fut	0	root	_	_
 6	היום	היום	ADV	ADV	_	5	advmod	_	_
 7-8	למחנה	_	_	_	_	_	_	_	_
 7	ל	ל	ADP	ADP	_	8	case	_	_
@@ -1893,7 +1893,7 @@
 9	אימונים	אימון	NOUN	NOUN	Gender=Masc|Number=Plur	8	compound:smixut	_	_
 10-11	שיימשך	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	יימשך	נמשך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	8	acl:relcl	_	_
+11	יימשך	נמשך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.ש.כ|Tense=Fut|Voice=Mid	8	acl:relcl	_	_
 12	עד	עד	ADP	ADP	_	13	case	_	_
 13	יום	יום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	obl	_	_
 14	ד	ד	PROPN	PROPN	_	13	compound:smixut	_	SpaceAfter=No
@@ -1906,7 +1906,7 @@
 3-4	הצהריים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	צהריים	צהריים	NOUN	NOUN	Gender=Masc|Number=Plur	5	obl	_	_
-5	מתוכנן	תוכנן	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+5	מתוכנן	תוכנן	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ת.כ.נ.נ|VerbForm=Part|Voice=Pass	0	root	_	_
 6	מישחק	משחק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	אימון	אימון	NOUN	NOUN	Gender=Masc|Number=Sing	6	compound:smixut	_	_
 8	עם	עם	ADP	ADP	_	10	case	_	_
@@ -1928,7 +1928,7 @@
 1-2	המזכירות	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	מזכירות	מזכירות	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	החליטה	החליט	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+3	החליטה	החליט	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ל.ט|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	3	punct	_	_
 5	כי	כי	SCONJ	SCONJ	_	12	mark	_	_
 6-8	בשבוע	_	_	_	_	_	_	_	_
@@ -1939,7 +1939,7 @@
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	בא	בא	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
 11	לא	לא	ADV	ADV	Polarity=Neg	12	advmod	_	_
-12	יהיו	_	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Fut	3	ccomp	_	_
+12	יהיו	_	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	3	ccomp	_	_
 13	מישחקים	משחק	NOUN	NOUN	Gender=Masc|Number=Plur	12	nsubj	_	_
 14-15	ביום	_	_	_	_	_	_	_	_
 14	ב	ב	ADP	ADP	_	15	case	_	_
@@ -1963,7 +1963,7 @@
 2	ב	ב	ADP	ADP	_	4	case	_	_
 3	שלוש	שלוש	NUM	NUM	Gender=Fem|Number=Sing	4	nummod	_	_
 4	מערכות	מערכה	NOUN	NOUN	Gender=Fem|Number=Plur	1	nmod	_	_
-5	התרחשה	התרחש	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+5	התרחשה	התרחש	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ר.ח.ש|Tense=Past	0	root	_	_
 6	אמש	אמש	ADV	ADV	_	5	advmod	_	_
 7-8	באולם	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
@@ -1983,7 +1983,7 @@
 2	סיום_	סיום	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 3	_של_	של	ADP	ADP	_	4	case:gen	_	_
 4	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nmod:poss	_	_
-5	ניצח	ניצח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	ניצח	ניצח	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.צ.ח|Tense=Past|Voice=Act	0	root	_	_
 6-7	האלוף	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	אלוף	אלוף	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
@@ -2017,7 +2017,7 @@
 4-5	הדקות	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	דקות	דקה	NOUN	NOUN	Gender=Fem|Number=Plur	2	compound:smixut	_	_
-6	היה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+6	היה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 7	שיויוון	_	NOUN	NOUN	Definite=Cons	6	nsubj	_	_
 8	85	85	NUM	NUM	_	7	compound:smixut	_	_
 9	85	85	NUM	NUM	_	8	nummod	_	_
@@ -2039,7 +2039,7 @@
 # text = עצוב היה לראות אמש את בועז ינאי, מאמן הפועל גבת העמק, יושב בתום המשחק בודד על הספסל מהרהר כיצד יכלו חניכיו לנצח את האלוף; כיצד נשמט הניצחון מבין האצבעות.
 1	עצוב	עצוב	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
 2	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	1	cop	_	_
-3	לראות	ראה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	1	xcomp	_	_
+3	לראות	ראה	VERB	VERB	HebBinyan=PAAL|Root=ר.א.י|VerbForm=Inf|Voice=Act	1	xcomp	_	_
 4	אמש	אמש	ADV	ADV	_	3	advmod	_	_
 5	את	את	ADP	ADP	Case=Acc	6	case:acc	_	_
 6	בועז	בועז	PROPN	PROPN	_	3	obj	_	_
@@ -2054,7 +2054,7 @@
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	עמק	עמק	NOUN	NOUN	Gender=Masc|Number=Sing	12	flat:name	_	_
 15	,	,	PUNCT	PUNCT	_	3	punct	_	_
-16	יושב	ישב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	advcl	_	_
+16	יושב	ישב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=י.ש.ב|VerbForm=Part|Voice=Act	3	advcl	_	_
 17-18	בתום	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	תום	תום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	obl	_	_
@@ -2066,21 +2066,21 @@
 23-24	הספסל	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	ספסל	ספסל	NOUN	NOUN	Gender=Masc|Number=Sing	16	obl	_	_
-25	מהרהר	הרהר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	16	parataxis	_	_
+25	מהרהר	הרהר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ה.ר.ה.ר|VerbForm=Part|Voice=Act	16	parataxis	_	_
 26	כיצד	כיצד	ADV	ADV	PronType=Int	27	advmod	_	_
-27	יכלו	_	VERB	VERB	Gender=Fem,Masc|HebSource=ConvUncertainHead|Number=Plur|Person=3|Tense=Fut	25	dep	_	_
+27	יכלו	_	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Plur|Person=3|Root=י.כ.ל|Tense=Fut	25	dep	_	_
 28-30	חניכיו	_	_	_	_	_	_	_	_
 28	חניך_	חניך	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	27	nsubj	_	_
 29	_של_	של	ADP	ADP	_	30	case:gen	_	_
 30	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	28	nmod:poss	_	_
-31	לנצח	ניצח	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	27	xcomp	_	_
+31	לנצח	ניצח	VERB	VERB	HebBinyan=PIEL|Root=נ.צ.ח|VerbForm=Inf|Voice=Act	27	xcomp	_	_
 32	את	את	ADP	ADP	Case=Acc	34	case:acc	_	_
 33-34	האלוף	_	_	_	_	_	_	_	SpaceAfter=No
 33	ה	ה	DET	DET	PronType=Art	34	det:def	_	_
 34	אלוף	אלוף	NOUN	NOUN	Gender=Masc|Number=Sing	31	obj	_	_
 35	;	;	PUNCT	PUNCT	_	37	cc	_	_
 36	כיצד	כיצד	ADV	ADV	PronType=Int	37	advmod	_	_
-37	נשמט	נשמט	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	27	conj	_	_
+37	נשמט	נשמט	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.מ.ט|Tense=Past|Voice=Mid	27	conj	_	_
 38-39	הניצחון	_	_	_	_	_	_	_	_
 38	ה	ה	DET	DET	PronType=Art	39	det:def	_	_
 39	ניצחון	ניצחון	NOUN	NOUN	Gender=Masc|Number=Sing	37	nsubj	_	_
@@ -2107,7 +2107,7 @@
 10	מ	מ	X	X	Xtra=Junk	11	dep	_	_
 11	קבוצה	קבוצה	X	X	Xtra=Junk	4	conj	_	_
 12	לא	לא	ADV	ADV	Polarity=Neg	13	advmod	_	_
-13	הראו	הראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+13	הראו	הראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ר.א.י|Tense=Past|Voice=Act	0	root	_	_
 14	סימני	סימן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	13	obj	_	_
 15	אושר	אושר	NOUN	NOUN	Gender=Masc|Number=Sing	14	compound:smixut	_	_
 16-17	בסיום	_	_	_	_	_	_	_	_
@@ -2124,7 +2124,7 @@
 23	כמותו	כמותו	ADP	ADP	_	24	case	_	_
 24	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	26	obl	_	_
 25	לא	לא	ADV	ADV	Polarity=Neg	26	advmod	_	_
-26	ידעו	ידע	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	19	acl	_	_
+26	ידעו	ידע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.ד.ע|Tense=Past	19	acl	_	_
 27-29	בעמק	_	_	_	_	_	_	_	_
 27	ב	ב	ADP	ADP	_	29	case	_	_
 28	ה_	ה	DET	DET	PronType=Art	29	det:def	_	_
@@ -2151,7 +2151,7 @@
 # text = גם זו הסתיימה אחרי שתי הארכות.
 1	גם	גם	ADV	ADV	_	2	det	_	_
 2	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	nsubj	_	_
-3	הסתיימה	הסתיים	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	הסתיימה	הסתיים	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ס.י.מ|Tense=Past	0	root	_	_
 4	אחרי	אחרי	ADP	ADP	_	6	case	_	_
 5	שתי	שתי	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	6	nummod	_	_
 6	הארכות	הארכה	NOUN	NOUN	Gender=Fem|Number=Plur	3	obl	_	SpaceAfter=No
@@ -2164,7 +2164,7 @@
 2	מי	מי	ADV	ADV	PronType=Int	15	nsubj	_	_
 3-4	שפרץ	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	פרץ	פרץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	acl:relcl	_	_
+4	פרץ	פרץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ר.צ|Tense=Past|Voice=Act	2	acl:relcl	_	_
 5	אז	אז	ADV	ADV	_	4	advmod	_	_
 6-8	למגרש	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	8	case	_	_
@@ -2222,7 +2222,7 @@
 # sent_id = 5809
 # text = ארי קלע 43 נקודות (שיא אישי) ורוברטס צבר 39 נקודות ו-12 כדורים חוזרים מהסל.
 1	ארי	ארי	PROPN	PROPN	_	2	nsubj	_	_
-2	קלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	קלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ל.ע|Tense=Past|Voice=Act	0	root	_	_
 3	43	43	NUM	NUM	_	4	nummod	_	_
 4	נקודות	נקודה	NOUN	NOUN	Gender=Fem|Number=Plur	2	obj	_	_
 5	(	(	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
@@ -2232,7 +2232,7 @@
 9-10	ורוברטס	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
 10	רוברטס	רוברטס	PROPN	PROPN	_	11	nsubj	_	_
-11	צבר	צבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+11	צבר	צבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=צ.ב.ר|Tense=Past|Voice=Act	2	conj	_	_
 12	39	39	NUM	NUM	_	13	nummod	_	_
 13	נקודות	נקודה	NOUN	NOUN	Gender=Fem|Number=Plur	11	dep	_	_
 14	ו	_	CCONJ	CCONJ	_	17	cc	_	SpaceAfter=No
@@ -2255,7 +2255,7 @@
 4-5	האחרים	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	אחרים	אחר	ADJ	ADJ	Gender=Masc|Number=Plur	1	amod	_	_
-6	שיחקו	שיחק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	שיחקו	שיחק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ש.ח.ק|Tense=Past|Voice=Act	0	root	_	_
 7	עם	עם	ADP	ADP	_	10	case	_	_
 8	כל	כול	DET	DET	Definite=Cons	10	det	_	_
 9-10	הלב	_	_	_	_	_	_	_	_
@@ -2268,7 +2268,7 @@
 14	רחוקים	רחוק	ADJ	ADJ	Gender=Masc|Number=Plur	6	conj	_	_
 15-16	מלהפתיע	_	_	_	_	_	_	_	_
 15	מ	מ	ADP	ADP	_	16	case	_	_
-16	להפתיע	הפתיע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	14	obl	_	_
+16	להפתיע	הפתיע	VERB	VERB	HebBinyan=HIFIL|Root=פ.ת.ע|VerbForm=Inf|Voice=Act	14	obl	_	_
 17	את	את	ADP	ADP	Case=Acc	18	case:acc	_	_
 18-20	חניכיו	_	_	_	_	_	_	_	_
 18	חניך_	חניך	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	16	obj	_	_
@@ -2284,7 +2284,7 @@
 1	שחקני	שחקן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	תל	תל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	1	compound:smixut	_	_
 3	אביב	אביב	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
-4	הראו	הראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	הראו	הראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ר.א.י|Tense=Past|Voice=Act	0	root	_	_
 5	רק	רק	ADV	ADV	_	8	det	_	_
 6	שמץ	שמץ	NOUN	NOUN	_	8	det	_	_
 7-10	מיכולתם	_	_	_	_	_	_	_	SpaceAfter=No
@@ -2354,8 +2354,8 @@
 12	תל	תל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	15	dep	_	_
 13	אביב	אביב	NOUN	NOUN	Gender=Masc|Number=Sing	12	compound:smixut	_	_
 14	אינה	אינו	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	15	advmod	_	_
-15	מצליחה	הצליח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	9	advcl	_	_
-16	לברוח	ברח	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	15	xcomp	_	_
+15	מצליחה	הצליח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=צ.ל.ח|VerbForm=Part|Voice=Act	9	advcl	_	_
+16	לברוח	ברח	VERB	VERB	HebBinyan=PAAL|Root=ב.ר.ח|VerbForm=Inf|Voice=Act	15	xcomp	_	_
 17-18	מגבת	_	_	_	_	_	_	_	SpaceAfter=No
 17	מ	מ	ADP	ADP	_	18	case	_	_
 18	גבת	גבת	PROPN	PROPN	_	16	obl	_	_
@@ -2410,7 +2410,7 @@
 10	,	,	PUNCT	PUNCT	_	9	punct	_	_
 11-12	שהחליף	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-12	החליף	החליף	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	9	acl:relcl	_	_
+12	החליף	החליף	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ל.פ|Tense=Past|Voice=Act	9	acl:relcl	_	_
 13	שחקנים	שחקן	NOUN	NOUN	Gender=Masc|Number=Plur	12	obj	_	_
 14	רבים	רב	ADJ	ADJ	Gender=Masc|Number=Plur	13	amod	_	_
 15-16	במהלך	_	_	_	_	_	_	_	_
@@ -2421,8 +2421,8 @@
 18	משחק	משחק	NOUN	NOUN	Gender=Masc|Number=Sing	12	obl	_	_
 19	,	,	PUNCT	PUNCT	_	21	punct	_	_
 20	אכן	אכן	ADV	ADV	_	21	advmod	_	_
-21	יצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	7	ccomp	_	_
-22	להגדיל	הגדיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	21	xcomp	_	_
+21	יצליח	הצליח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ל.ח|Tense=Fut|Voice=Act	7	ccomp	_	_
+22	להגדיל	הגדיל	VERB	VERB	HebBinyan=HIFIL|Root=ג.ד.ל|VerbForm=Inf|Voice=Act	21	xcomp	_	_
 23	לבסוף	לבסוף	ADV	ADV	_	22	advmod	_	_
 24	את	את	ADP	ADP	Case=Acc	25	case:acc	_	_
 25-27	יתרונו	_	_	_	_	_	_	_	SpaceAfter=No
@@ -2448,12 +2448,12 @@
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	משחק	משחק	NOUN	NOUN	Gender=Masc|Number=Sing	10	compound:smixut	_	_
 13	)	)	PUNCT	PUNCT	_	10	punct	_	_
-14	איפשרה	אפשר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+14	איפשרה	אפשר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=א.פ.ש.ר|Tense=Past|Voice=Act	0	root	_	_
 15-17	לאורחים	_	_	_	_	_	_	_	_
 15	ל	ל	ADP	ADP	_	17	case	_	_
 16	ה_	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	אורחים	אורח	NOUN	NOUN	Gender=Masc|Number=Plur	14	obl	_	_
-18	לברוח	ברח	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	14	xcomp	_	SpaceAfter=No
+18	לברוח	ברח	VERB	VERB	HebBinyan=PAAL|Root=ב.ר.ח|VerbForm=Inf|Voice=Act	14	xcomp	_	SpaceAfter=No
 19	.	.	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 5817
@@ -2464,7 +2464,7 @@
 3-4	הגדולה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	גדולה	גדול	ADJ	ADJ	Gender=Fem|Number=Sing	2	amod	_	_
-5	החלה	החל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	החלה	החל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ל.ל|Tense=Past|Voice=Act	0	root	_	_
 6	14	14	NUM	NUM	_	7	nummod	_	_
 7	שניות	שנייה	NOUN	NOUN	Gender=Fem|Number=Plur	5	dep	_	_
 8-10	לסיום	_	_	_	_	_	_	_	SpaceAfter=No
@@ -2477,10 +2477,10 @@
 # text = ניר אלון חטף כדור, רץ לבדו לסל ונבלם בעבירה.
 1	ניר	ניר	PROPN	PROPN	_	3	nsubj	_	_
 2	אלון	אלון	PROPN	PROPN	_	1	flat:name	_	_
-3	חטף	חטף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	חטף	חטף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ט.פ|Tense=Past|Voice=Act	0	root	_	_
 4	כדור	כדור	NOUN	NOUN	Gender=Masc|Number=Sing	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	3	punct	_	_
-6	רץ	רץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	conj	_	_
+6	רץ	רץ	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ר.ו.צ|Tense=Past|Voice=Act	3	conj	_	_
 7	לבדו	לבד	ADV	ADV	_	6	advmod	_	_
 8-10	לסל	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	10	case	_	_
@@ -2488,7 +2488,7 @@
 10	סל	סל	NOUN	NOUN	Gender=Masc|Number=Sing	6	obl	_	_
 11-12	ונבלם	_	_	_	_	_	_	_	_
 11	ו	ו	CCONJ	CCONJ	_	12	cc	_	_
-12	נבלם	נבלם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	3	conj	_	_
+12	נבלם	נבלם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ב.ל.מ|Tense=Past|Voice=Mid	3	conj	_	_
 13-14	בעבירה	_	_	_	_	_	_	_	SpaceAfter=No
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	עבירה	עבירה	NOUN	NOUN	Gender=Fem|Number=Sing	12	obl	_	_
@@ -2497,12 +2497,12 @@
 # sent_id = 5819
 # text = הוא קלע נקודה אחת והשיג שיוויון 83 83.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	קלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	קלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ל.ע|Tense=Past|Voice=Act	0	root	_	_
 3	נקודה	נקודה	NOUN	NOUN	Gender=Fem|Number=Sing	2	obj	_	_
 4	אחת	אחת	NUM	NUM	Gender=Fem|Number=Sing	3	nummod	_	_
 5-6	והשיג	_	_	_	_	_	_	_	_
 5	ו	ו	CCONJ	CCONJ	_	6	cc	_	_
-6	השיג	השיג	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+6	השיג	השיג	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.שׂ.ג|Tense=Past|Voice=Act	2	conj	_	_
 7	שיוויון	שוויון	NOUN	NOUN	Gender=Masc|Number=Sing	6	obj	_	_
 8	83	83	NUM	NUM	_	6	dep	_	_
 9	83	83	NUM	NUM	_	8	nummod	_	SpaceAfter=No
@@ -2511,7 +2511,7 @@
 # sent_id = 5820
 # text = מכבי איבד את הכדור פעם נוספת וארי רוזנברג, שתי שניות לסיום המשחק, עלה לקלוע מטווח שלוש נקודות.
 1	מכבי	מכבי	PROPN	PROPN	_	2	nsubj	_	_
-2	איבד	איבד	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	איבד	איבד	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=א.ב.ד|Tense=Past|Voice=Act	0	root	_	_
 3	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 4-5	הכדור	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -2532,8 +2532,8 @@
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	משחק	משחק	NOUN	NOUN	Gender=Masc|Number=Sing	15	compound:smixut	_	_
 18	,	,	PUNCT	PUNCT	_	13	punct	_	_
-19	עלה	עלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
-20	לקלוע	קלע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	19	xcomp	_	_
+19	עלה	עלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ל.י|Tense=Past|Voice=Act	2	conj	_	_
+20	לקלוע	קלע	VERB	VERB	HebBinyan=PAAL|Root=ק.ל.ע|VerbForm=Inf|Voice=Act	19	xcomp	_	_
 21-22	מטווח	_	_	_	_	_	_	_	_
 21	מ	מ	ADP	ADP	_	22	case	_	_
 22	טווח	טווח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	20	obl	_	_
@@ -2544,7 +2544,7 @@
 # sent_id = 5821
 # text = הוא נחסם שלא כחוק ונשקרה עבירה.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	נחסם	נחסם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+2	נחסם	נחסם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ח.ס.מ|Tense=Past|Voice=Mid	0	root	_	_
 3	שלא	_	ADV	ADV	_	4	advmod	_	_
 4-6	כחוק	_	_	_	_	_	_	_	_
 4	כ	כ	ADP	ADP	_	6	case	_	_
@@ -2552,7 +2552,7 @@
 6	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	2	obl	_	_
 7-8	ונשקרה	_	_	_	_	_	_	_	_
 7	ו	ו	CCONJ	CCONJ	_	8	cc	_	_
-8	נשקרה	_	VERB	VERB	_	2	conj	_	_
+8	נשקרה	_	VERB	VERB	HebBinyan=NIFAL|Root=ש.ר.ק	2	conj	_	_
 9	עבירה	עבירה	NOUN	NOUN	Gender=Fem|Number=Sing	8	nsubj	_	SpaceAfter=No
 10	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
@@ -2561,7 +2561,7 @@
 1-2	הקהל	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	קהל	קהל	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
-3	עצר	עצר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	עצר	עצר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.צ.ר|Tense=Past|Voice=Act	0	root	_	_
 4-6	נשימתו	_	_	_	_	_	_	_	SpaceAfter=No
 4	נשימה_	נשימה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	3	obj	_	_
 5	_של_	של	ADP	ADP	_	6	case:gen	_	_
@@ -2571,7 +2571,7 @@
 # sent_id = 5823
 # text = ארי זרק שלוש פעמים מקו העונשין וקלע רק שתיים 85 83 לגבת.
 1	ארי	ארי	PROPN	PROPN	_	2	nsubj	_	_
-2	זרק	זרק	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	זרק	זרק	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ז.ר.ק|Tense=Past|Voice=Act	0	root	_	_
 3	שלוש	שלוש	NUM	NUM	Gender=Fem|Number=Sing	4	nummod	_	_
 4	פעמים	פעם	NOUN	NOUN	Gender=Fem|Number=Plur	2	dep	_	_
 5-6	מקו	_	_	_	_	_	_	_	_
@@ -2582,7 +2582,7 @@
 8	עונשין	עונש	NOUN	NOUN	Gender=Masc|Number=Plur	6	compound:smixut	_	_
 9-10	וקלע	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	10	cc	_	_
-10	קלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+10	קלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ל.ע|Tense=Past|Voice=Act	2	conj	_	_
 11	רק	רק	ADV	ADV	_	12	det	_	_
 12	שתיים	שתיים	NUM	NUM	Gender=Fem|Number=Sing	10	obj	_	_
 13	85	85	NUM	NUM	_	10	dep	_	_
@@ -2604,12 +2604,12 @@
 # text = שחקני גבת לחצו ומוטי דניאל קיבל את הכדור מתחת לסל גבת והישווה ל-8585 8585.
 1	שחקני	שחקן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	3	nsubj	_	_
 2	גבת	גבת	PROPN	PROPN	_	1	compound:smixut	_	_
-3	לחצו	לחץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	לחצו	לחץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ל.ח.צ|Tense=Past|Voice=Act	0	root	_	_
 4-5	ומוטי	_	_	_	_	_	_	_	_
 4	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
 5	מוטי	מוטי	PROPN	PROPN	_	7	nsubj	_	_
 6	דניאל	דניאל	PROPN	PROPN	_	5	flat:name	_	_
-7	קיבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	conj	_	_
+7	קיבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Past|Voice=Act	3	conj	_	_
 8	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 9-10	הכדור	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -2621,7 +2621,7 @@
 14	גבת	גבת	PROPN	PROPN	_	13	compound:smixut	_	_
 15-16	והישווה	_	_	_	_	_	_	_	_
 15	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
-16	הישווה	_	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1|Tense=Past|Voice=Act	7	conj	_	_
+16	הישווה	_	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1|Root=ש.ו.י|Tense=Past|Voice=Act	7	conj	_	_
 17	ל	ל	ADP	ADP	_	19	case	_	SpaceAfter=No
 18	-	-	PUNCT	PUNCT	_	19	punct	_	SpaceAfter=No
 19	8585	8585	NUM	NUM	_	16	obl	_	_
@@ -2644,7 +2644,7 @@
 5-6	הבאות	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	באות	בא	ADJ	ADJ	Gender=Fem|Number=Plur	4	amod	_	_
-7	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+7	התנהל	התנהל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=נ.ה.ל|Tense=Past	0	root	_	_
 8	שוב	שוב	ADV	ADV	_	7	advmod	_	_
 9	מרדף	מרדף	NOUN	NOUN	Gender=Masc|Number=Sing	7	nsubj	_	SpaceAfter=No
 10	.	.	PUNCT	PUNCT	_	7	punct	_	_
@@ -2652,7 +2652,7 @@
 # sent_id = 5828
 # text = מכבי מוביל לקראת סיום ההארכה בשתי נקודות, ושוב היה זה רוזנברג שקלע שתי נקודות (97 97) ששלחו את הקבוצות להארכה נוספת.
 1	מכבי	מכבי	PROPN	PROPN	_	2	nsubj	_	_
-2	מוביל	הוביל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	מוביל	הוביל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=י.ב.ל|VerbForm=Part|Voice=Act	0	root	_	_
 3	לקראת	לקראת	ADP	ADP	_	4	case	_	_
 4	סיום	סיום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	obl	_	_
 5-6	ההארכה	_	_	_	_	_	_	_	_
@@ -2671,7 +2671,7 @@
 15	רוזנברג	רוזנברג	PROPN	PROPN	_	2	conj	_	_
 16-17	שקלע	_	_	_	_	_	_	_	_
 16	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
-17	קלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	15	acl:relcl	_	_
+17	קלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ל.ע|Tense=Past|Voice=Act	15	acl:relcl	_	_
 18	שתי	שתי	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	19	nummod	_	_
 19	נקודות	נקודה	NOUN	NOUN	Gender=Fem|Number=Plur	17	obj	_	_
 20	(	(	PUNCT	PUNCT	_	21	punct	_	SpaceAfter=No
@@ -2680,7 +2680,7 @@
 23	)	)	PUNCT	PUNCT	_	21	punct	_	_
 24-25	ששלחו	_	_	_	_	_	_	_	_
 24	ש	ש	SCONJ	SCONJ	_	25	mark	_	_
-25	שלחו	שלח	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	19	acl:relcl	_	_
+25	שלחו	שלח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ש.ל.ח|Tense=Past	19	acl:relcl	_	_
 26	את	את	ADP	ADP	Case=Acc	28	case:acc	_	_
 27-28	הקבוצות	_	_	_	_	_	_	_	_
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
@@ -2698,7 +2698,7 @@
 3	,	,	PUNCT	PUNCT	_	1	punct	_	_
 4-5	ששיחקו	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	שיחקו	שיחק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	1	acl:relcl	_	_
+5	שיחקו	שיחק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ש.ח.ק|Tense=Past|Voice=Act	1	acl:relcl	_	_
 6	כמעט	כמעט	ADV	ADV	_	7	advmod	_	_
 7	לאורך	לאורך	ADP	ADP	_	10	case	_	_
 8	כל	כול	DET	DET	Definite=Cons	10	det	_	_
@@ -2722,7 +2722,7 @@
 23	ו	ו	CCONJ	CCONJ	_	24	cc	_	_
 24	ניר	ניר	PROPN	PROPN	_	17	conj	_	_
 25	אלון	אלון	PROPN	PROPN	_	24	flat:name	_	_
-26	החלו	החל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+26	החלו	החל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ח.ל.ל|Tense=Past|Voice=Act	0	root	_	_
 27	את	את	ADP	ADP	Case=Acc	29	case:acc	_	_
 28-29	ההארכה	_	_	_	_	_	_	_	_
 28	ה	ה	DET	DET	PronType=Art	29	det:def	_	_
@@ -2742,7 +2742,7 @@
 # text = שחקני מכבי ניצלו את החולשה הפיזית של יריביהם ואת חוסר בטחונם.
 1	שחקני	שחקן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	3	nsubj	_	_
 2	מכבי	מכבי	PROPN	PROPN	_	1	compound:smixut	_	_
-3	ניצלו	ניצל	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	0	root	_	_
+3	ניצלו	ניצל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=נ.צ.ל|Tense=Past	0	root	_	_
 4	את	את	ADP	ADP	Case=Acc	6	case:acc	_	_
 5-6	החולשה	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -2777,7 +2777,7 @@
 7	דקה	דקה	NOUN	NOUN	Gender=Fem|Number=Sing	2	appos	_	_
 8	48	48	NUM	NUM	_	7	nummod	_	SpaceAfter=No
 9	)	)	PUNCT	PUNCT	_	7	punct	_	_
-10	עלה	עלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+10	עלה	עלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ל.י|Tense=Past|Voice=Act	0	root	_	_
 11	מכבי	מכבי	PROPN	PROPN	_	10	nsubj	_	_
 12-13	ליתרון	_	_	_	_	_	_	_	_
 12	ל	ל	ADP	ADP	_	13	case	_	_
@@ -2806,14 +2806,14 @@
 # text = גבת עוד ניסתה לשנות, אבל לא יותר מאשר לצמצם עם השריקה ל-111 110.
 1	גבת	גבת	PROPN	PROPN	_	3	nsubj	_	_
 2	עוד	עוד	ADV	ADV	_	3	advmod	_	_
-3	ניסתה	ניסה	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-4	לשנות	שינה	VERB	VERB	VerbForm=Inf	3	xcomp	_	SpaceAfter=No
+3	ניסתה	ניסה	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.ס.י|Tense=Past|Voice=Act	0	root	_	_
+4	לשנות	שינה	VERB	VERB	HebBinyan=PAAL|Root=ש.נ.י|VerbForm=Inf	3	xcomp	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	4	punct	_	_
 6	אבל	אבל	CCONJ	CCONJ	_	10	cc	_	_
 7	לא	לא	ADV	ADV	Polarity=Neg	10	advmod	_	_
 8	יותר	יותר	ADV	ADV	_	10	advmod	_	_
 9	מאשר	מאשר	CCONJ	CCONJ	_	10	dep	_	_
-10	לצמצם	צמצם	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	4	conj	_	_
+10	לצמצם	צמצם	VERB	VERB	HebBinyan=PIEL|Root=צ.מ.צ.מ|VerbForm=Inf|Voice=Act	4	conj	_	_
 11	עם	עם	ADP	ADP	_	13	case	_	_
 12-13	השריקה	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
@@ -2826,7 +2826,7 @@
 
 # sent_id = 5833
 # text = שפטו מצויין הצעירים דן בורנשטיין וגוזף עליני.
-1	שפטו	שפט	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+1	שפטו	שפט	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ש.פ.ט|Tense=Past|Voice=Act	0	root	_	_
 2	מצויין	_	ADV	ADV	_	1	advmod	_	_
 3-4	הצעירים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
@@ -2855,8 +2855,8 @@
 10	מיכה	מיכה	PROPN	PROPN	_	9	flat:name	_	_
 11	גולדמן	גולדמן	PROPN	PROPN	_	9	flat:name	_	SpaceAfter=No
 12	,	,	PUNCT	PUNCT	_	13	punct	_	_
-13	ביקש	ביקש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-14	לזמן	זימן	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	13	xcomp	_	_
+13	ביקש	ביקש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ב.ק.ש|Tense=Past|Voice=Act	0	root	_	_
+14	לזמן	זימן	VERB	VERB	HebBinyan=PIEL|Root=ז.מ.נ|VerbForm=Inf|Voice=Act	13	xcomp	_	_
 15	למחר	_	ADV	ADV	_	14	advmod	_	_
 16	דיון	דיון	NOUN	NOUN	Gender=Masc|Number=Sing	14	obj	_	_
 17-19	בועדה	_	_	_	_	_	_	_	_
@@ -2873,7 +2873,7 @@
 25	אחרונים	אחרון	ADJ	ADJ	Gender=Masc|Number=Plur	23	amod	_	_
 26-27	הנוגעים	_	_	_	_	_	_	_	_
 26	ה	ה	SCONJ	SCONJ	_	27	mark	_	_
-27	נוגעים	נגע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	23	acl:relcl	_	_
+27	נוגעים	נגע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=נ.ג.ע|VerbForm=Part|Voice=Act	23	acl:relcl	_	_
 28-29	למערכת	_	_	_	_	_	_	_	_
 28	ל	ל	ADP	ADP	_	29	case	_	_
 29	מערכת	מערכת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	27	obl	_	_
@@ -2893,7 +2893,7 @@
 # text = ח"כ גולדמן הזכיר את פרשת המשחק שנדחה בין הפועל בית שאן להפועל אום אל פאחם, ואת תקיפת נערי מכבי אור עקיבא, אחרי משחק הליגה בשבת עם נערי הפועל טייבה.
 1	ח"כ	ח"ך	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	3	nsubj	_	_
 2	גולדמן	גולדמן	PROPN	PROPN	_	1	flat:name	_	_
-3	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ז.כ.ר|Tense=Past|Voice=Act	0	root	_	_
 4	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 5	פרשת	פרשה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	obj	_	_
 6-7	המשחק	_	_	_	_	_	_	_	_
@@ -2901,7 +2901,7 @@
 7	משחק	משחק	NOUN	NOUN	Gender=Masc|Number=Sing	5	compound:smixut	_	_
 8-9	שנדחה	_	_	_	_	_	_	_	_
 8	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
-9	נדחה	נדחה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	7	acl:relcl	_	_
+9	נדחה	נדחה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ד.ח.י|Tense=Past|Voice=Mid	7	acl:relcl	_	_
 10	בין	בין	ADP	ADP	_	12	case	_	_
 11-12	הפועל	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
@@ -2945,7 +2945,7 @@
 # text = ח"כ גולדמן הזכיר גם את החלטת איגוד הכדורסל לא לקיים בישובים ערביים משחקים בין קבוצות מקומיות לקבוצות יהודיות, על רקע המתח הבטחוני.
 1	ח"כ	ח"ך	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	3	nsubj	_	_
 2	גולדמן	גולדמן	PROPN	PROPN	_	1	flat:name	_	_
-3	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ז.כ.ר|Tense=Past|Voice=Act	0	root	_	_
 4	גם	גם	ADV	ADV	_	6	det	_	_
 5	את	את	ADP	ADP	Case=Acc	6	case:acc	_	_
 6	החלטת	החלטה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	obj	_	_
@@ -2954,7 +2954,7 @@
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	כדורסל	כדורסל	NOUN	NOUN	Gender=Masc|Number=Sing	7	compound:smixut	_	_
 10	לא	לא	ADV	ADV	Polarity=Neg	11	advmod	_	_
-11	לקיים	קיים	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	6	acl	_	_
+11	לקיים	קיים	VERB	VERB	HebBinyan=PIEL|Root=ק.י.מ|VerbForm=Inf|Voice=Act	6	acl	_	_
 12-13	בישובים	_	_	_	_	_	_	_	_
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	ישובים	יישוב	NOUN	NOUN	Gender=Masc|Number=Plur	11	obl	_	_
@@ -2985,7 +2985,7 @@
 3-4	הספורט	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	ספורט	ספורט	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
-5	יזמן	זימן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+5	יזמן	זימן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ז.מ.נ|Tense=Fut|Voice=Act	0	root	_	_
 6-8	לדיון	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -3052,7 +3052,7 @@
 2	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
 3	שאן	שאן	PROPN	PROPN	_	2	flat:name	_	_
 4	לא	לא	ADV	ADV	Polarity=Neg	5	advmod	_	_
-5	היה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+5	היה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 6-7	בשבת	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	שבת	שבת	PROPN	PROPN	_	5	obl	_	_
@@ -3081,7 +3081,7 @@
 25	אום	אום	NOUN	NOUN	Gender=Masc|Number=Sing	24	compound:smixut	_	_
 26	אל	אל	PROPN	PROPN	_	25	flat:name	_	_
 27	פאחם	פאחם	PROPN	PROPN	_	25	flat:name	_	_
-28	הגישו	הגיש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	5	obl	_	_
+28	הגישו	הגיש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Act	5	obl	_	_
 29	בקשה	בקשה	NOUN	NOUN	Gender=Fem|Number=Sing	28	obj	_	_
 30-31	לבית	_	_	_	_	_	_	_	_
 30	ל	ל	ADP	ADP	_	31	case	_	_
@@ -3096,7 +3096,7 @@
 36	ב	ב	ADP	ADP	_	37	case	_	_
 37	נצרת	נצרת	PROPN	PROPN	_	31	nmod	_	_
 38	עילית	עילי	ADJ	ADJ	Gender=Fem|Number=Sing	37	amod	_	_
-39	לבטל	ביטל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	28	xcomp	_	_
+39	לבטל	ביטל	VERB	VERB	HebBinyan=PIEL|Root=ב.ט.ל|VerbForm=Inf|Voice=Act	28	xcomp	_	_
 40-41	אותו	_	_	_	_	_	_	_	SpaceAfter=No
 40	את_	את_	ADP	ADP	Case=Acc	41	case:acc	_	_
 41	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	39	obj	_	_
@@ -3108,14 +3108,14 @@
 2-3	המשפט	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
-4	נעתר	נעתר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+4	נעתר	נעתר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ע.ת.ר|Tense=Past|Voice=Mid	0	root	_	_
 5-7	לבקשה	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	בקשה	בקשה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
 8-9	והוציא	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
-9	הוציא	הוציא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	conj	_	_
+9	הוציא	הוציא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.צ.א|Tense=Past|Voice=Act	4	conj	_	_
 10	צו	צו	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	9	obj	_	_
 11	מניעה	מניעה	NOUN	NOUN	Gender=Fem|Number=Sing	10	compound:smixut	_	_
 12-15	לקיומו	_	_	_	_	_	_	_	SpaceAfter=No
@@ -3136,7 +3136,7 @@
 6	אום	אום	NOUN	NOUN	Gender=Masc|Number=Sing	5	compound:smixut	_	_
 7	אל	אל	PROPN	PROPN	_	6	flat:name	_	_
 8	פאחם	פאחם	PROPN	PROPN	_	6	flat:name	_	_
-9	נבע	נבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+9	נבע	נבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ב.ע|Tense=Past|Voice=Act	0	root	_	_
 10	על	על	ADP	ADP	_	12	case	_	_
 11	רקע	רקע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	10	fixed	_	_
 12	הצהרות	הצהרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	9	obl	_	_
@@ -3149,7 +3149,7 @@
 19	,	,	PUNCT	PUNCT	_	13	punct	_	_
 20-21	שדיבר	_	_	_	_	_	_	_	_
 20	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
-21	דיבר	דיבר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	13	acl:relcl	_	_
+21	דיבר	דיבר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ד.ב.ר|Tense=Past|Voice=Act	13	acl:relcl	_	_
 22	על	על	ADP	ADP	_	25	case	_	_
 23	דקת	דקה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	25	nmod	_	SpaceAfter=No
 24	-	-	PUNCT	PUNCT	_	25	punct	_	SpaceAfter=No
@@ -3168,14 +3168,14 @@
 35	,	,	PUNCT	PUNCT	_	28	punct	_	_
 36-37	שנרצח	_	_	_	_	_	_	_	_
 36	ש	ש	SCONJ	SCONJ	_	37	mark	_	_
-37	נרצח	נרצח	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	28	acl:relcl	_	_
+37	נרצח	נרצח	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ר.צ.ח|Tense=Past|Voice=Mid	28	acl:relcl	_	_
 38-40	בשבוע	_	_	_	_	_	_	_	_
 38	ב	ב	ADP	ADP	_	40	case	_	_
 39	ה_	ה	DET	DET	PronType=Art	40	det:def	_	_
 40	שבוע	שבוע	NOUN	NOUN	Gender=Masc|Number=Sing	37	obl	_	_
 41-42	שעבר	_	_	_	_	_	_	_	SpaceAfter=No
 41	ש	ש	SCONJ	SCONJ	_	42	mark	_	_
-42	עבר	עבר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	40	acl:relcl	_	_
+42	עבר	עבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past	40	acl:relcl	_	_
 43	.	.	PUNCT	PUNCT	_	9	punct	_	_
 
 # sent_id = 5841
@@ -3183,7 +3183,7 @@
 1	בעקבות	בעקבות	ADP	ADP	_	2	case	_	_
 2	אמירה	אמירה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
 3	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	det	_	_
-4	הושעה	הושעה	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	הושעה	הושעה	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ש.ע.י|Tense=Past|Voice=Pass	0	root	_	_
 5	קפלן	קפלן	PROPN	PROPN	_	4	nsubj	_	_
 6-7	מאימוני	_	_	_	_	_	_	_	_
 6	מ	מ	ADP	ADP	_	7	case	_	_
@@ -3203,7 +3203,7 @@
 5-6	אותו	_	_	_	_	_	_	_	_
 5	את_	את_	ADP	ADP	Case=Acc	6	case:acc	_	_
 6	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	obj	_	_
-7	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	acl	_	_
+7	הזכיר	הזכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ז.כ.ר|Tense=Past|Voice=Act	2	acl	_	_
 8	ח"כ	ח"ך	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	7	nsubj	_	_
 9	גולדמן	גולדמן	PROPN	PROPN	_	8	flat:name	_	_
 10	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	0	root	_	_
@@ -3226,21 +3226,21 @@
 6	אור	אור	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	flat:name	_	_
 7	עקיבא	עקיבא	PROPN	PROPN	_	6	flat:name	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	9	punct	_	_
-9	הותקף	הותקף	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+9	הותקף	הותקף	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ת.ק.פ|Tense=Past|Voice=Pass	0	root	_	_
 10	בידי	בידי	ADP	ADP	_	11	case	_	_
 11	רעולי	רעול	NOUN	NOUN	Definite=Cons	9	obl	_	_
 12	פנים	_	NOUN	NOUN	Gender=Masc|Number=Plur	11	compound:smixut	_	_
 13-14	שיצאו	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
-14	יצאו	יצא	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	11	acl:relcl	_	_
+14	יצאו	יצא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.צ.א|Tense=Past	11	acl:relcl	_	_
 15-16	ממטע	_	_	_	_	_	_	_	_
 15	מ	מ	ADP	ADP	_	16	case	_	_
 16	מטע	מטע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	obl	_	_
 17	זיתים	זית	NOUN	NOUN	Gender=Fem|Number=Plur	16	compound:smixut	_	_
 18-19	והחלו	_	_	_	_	_	_	_	_
 18	ו	ו	CCONJ	CCONJ	_	19	cc	_	_
-19	החלו	החל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	14	conj	_	_
-20	לרגום	רגם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	19	xcomp	_	_
+19	החלו	החל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ח.ל.ל|Tense=Past|Voice=Act	14	conj	_	_
+20	לרגום	רגם	VERB	VERB	HebBinyan=PAAL|Root=ר.ג.מ|VerbForm=Inf|Voice=Act	19	xcomp	_	_
 21-22	באבנים	_	_	_	_	_	_	_	_
 21	ב	ב	ADP	ADP	_	22	case	_	_
 22	אבנים	אבן	NOUN	NOUN	Gender=Fem|Number=Plur	20	obl	_	_
@@ -3257,7 +3257,7 @@
 # text = ח"כ גולדמן אמר ל"ספורט הארץ": "הספורט נועד לאחד ולחזק דו-קיום בין יהודים לערבים, ולא להיגרר אחרי בודדים המנסים לפגוע במרקם שנוצר בין יהודים לערבים באמצעות מגרש הספורט.
 1	ח"כ	ח"ך	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	3	nsubj	_	_
 2	גולדמן	גולדמן	PROPN	PROPN	_	1	flat:name	_	_
-3	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 4-6	ל"ספורט	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	6	case	_	_
 5	"	"	PUNCT	PUNCT	_	6	punct	_	_
@@ -3271,11 +3271,11 @@
 12-13	הספורט	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	ספורט	ספורט	NOUN	NOUN	Gender=Masc|Number=Sing	14	nsubj	_	_
-14	נועד	נועד	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	3	ccomp	_	_
-15	לאחד	איחד	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	14	xcomp	_	_
+14	נועד	נועד	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.ע.ד|Tense=Past|Voice=Mid	3	ccomp	_	_
+15	לאחד	איחד	VERB	VERB	HebBinyan=PIEL|Root=א.ח.ד|VerbForm=Inf|Voice=Act	14	xcomp	_	_
 16-17	ולחזק	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
-17	לחזק	חיזק	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	15	conj	_	_
+17	לחזק	חיזק	VERB	VERB	HebBinyan=PIEL|Root=ח.ז.ק|VerbForm=Inf|Voice=Act	15	conj	_	_
 18	דו	דו	ADV	ADV	HebSource=ConvUncertainHead|Prefix=Yes	20	compound:affix	_	SpaceAfter=No
 19	-	-	PUNCT	PUNCT	_	20	punct	_	SpaceAfter=No
 20	קיום	קיום	NOUN	NOUN	Gender=Masc|Number=Sing	15	obj	_	_
@@ -3288,20 +3288,20 @@
 26-27	ולא	_	_	_	_	_	_	_	_
 26	ו	ו	CCONJ	CCONJ	_	28	cc	_	_
 27	לא	לא	ADV	ADV	Polarity=Neg	28	advmod	_	_
-28	להיגרר	נגרר	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	15	conj	_	_
+28	להיגרר	נגרר	VERB	VERB	HebBinyan=NIFAL|Root=ג.ר.ר|VerbForm=Inf|Voice=Mid	15	conj	_	_
 29	אחרי	אחרי	ADP	ADP	_	30	case	_	_
 30	בודדים	בודד	NOUN	NOUN	Gender=Masc|Number=Plur	28	obl	_	_
 31-32	המנסים	_	_	_	_	_	_	_	_
 31	ה	ה	SCONJ	SCONJ	_	32	mark	_	_
-32	מנסים	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	30	acl:relcl	_	_
-33	לפגוע	פגע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	32	xcomp	_	_
+32	מנסים	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=נ.ס.י|VerbForm=Part|Voice=Act	30	acl:relcl	_	_
+33	לפגוע	פגע	VERB	VERB	HebBinyan=PAAL|Root=פ.ג.ע|VerbForm=Inf|Voice=Act	32	xcomp	_	_
 34-36	במרקם	_	_	_	_	_	_	_	_
 34	ב	ב	ADP	ADP	_	36	case	_	_
 35	ה_	ה	DET	DET	PronType=Art	36	det:def	_	_
 36	מרקם	מרקם	NOUN	NOUN	Gender=Masc|Number=Sing	33	obl	_	_
 37-38	שנוצר	_	_	_	_	_	_	_	_
 37	ש	ש	SCONJ	SCONJ	_	38	mark	_	_
-38	נוצר	נוצר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	36	acl:relcl	_	_
+38	נוצר	נוצר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.צ.ר|Tense=Past|Voice=Mid	36	acl:relcl	_	_
 39	בין	בין	ADP	ADP	_	40	case	_	_
 40	יהודים	יהודי	NOUN	NOUN	Gender=Masc|Number=Plur	38	obl	_	_
 41-42	לערבים	_	_	_	_	_	_	_	_
@@ -3318,9 +3318,9 @@
 # text = כל נסיון לפגוע יש לגנות אותו.
 1	כל	כול	DET	DET	Definite=Cons	2	det	_	_
 2	נסיון	ניסיון	NOUN	NOUN	Gender=Masc|Number=Sing	4	dislocated	_	_
-3	לפגוע	פגע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	2	acl	_	_
+3	לפגוע	פגע	VERB	VERB	HebBinyan=PAAL|Root=פ.ג.ע|VerbForm=Inf|Voice=Act	2	acl	_	_
 4	יש	יש	AUX	AUX	VerbType=Mod	5	aux	_	_
-5	לגנות	גינה	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	0	root	_	_
+5	לגנות	גינה	VERB	VERB	HebBinyan=PIEL|Root=ג.נ.י|VerbForm=Inf|Voice=Act	0	root	_	_
 6-7	אותו	_	_	_	_	_	_	_	SpaceAfter=No
 6	את_	את_	ADP	ADP	Case=Acc	7	case:acc	_	_
 7	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	obj	_	_
@@ -3329,7 +3329,7 @@
 # sent_id = 5846
 # text = יש לערוך פעולות הסברה לקירוב יהודים וערבים שגורלם לחיות יחד בארץ הזו".
 1	יש	יש	AUX	AUX	VerbType=Mod	2	aux	_	_
-2	לערוך	ערך	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+2	לערוך	ערך	VERB	VERB	HebBinyan=PAAL|Root=ע.ר.כ|VerbForm=Inf|Voice=Act	0	root	_	_
 3	פעולות	פעולה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	2	obj	_	_
 4	הסברה	הסברה	NOUN	NOUN	Gender=Fem|Number=Sing	3	compound:smixut	_	_
 5-6	לקירוב	_	_	_	_	_	_	_	_
@@ -3344,7 +3344,7 @@
 11	גורל_	גורל	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
 12	_של_	של	ADP	ADP	_	13	case:gen	_	_
 13	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	11	nmod:poss	_	_
-14	לחיות	חי	VERB	VERB	VerbForm=Inf	7	acl:relcl	_	_
+14	לחיות	חי	VERB	VERB	HebBinyan=PAAL|Root=ח.י.י|VerbForm=Inf	7	acl:relcl	_	_
 15	יחד	יחד	ADV	ADV	_	14	advmod	_	_
 16-18	בארץ	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	18	case	_	_
@@ -3362,14 +3362,14 @@
 2-3	השרון	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	שרון	שרון	PROPN	PROPN	_	1	compound:smixut	_	_
-4	חוללה	חולל	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
+4	חוללה	חולל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ח.ו.ל|Tense=Past	0	root	_	_
 5	אמש	אמש	ADV	ADV	_	4	advmod	_	_
 6	הפתעה	הפתעה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obj	_	_
 7	גדולה	גדול	ADJ	ADJ	Gender=Fem|Number=Sing	6	amod	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	4	punct	_	_
 9-10	כשניצחה	_	_	_	_	_	_	_	_
 9	כש	כש	SCONJ	SCONJ	Case=Tem	10	mark	_	_
-10	ניצחה	ניצח	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	advcl	_	_
+10	ניצחה	ניצח	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.צ.ח|Tense=Past|Voice=Act	4	advcl	_	_
 11	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 12-13	המוליך	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
@@ -3395,7 +3395,7 @@
 4-5	הראשונה	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
-6	נקטה	נקט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	נקטה	נקט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ק.ט|Tense=Past|Voice=Act	0	root	_	_
 7	ירושלים	ירושלים	PROPN	PROPN	_	6	nsubj	_	_
 8-9	בשמירה	_	_	_	_	_	_	_	_
 8	ב	ב	ADP	ADP	_	9	case	_	_
@@ -3403,7 +3403,7 @@
 10	איזורית	אזורי	ADJ	ADJ	Gender=Fem|Number=Sing	9	amod	_	_
 11-12	ושלטה	_	_	_	_	_	_	_	_
 11	ו	ו	CCONJ	CCONJ	_	12	cc	_	_
-12	שלטה	שלט	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	6	conj	_	_
+12	שלטה	שלט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.ל.ט|Tense=Past	6	conj	_	_
 13-15	במשחק	_	_	_	_	_	_	_	SpaceAfter=No
 13	ב	ב	ADP	ADP	_	15	case	_	_
 14	ה_	ה	DET	DET	PronType=Art	15	det:def	_	_
@@ -3420,7 +3420,7 @@
 5-6	וגיילס	_	_	_	_	_	_	_	_
 5	ו	ו	CCONJ	CCONJ	_	6	cc	_	_
 6	גיילס	גיילס	PROPN	PROPN	_	4	conj	_	_
-7	קלעו	קלע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	קלעו	קלע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ק.ל.ע|Tense=Past|Voice=Act	0	root	_	_
 8	נקודות	נקודה	NOUN	NOUN	Gender=Fem|Number=Plur	7	obj	_	_
 9	רבות	רב	ADJ	ADJ	Gender=Fem|Number=Plur	8	amod	_	SpaceAfter=No
 10	.	.	PUNCT	PUNCT	_	7	punct	_	_
@@ -3437,7 +3437,7 @@
 6	שמירה	שמירה	NOUN	NOUN	Gender=Fem|Number=Sing	1	nmod	_	_
 7	אישית	אישי	ADJ	ADJ	Gender=Fem|Number=Sing	6	amod	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	9	punct	_	_
-9	החלה	החל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+9	החלה	החל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ל.ל|Tense=Past|Voice=Act	0	root	_	_
 10	את	את	ADP	ADP	Case=Acc	12	case:acc	_	_
 11-12	המשחק	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
@@ -3453,7 +3453,7 @@
 2	אט	אט	ADV	ADV	_	5	advmod	_	SpaceAfter=No
 3	-	-	PUNCT	PUNCT	_	2	fixed	_	SpaceAfter=No
 4	אט	אט	ADV	ADV	_	2	fixed	_	_
-5	נכנסה	נכנס	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+5	נכנסה	נכנס	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=כ.נ.ס|Tense=Past|Voice=Mid	0	root	_	_
 6-8	למאבק	_	_	_	_	_	_	_	SpaceAfter=No
 6	ל	ל	ADP	ADP	_	8	case	_	_
 7	ה_	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -3469,7 +3469,7 @@
 4	ה	ה	DET	DET	PronType=Art	6	dep	_	SpaceAfter=No
 5	-	-	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 6	7	7	NUM	NUM	_	3	amod	_	_
-7	היה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+7	היה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 8	שיוויון	שוויון	NOUN	NOUN	Gender=Masc|Number=Sing	7	nsubj	_	_
 9	14	14	NUM	NUM	HebSource=ConvUncertainLabel	8	nmod	_	_
 10	14	14	NUM	NUM	_	9	nummod	_	SpaceAfter=No
@@ -3483,12 +3483,12 @@
 3	יוגוסלווי	יוגוסלבי	ADJ	ADJ	Gender=Masc|Number=Sing	1	amod	_	_
 4-5	שנראה	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	1	acl:relcl	_	_
+5	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ר.א.י|VerbForm=Part|Voice=Mid	1	acl:relcl	_	_
 6	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	5	cop	_	SpaceAfter=No
 7	,	,	PUNCT	PUNCT	_	5	punct	_	_
 8	כי	כי	SCONJ	SCONJ	_	9	mark	_	_
-9	ייאלץ	נאלץ	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	5	advcl	_	_
-10	לעזוב	עזב	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	9	xcomp	_	_
+9	ייאלץ	נאלץ	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=א.ל.צ|Tense=Fut|Voice=Mid	5	advcl	_	_
+10	לעזוב	עזב	VERB	VERB	HebBinyan=PAAL|Root=ע.ז.ב|VerbForm=Inf|Voice=Act	9	xcomp	_	_
 11	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 12-13	הקבוצה	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
@@ -3503,10 +3503,10 @@
 19	חלשה	חלש	ADJ	ADJ	Gender=Fem|Number=Sing	15	amod	_	_
 20	עד	עד	ADP	ADP	_	10	advmod	_	_
 21	כה	כה	ADV	ADV	_	20	fixed	_	_
-22	הצטיין	הצטיין	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+22	הצטיין	הצטיין	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=צ.י.נ|Tense=Past	0	root	_	_
 23-24	וקלע	_	_	_	_	_	_	_	_
 23	ו	ו	CCONJ	CCONJ	_	24	cc	_	_
-24	קלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	22	conj	_	_
+24	קלע	קלע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ל.ע|Tense=Past|Voice=Act	22	conj	_	_
 25	15	15	NUM	NUM	_	26	nummod	_	_
 26	נקודות	נקודה	NOUN	NOUN	Gender=Fem|Number=Plur	22	obj	_	_
 27	עד	עד	ADP	ADP	_	29	case	_	_
@@ -3520,17 +3520,17 @@
 34-35	בה	_	_	_	_	_	_	_	_
 34	ב_	ב	ADP	ADP	_	35	case	_	_
 35	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	36	obl	_	_
-36	נפגע	נפגע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	29	acl:relcl	_	_
+36	נפגע	נפגע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=פ.ג.ע|Tense=Past|Voice=Mid	29	acl:relcl	_	_
 37	בידי	בידי	ADP	ADP	_	38	case	_	_
 38	רוברטס	רוברטס	PROPN	PROPN	_	36	obl	_	_
 39-40	והורד	_	_	_	_	_	_	_	_
 39	ו	ו	CCONJ	CCONJ	_	40	cc	_	_
-40	הורד	הורד	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	36	conj	_	_
+40	הורד	הורד	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=י.ר.ד|Tense=Past|Voice=Pass	36	conj	_	_
 41-43	מהמגרש	_	_	_	_	_	_	_	_
 41	מ	מ	ADP	ADP	_	43	case	_	_
 42	ה	ה	DET	DET	PronType=Art	43	det:def	_	_
 43	מגרש	מגרש	NOUN	NOUN	Gender=Masc|Number=Sing	40	obl	_	_
-44	נאנק	נאנק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	40	advcl	_	_
+44	נאנק	נאנק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=א.נ.ק|VerbForm=Part|Voice=Mid	40	advcl	_	_
 45-46	מכאבים	_	_	_	_	_	_	_	SpaceAfter=No
 45	מ	מ	ADP	ADP	_	46	case	_	_
 46	כאבים	כאב	NOUN	NOUN	Gender=Masc|Number=Plur	44	obl	_	_
@@ -3539,22 +3539,22 @@
 # sent_id = 5854
 # text = מש נראה שרמת השרון עומדת להיכנע, דאגו איסטרלינג ונוורסון להשאיר אותה בתמונת המאבק.
 1	מש	מש	ADP	ADP	_	2	mark	_	_
-2	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	10	advcl	_	_
+2	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ר.א.י|Tense=Past|Voice=Mid	10	advcl	_	_
 3-4	שרמת	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
 4	רמת	רמה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	nsubj	_	_
 5-6	השרון	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	שרון	שרון	PROPN	PROPN	_	4	compound:smixut	_	_
-7	עומדת	עמד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	ccomp	_	_
-8	להיכנע	נכנע	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	7	xcomp	_	SpaceAfter=No
+7	עומדת	עמד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ע.מ.ד|VerbForm=Part|Voice=Act	2	ccomp	_	_
+8	להיכנע	נכנע	VERB	VERB	HebBinyan=NIFAL|Root=כ.נ.ע|VerbForm=Inf|Voice=Mid	7	xcomp	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	10	punct	_	_
-10	דאגו	דאג	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+10	דאגו	דאג	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ד.א.ג|Tense=Past|Voice=Act	0	root	_	_
 11	איסטרלינג	איסטרלינג	PROPN	PROPN	_	10	nsubj	_	_
 12-13	ונוורסון	_	_	_	_	_	_	_	_
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
 13	נוורסון	נוורסון	PROPN	PROPN	_	11	conj	_	_
-14	להשאיר	השאיר	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	10	xcomp	_	_
+14	להשאיר	השאיר	VERB	VERB	HebBinyan=HIFIL|Root=ש.א.ר|VerbForm=Inf|Voice=Act	10	xcomp	_	_
 15-16	אותה	_	_	_	_	_	_	_	_
 15	את_	את_	ADP	ADP	Case=Acc	16	case:acc	_	_
 16	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	14	obj	_	_
@@ -3586,7 +3586,7 @@
 3-4	המשחק	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	משחק	משחק	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
-5	הפך	הפך	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	7	aux	_	_
+5	הפך	הפך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ה.פ.כ|Tense=Past	7	aux	_	_
 6-7	למהיר	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	מהיר	מהיר	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
@@ -3600,7 +3600,7 @@
 3-4	ונוורסון	_	_	_	_	_	_	_	_
 3	ו	ו	CCONJ	CCONJ	_	4	cc	_	_
 4	נוורסון	נוורסון	PROPN	PROPN	_	1	conj	_	_
-5	צלפו	צלף	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	צלפו	צלף	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=צ.ל.פ|Tense=Past|Voice=Act	0	root	_	_
 6-7	מכל	_	_	_	_	_	_	_	_
 6	מ	מ	ADP	ADP	_	8	case	_	_
 7	כל	כול	DET	DET	Definite=Cons	8	det	_	_
@@ -3613,7 +3613,7 @@
 13	ה	ה	DET	DET	PronType=Art	15	dep	_	SpaceAfter=No
 14	-	-	PUNCT	PUNCT	_	15	punct	_	SpaceAfter=No
 15	27	27	NUM	NUM	_	12	amod	_	_
-16	הובילה	הוביל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	conj	_	_
+16	הובילה	הוביל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ב.ל|Tense=Past|Voice=Act	5	conj	_	_
 17	רמת	רמה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	16	dep	_	_
 18-19	השרון	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
@@ -3625,7 +3625,7 @@
 # sent_id = 5858
 # text = מוטאפציץ החזיר את ירושלים ליתרון 61 60.
 1	מוטאפציץ	מוטאפציץ	PROPN	PROPN	_	2	nsubj	_	_
-2	החזיר	החזיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	החזיר	החזיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ז.ר|Tense=Past|Voice=Act	0	root	_	_
 3	את	את	ADP	ADP	Case=Acc	4	case:acc	_	_
 4	ירושלים	ירושלים	PROPN	PROPN	_	2	obj	_	_
 5-6	ליתרון	_	_	_	_	_	_	_	_
@@ -3638,7 +3638,7 @@
 # sent_id = 5859
 # text = אז החלה הבריחה המדהימה של המקומיים.
 1	אז	אז	ADV	ADV	_	2	advmod	_	_
-2	החלה	החל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	החלה	החל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ל.ל|Tense=Past|Voice=Act	0	root	_	_
 3-4	הבריחה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	בריחה	בריחה	NOUN	NOUN	Gender=Fem|Number=Sing	2	nsubj	_	_
@@ -3654,11 +3654,11 @@
 # sent_id = 5860
 # text = ירושלים הפכה לקבוצה מפוררת.
 1	ירושלים	ירושלים	PROPN	PROPN	_	4	nsubj	_	_
-2	הפכה	הפך	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	4	aux	_	_
+2	הפכה	הפך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ה.פ.כ|Tense=Past	4	aux	_	_
 3-4	לקבוצה	_	_	_	_	_	_	_	_
 3	ל	ל	ADP	ADP	_	4	case	_	_
 4	קבוצה	קבוצה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
-5	מפוררת	פורר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	amod	_	SpaceAfter=No
+5	מפוררת	פורר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=פ.ר.ר|VerbForm=Part|Voice=Act	4	amod	_	SpaceAfter=No
 6	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 5861
@@ -3667,12 +3667,12 @@
 1	שחקן_	שחקן	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
 3	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	1	nmod:poss	_	_
-4	החלו	החל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
-5	לגלות	גילה	VERB	VERB	VerbForm=Inf	4	xcomp	_	_
+4	החלו	החל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ח.ל.ל|Tense=Past|Voice=Act	0	root	_	_
+5	לגלות	גילה	VERB	VERB	HebBinyan=PIEL|Root=ג.ל.י|VerbForm=Inf	4	xcomp	_	_
 6	עצבנות	עצבנות	NOUN	NOUN	Gender=Fem|Number=Sing	5	obj	_	_
 7-8	שפגמה	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
-8	פגמה	פגם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	acl:relcl	_	_
+8	פגמה	פגם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ג.מ|Tense=Past|Voice=Act	6	acl:relcl	_	_
 9-12	ביכולתם	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	יכולת_	יכולת	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	8	obl	_	_
@@ -3680,11 +3680,11 @@
 12	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	10	nmod:poss	_	_
 13-14	ומנעה	_	_	_	_	_	_	_	_
 13	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
-14	מנעה	מנע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	8	conj	_	_
+14	מנעה	מנע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.נ.ע|Tense=Past|Voice=Act	8	conj	_	_
 15-16	מהם	_	_	_	_	_	_	_	_
 15	מן_	מן	ADP	ADP	_	16	case	_	_
 16	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	14	obl	_	_
-17	לתת	נתן	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	14	xcomp	_	_
+17	לתת	נתן	VERB	VERB	HebBinyan=PAAL|Root=נ.ת.נ|VerbForm=Inf|Voice=Act	14	xcomp	_	_
 18	תשובה	תשובה	NOUN	NOUN	Gender=Fem|Number=Sing	17	obj	_	_
 19	מעשית	מעשי	ADJ	ADJ	Gender=Fem|Number=Sing	18	amod	_	_
 20-22	ליכולת	_	_	_	_	_	_	_	_
@@ -3693,7 +3693,7 @@
 22	יכולת	יכולת	NOUN	NOUN	Gender=Fem|Number=Sing	17	obl	_	_
 23-24	המצויינת	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
-24	מצויינת	צוין	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	22	amod	_	_
+24	מצויינת	צוין	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=צ.י.נ|VerbForm=Part|Voice=Pass	22	amod	_	_
 25	של	של	ADP	ADP	Case=Gen	27	case:gen	_	_
 26-27	המקומיים	_	_	_	_	_	_	_	SpaceAfter=No
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
@@ -3715,10 +3715,10 @@
 9-10	הראשונה	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	8	amod	_	_
-11	הצטיינו	הצטיין	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	1	acl:relcl	_	SpaceAfter=No
+11	הצטיינו	הצטיין	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=צ.י.נ|Tense=Past	1	acl:relcl	_	SpaceAfter=No
 12	,	,	PUNCT	PUNCT	_	14	punct	_	_
 13	כמו	_	ADV	ADV	_	14	advmod	_	_
-14	נעלמו	נעלם	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
+14	נעלמו	נעלם	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ע.ל.מ|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
 15	.	.	PUNCT	PUNCT	_	14	punct	_	_
 
 # sent_id = 5863
@@ -3729,7 +3729,7 @@
 3	_של_	של	ADP	ADP	_	4	case:gen	_	_
 4	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	2	nmod:poss	_	_
 5	לא	לא	ADV	ADV	Polarity=Neg	6	advmod	_	_
-6	יכלו	_	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut	0	root	_	_
+6	יכלו	_	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.כ.ל|Tense=Fut	0	root	_	_
 7-8	לרמת	_	_	_	_	_	_	_	_
 7	ל	ל	ADP	ADP	_	8	case	_	_
 8	רמת	רמה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	obl	_	_
@@ -3738,7 +3738,7 @@
 10	שרון	שרון	PROPN	PROPN	_	8	compound:smixut	_	_
 11-12	שהגדילה	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-12	הגדילה	הגדיל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	8	acl:relcl	_	_
+12	הגדילה	הגדיל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ג.ד.ל|Tense=Past|Voice=Act	8	acl:relcl	_	_
 13-15	יתרונה	_	_	_	_	_	_	_	_
 13	יתרון_	יתרון	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	12	obj	_	_
 14	_של_	של	ADP	ADP	_	15	case:gen	_	_
@@ -3756,12 +3756,12 @@
 1-2	הקהל	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	קהל	קהל	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
-3	עמד	עמד	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	עמד	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.מ.ד|Tense=Past	0	root	_	_
 4	על	על	ADP	ADP	_	5	case	_	_
 5	רגליו	_	NOUN	NOUN	_	3	obl	_	_
 6-7	והריע	_	_	_	_	_	_	_	SpaceAfter=No
 6	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
-7	הריע	הריע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	conj	_	_
+7	הריע	הריע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ר.ו.ע|Tense=Past|Voice=Act	3	conj	_	_
 8	.	.	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 5865
@@ -3774,7 +3774,7 @@
 4	ה_	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	אולם	אולם	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod	_	_
 6	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	7	cop	_	_
-7	מחריש	החריש	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+7	מחריש	החריש	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ח.ר.ש|VerbForm=Part|Voice=Act	0	root	_	_
 8	אוזניים	אוזן	NOUN	NOUN	Gender=Fem|Number=Plur	7	compound:smixut	_	SpaceAfter=No
 9	.	.	PUNCT	PUNCT	_	7	punct	_	_
 
@@ -3810,7 +3810,7 @@
 2	כ	כ	ADP	ADP	_	4	det	_	_
 3	עשרים	עשרים	NUM	NUM	Gender=Fem,Masc|Number=Sing	4	nummod	_	_
 4	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
-5	עלה	עלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	עלה	עלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ל.י|Tense=Past|Voice=Act	0	root	_	_
 6-7	מארה"ב	_	_	_	_	_	_	_	_
 6	מ	מ	ADP	ADP	_	7	case	_	_
 7	ארה"ב	ארה"ב	PROPN	PROPN	Abbr=Yes	5	obl	_	_
@@ -3830,7 +3830,7 @@
 18	,	,	PUNCT	PUNCT	_	5	punct	_	_
 19-20	והשתקע	_	_	_	_	_	_	_	_
 19	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
-20	השתקע	השתקע	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	5	conj	_	_
+20	השתקע	השתקע	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ש.ק.ע|Tense=Past	5	conj	_	_
 21-22	ברעננה	_	_	_	_	_	_	_	SpaceAfter=No
 21	ב	ב	ADP	ADP	_	22	case	_	_
 22	רעננה	רעננה	PROPN	PROPN	_	20	obl	_	_
@@ -3839,7 +3839,7 @@
 # sent_id = 5869
 # text = הוא רכש שם חלקת אדמה לבנייה והעביר אותה לעמותת "מוסדות קליוולנד והקריה ברעננה" כמכר בלא תמורה.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	רכש	רכש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	רכש	רכש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ר.כ.ש|Tense=Past|Voice=Act	0	root	_	_
 3	שם	שם	ADV	ADV	_	2	advmod	_	_
 4	חלקת	חלקה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	2	obj	_	_
 5	אדמה	אדמה	NOUN	NOUN	Gender=Fem|Number=Sing	4	compound:smixut	_	_
@@ -3848,7 +3848,7 @@
 7	בנייה	בנייה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nmod	_	_
 8-9	והעביר	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
-9	העביר	העביר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+9	העביר	העביר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past|Voice=Act	2	conj	_	_
 10-11	אותה	_	_	_	_	_	_	_	_
 10	את_	את_	ADP	ADP	Case=Acc	11	case:acc	_	_
 11	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	9	obj	_	_
@@ -3879,7 +3879,7 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	כוונה	כוונה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 3	היתה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	4	cop	_	_
-4	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+4	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|Root=ק.ו.מ|VerbForm=Inf|Voice=Act	0	root	_	_
 5-6	בה	_	_	_	_	_	_	_	_
 5	ב_	ב	ADP	ADP	_	6	case	_	_
 6	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	4	obl	_	_
@@ -3888,7 +3888,7 @@
 9	,	,	PUNCT	PUNCT	_	7	punct	_	_
 10-11	שתכלול	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	תכלול	כלל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	7	acl:relcl	_	_
+11	תכלול	כלל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ל.ל|Tense=Fut|Voice=Act	7	acl:relcl	_	_
 12	מרכז	מרכז	NOUN	NOUN	Gender=Masc|Number=Sing	11	obj	_	_
 13	קהילתי	קהילתי	ADJ	ADJ	Gender=Masc|Number=Sing	12	amod	_	SpaceAfter=No
 14	,	,	PUNCT	PUNCT	_	12	punct	_	_
@@ -3919,7 +3919,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	מארס	מרס	PROPN	PROPN	_	4	obl	_	_
 3	1983	1983	NUM	NUM	_	2	nummod	_	_
-4	התקשרה	התקשר	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+4	התקשרה	התקשר	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ק.ש.ר|Tense=Past	0	root	_	_
 5-6	העמותה	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
@@ -3949,7 +3949,7 @@
 26	פה_	פה	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	29	obl	_	_
 27	_של_	של	ADP	ADP	_	28	case:gen	_	_
 28	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	26	nmod:poss	_	_
-29	תבנה	בנה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	21	acl:relcl	_	_
+29	תבנה	בנה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ב.נ.י|Tense=Fut|Voice=Act	21	acl:relcl	_	_
 30-31	החברה	_	_	_	_	_	_	_	_
 30	ה	ה	DET	DET	PronType=Art	31	det:def	_	_
 31	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	29	nsubj	_	_
@@ -3971,7 +3971,7 @@
 2	מ	מ	ADP	ADP	_	4	case	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	דירות	דירה	NOUN	NOUN	Gender=Fem|Number=Plur	5	obj	_	_
-5	תקבל	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+5	תקבל	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Fut|Voice=Act	0	root	_	_
 6-7	החברה	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
@@ -3981,8 +3981,8 @@
 10	11	11	NUM	NUM	_	12	nummod	_	_
 11-12	הנותרות	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
-12	נותרות	נותר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	13	nsubj	_	_
-13	יעברו	עבר	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut	5	conj	_	_
+12	נותרות	נותר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=י.ת.ר|VerbForm=Part|Voice=Mid	13	nsubj	_	_
+13	יעברו	עבר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ב.ר|Tense=Fut	5	conj	_	_
 14-16	לעמותה	_	_	_	_	_	_	_	SpaceAfter=No
 14	ל	ל	ADP	ADP	_	16	case	_	_
 15	ה_	ה	DET	DET	PronType=Art	16	det:def	_	_
@@ -3993,11 +3993,11 @@
 # text = תמורת זה התחייבה העמותה להעביר חלק מהמגרש לבעלות החברה.
 1	תמורת	תמורת	ADP	ADP	_	2	case	_	_
 2	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	3	obl	_	_
-3	התחייבה	התחייב	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	התחייבה	התחייב	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ח.י.ב|Tense=Past	0	root	_	_
 4-5	העמותה	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-6	להעביר	העביר	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
+6	להעביר	העביר	VERB	VERB	HebBinyan=HIFIL|Root=ע.ב.ר|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 7	חלק	חלק	NOUN	NOUN	Gender=Masc|Number=Sing	10	det	_	_
 8-10	מהמגרש	_	_	_	_	_	_	_	_
 8	מ	מ	ADP	ADP	HebSource=ConvUncertainLabel	10	case	_	_
@@ -4023,11 +4023,11 @@
 6-7	הקומבינציה	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	קומבינציה	קומבינציה	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
-8	התחייבה	התחייב	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+8	התחייבה	התחייב	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ח.ו.ב|Tense=Past	0	root	_	_
 9-10	העמותה	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	8	nsubj	_	_
-11	לשלם	שילם	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	8	xcomp	_	_
+11	לשלם	שילם	VERB	VERB	HebBinyan=PIEL|Root=ש.ל.מ|VerbForm=Inf|Voice=Act	8	xcomp	_	_
 12	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 13	מס	מס	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	obj	_	_
 14-15	הערך	_	_	_	_	_	_	_	_
@@ -4062,7 +4062,7 @@
 37	אף	אף	CCONJ	CCONJ	_	11	advcl	_	_
 38	כי	כי	SCONJ	SCONJ	HebSource=ConvUncertainHead	37	dep	_	_
 39	לא	לא	ADV	ADV	Polarity=Neg	40	advmod	_	_
-40	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Tense=Past|Voice=Mid	37	dep	_	_
+40	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Root=ק.ב.ע|Tense=Past|Voice=Mid	37	dep	_	_
 41	תאריך	תאריך	NOUN	NOUN	Gender=Masc|Number=Sing	40	nsubj	_	SpaceAfter=No
 42	.	.	PUNCT	PUNCT	_	8	punct	_	_
 
@@ -4074,11 +4074,11 @@
 3-4	הקומבינציה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	קומבינציה	קומבינציה	NOUN	NOUN	Gender=Fem|Number=Sing	2	compound:smixut	_	_
-5	התחייבה	התחייב	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+5	התחייבה	התחייב	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ח.י.ב|Tense=Past	0	root	_	_
 6-7	החברה	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
-8	למסור	מסר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
+8	למסור	מסר	VERB	VERB	HebBinyan=PAAL|Root=מ.ס.ר|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 9-11	לעמותה	_	_	_	_	_	_	_	_
 9	ל	ל	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
@@ -4104,13 +4104,13 @@
 
 # sent_id = 5876
 # text = הוסכם, כי הנכס יועבר על שם החברה רק כנגד מסירת הדירות.
-1	הוסכם	הוסכם	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
+1	הוסכם	הוסכם	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ס.כ.מ|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	PUNCT	_	1	punct	_	_
 3	כי	כי	SCONJ	SCONJ	_	6	mark	_	_
 4-5	הנכס	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	נכס	נכס	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
-6	יועבר	הועבר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	1	ccomp	_	_
+6	יועבר	הועבר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Fut|Voice=Pass	1	ccomp	_	_
 7	על	על	ADP	ADP	_	8	case	_	_
 8	שם	שם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	obl	_	_
 9-10	החברה	_	_	_	_	_	_	_	_
@@ -4130,14 +4130,14 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	בנייה	בנייה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
-4	הושלמה	הושלם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	הושלמה	הושלם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ש.ל.מ|Tense=Past|Voice=Pass	0	root	_	_
 5-7	במועד	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	מועד	מועד	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 8-9	שנקבע	_	_	_	_	_	_	_	SpaceAfter=No
 8	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
-9	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	7	acl:relcl	_	_
+9	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ק.ב.ע|Tense=Past|Voice=Mid	7	acl:relcl	_	_
 10	,	,	PUNCT	PUNCT	_	7	punct	_	_
 11	ספטמבר	ספטמבר	PROPN	PROPN	_	7	appos	_	_
 12	84	84	NUM	NUM	_	11	nummod	_	SpaceAfter=No
@@ -4150,7 +4150,7 @@
 2	ב	ב	ADP	ADP	_	3	case	_	_
 3	אמצע	אמצע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
 4	87	87	NUM	NUM	_	3	compound:smixut	_	_
-5	הושלמו	הושלם	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+5	הושלמו	הושלם	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=ש.ל.מ|Tense=Past|Voice=Pass	0	root	_	_
 6	חלק	חלק	NOUN	NOUN	Gender=Masc|Number=Sing	9	det	_	_
 7-9	מהדירות	_	_	_	_	_	_	_	SpaceAfter=No
 7	מ	מ	ADP	ADP	HebSource=ConvUncertainLabel	9	case	_	_
@@ -4163,14 +4163,14 @@
 1-2	החברה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	הודיעה	הודיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הודיעה	הודיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ד.ע|Tense=Past|Voice=Act	0	root	_	_
 4-6	לעמותה	_	_	_	_	_	_	_	SpaceAfter=No
 4	ל	ל	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	3	obl	_	_
 7	,	,	PUNCT	PUNCT	_	3	punct	_	_
 8	כי	כי	SCONJ	SCONJ	_	9	mark	_	_
-9	שילמה	שילם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	ccomp	_	_
+9	שילמה	שילם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.ל.מ|Tense=Past|Voice=Act	3	ccomp	_	_
 10	את	את	ADP	ADP	Case=Acc	12	case:acc	_	_
 11-12	המע"ם	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
@@ -4180,8 +4180,8 @@
 15	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	14	det	_	_
 16-17	ודרשה	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
-17	דרשה	דרש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	9	conj	_	_
-18	להחזיר	החזיר	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	17	xcomp	_	_
+17	דרשה	דרש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ד.ר.ש|Tense=Past|Voice=Act	9	conj	_	_
+18	להחזיר	החזיר	VERB	VERB	HebBinyan=HIFIL|Root=ח.ז.ר|VerbForm=Inf|Voice=Act	17	xcomp	_	_
 19-20	לה	_	_	_	_	_	_	_	_
 19	ל_	ל	ADP	ADP	_	20	case	_	_
 20	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	18	obl	_	_
@@ -4193,7 +4193,7 @@
 25	כפי	כפי	SCONJ	SCONJ	_	27	mark	_	_
 26-27	שהתחייבה	_	_	_	_	_	_	_	SpaceAfter=No
 26	ש	ש	SCONJ	SCONJ	_	25	fixed	_	_
-27	התחייבה	התחייב	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	17	advcl	_	_
+27	התחייבה	התחייב	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ח.ו.ב|Tense=Past	17	advcl	_	_
 28	.	.	PUNCT	PUNCT	_	3	punct	_	_
 
 # sent_id = 5880
@@ -4204,7 +4204,7 @@
 4	,	,	PUNCT	PUNCT	_	2	punct	_	_
 5-6	המשקפת	_	_	_	_	_	_	_	_
 5	ה	ה	SCONJ	SCONJ	_	6	mark	_	_
-6	משקפת	שיקף	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	acl:relcl	_	_
+6	משקפת	שיקף	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ש.ק.פ|VerbForm=Part|Voice=Act	2	acl:relcl	_	_
 7	שינוי	שינוי	NOUN	NOUN	Gender=Masc|Number=Sing	6	obj	_	_
 8-10	בפועל	_	_	_	_	_	_	_	_
 8	ב	ב	ADP	ADP	_	10	case	_	_
@@ -4218,9 +4218,9 @@
 14	תשלום	תשלום	NOUN	NOUN	Gender=Masc|Number=Sing	12	compound:smixut	_	_
 15-16	המוסכמים	_	_	_	_	_	_	_	SpaceAfter=No
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
-16	מוסכמים	הוסכם	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	12	amod	_	_
+16	מוסכמים	הוסכם	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ס.כ.מ|VerbForm=Part|Voice=Pass	12	amod	_	_
 17	,	,	PUNCT	PUNCT	_	18	punct	_	_
-18	נחתם	נחתם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+18	נחתם	נחתם	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ח.ת.מ|Tense=Past|Voice=Mid	0	root	_	_
 19-20	בסוף	_	_	_	_	_	_	_	_
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	סוף	סוף	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	18	obl	_	_
@@ -4237,7 +4237,7 @@
 29	ו	ו	CCONJ	CCONJ	_	32	mark	_	_
 30	ב_	ב	ADP	ADP	_	31	case	_	_
 31	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	32	obl	_	_
-32	נקבעו	נקבע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	23	acl:relcl	_	_
+32	נקבעו	נקבע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ק.ב.ע|Tense=Past|Voice=Mid	23	acl:relcl	_	_
 33	מועדים	מועד	NOUN	NOUN	Gender=Masc|Number=Plur	32	nsubj	_	_
 34-35	להחזרת	_	_	_	_	_	_	_	_
 34	ל	ל	ADP	ADP	_	35	case	_	_
@@ -4252,7 +4252,7 @@
 1	16	16	NUM	NUM	_	2	nummod	_	_
 2	אלף	אלף	NUM	NUM	Gender=Masc|Number=Sing	3	nummod	_	_
 3	דולר	דולר	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
-4	שולמו	שולם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	שולמו	שולם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=ש.ל.מ|Tense=Past|Voice=Pass	0	root	_	_
 5	מראש	מראש	ADV	ADV	_	4	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	4	punct	_	_
 7-10	ותמורתם	_	_	_	_	_	_	_	_
@@ -4260,7 +4260,7 @@
 8	תמורה_	תמורה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	11	dep	_	_
 9	_של_	של	ADP	ADP	_	10	case:gen	_	_
 10	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	8	nmod:poss	_	_
-11	קיבלה	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	conj	_	_
+11	קיבלה	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Past|Voice=Act	4	conj	_	_
 12-13	העמותה	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	11	nsubj	_	_
@@ -4269,7 +4269,7 @@
 16	,	,	PUNCT	PUNCT	_	14	punct	_	_
 17-18	שנועדה	_	_	_	_	_	_	_	_
 17	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
-18	נועדה	נועד	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	14	acl:relcl	_	_
+18	נועדה	נועד	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.ע.ד|Tense=Past|Voice=Mid	14	acl:relcl	_	_
 19-20	למשפחת	_	_	_	_	_	_	_	_
 19	ל	ל	ADP	ADP	_	20	case	_	_
 20	משפחת	משפחה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	18	obl	_	_
@@ -4278,7 +4278,7 @@
 
 # sent_id = 5882
 # text = סוכם, ששאר הדירות יישארו בידי החברה כערובה לתשלום יתרת המס.
-1	סוכם	סוכם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
+1	סוכם	סוכם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ס.כ.מ|Tense=Past|Voice=Pass	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	PUNCT	_	1	punct	_	_
 3-4	ששאר	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
@@ -4286,7 +4286,7 @@
 5-6	הדירות	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	דירות	דירה	NOUN	NOUN	Gender=Fem|Number=Plur	7	nsubj	_	_
-7	יישארו	נשאר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Fut|Voice=Mid	1	ccomp	_	_
+7	יישארו	נשאר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ש.א.ר|Tense=Fut|Voice=Mid	1	ccomp	_	_
 8	בידי	בידי	ADP	ADP	_	10	case	_	_
 9-10	החברה	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -4307,14 +4307,14 @@
 # text = עם זאת נקבע, כי תנאי העסקה יישארו בעינם.
 1	עם	עם	ADP	ADP	_	2	case	_	_
 2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	obl	_	_
-3	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
+3	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ק.ב.ע|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	3	punct	_	_
 5	כי	כי	SCONJ	SCONJ	_	9	mark	_	_
 6	תנאי	תנאי	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	9	nsubj	_	_
 7-8	העסקה	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	עסקה	עסקה	NOUN	NOUN	Gender=Fem|Number=Sing	6	compound:smixut	_	_
-9	יישארו	נשאר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Fut|Voice=Mid	3	ccomp	_	_
+9	יישארו	נשאר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ש.א.ר|Tense=Fut|Voice=Mid	3	ccomp	_	_
 10	בעינם	בעין	ADV	ADV	_	9	advmod	_	SpaceAfter=No
 11	.	.	PUNCT	PUNCT	_	3	punct	_	_
 
@@ -4331,7 +4331,7 @@
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	8	nsubj	_	_
 8	אמורה	אמור	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbType=Mod	9	aux	_	_
-9	לשלם	שילם	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	3	acl:relcl	_	_
+9	לשלם	שילם	VERB	VERB	HebBinyan=PIEL|Root=ש.ל.מ|VerbForm=Inf|Voice=Act	3	acl:relcl	_	_
 10	את	את	ADP	ADP	Case=Acc	11	case:acc	_	_
 11	יתרת	יתרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	9	obj	_	_
 12-13	המס	_	_	_	_	_	_	_	SpaceAfter=No
@@ -4347,7 +4347,7 @@
 19	אלף	אלף	NUM	NUM	Gender=Masc|Number=Sing	20	nummod	_	_
 20	ש"ח	ש"ח	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	16	compound:smixut	_	SpaceAfter=No
 21	,	,	PUNCT	PUNCT	_	22	punct	_	_
-22	התנתה	התנה	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+22	התנתה	התנה	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ת.נ.י|Tense=Past|Voice=Act	0	root	_	_
 23	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	22	obj	_	_
 24-25	בקבלת	_	_	_	_	_	_	_	_
 24	ב	ב	ADP	ADP	_	25	case	_	_
@@ -4366,15 +4366,15 @@
 2	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
-5	סירבה	סירב	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	12	obl	_	_
-6	לשלם	שילם	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
+5	סירבה	סירב	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ס.ר.ב|Tense=Past|Voice=Act	12	obl	_	_
+6	לשלם	שילם	VERB	VERB	HebBinyan=PIEL|Root=ש.ל.מ|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 7	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 8	יתרת	יתרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	obj	_	_
 9-10	המע"ם	_	_	_	_	_	_	_	SpaceAfter=No
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	מע"ם	מע"ם	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	8	compound:smixut	_	_
 11	,	,	PUNCT	PUNCT	_	12	punct	_	_
-12	הגישה	הגיש	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+12	הגישה	הגיש	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Act	0	root	_	_
 13-14	נגדה	_	_	_	_	_	_	_	_
 13	נגד_	נגד	ADP	ADP	_	14	case	_	_
 14	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	12	obl	_	_
@@ -4387,7 +4387,7 @@
 19	סדר	סדר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	21	nmod	_	_
 20	-	-	PUNCT	PUNCT	_	21	punct	_	SpaceAfter=No
 21	דין	דין	NOUN	NOUN	Gender=Masc|Number=Sing	17	nmod	_	_
-22	מקוצר	קוצר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	21	amod	_	_
+22	מקוצר	קוצר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ק.צ.ר|VerbForm=Part|Voice=Pass	21	amod	_	_
 23-24	לבית	_	_	_	_	_	_	_	SpaceAfter=No
 23	ל	ל	ADP	ADP	_	27	case	_	_
 24	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	27	nmod	_	_
@@ -4410,10 +4410,10 @@
 1-2	העמותה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	הגישה	הגיש	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	הגישה	הגיש	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Act	0	root	_	_
 4	בקשת	בקשה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	obj	_	_
 5	רשות	רשות	NOUN	NOUN	Gender=Fem|Number=Sing	4	compound:smixut	_	_
-6	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	4	acl	_	_
+6	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|Root=ג.נ.נ|VerbForm=Inf	4	acl	_	_
 7	נגד	נגד	ADP	ADP	_	9	case	_	_
 8-9	התביעה	_	_	_	_	_	_	_	SpaceAfter=No
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -4439,7 +4439,7 @@
 8-9	הקומבינציה	_	_	_	_	_	_	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	קומבינציה	קומבינציה	NOUN	NOUN	Gender=Fem|Number=Sing	7	compound:smixut	_	_
-10	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
+10	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ק.ב.ע|Tense=Past|Voice=Mid	0	root	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	10	punct	_	_
 12	כי	כי	SCONJ	SCONJ	_	17	mark	_	_
 13	חובת	חובה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	17	nsubj	_	_
@@ -4447,7 +4447,7 @@
 15-16	המע"ם	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	מע"ם	מע"ם	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	14	compound:smixut	_	_
-17	תחול	חל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	10	ccomp	_	_
+17	תחול	חל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ו.ל|Tense=Fut|Voice=Act	10	ccomp	_	_
 18	רק	רק	ADV	ADV	_	19	advmod	_	_
 19	עם	עם	ADP	ADP	_	20	case	_	_
 20	מסירת	מסירה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	17	obl	_	_
@@ -4475,7 +4475,7 @@
 3-4	החברה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
-5	איחרה	איחר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	איחרה	איחר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=א.ח.ר|Tense=Past|Voice=Act	0	root	_	_
 6-7	בהשלמת	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	השלמת	השלמה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	5	obl	_	_
@@ -4486,7 +4486,7 @@
 10	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	כך	כך	PRON	PRON	Person=3|PronType=Dem	13	obl	_	_
-13	גרמה	גרם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	conj	_	_
+13	גרמה	גרם	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ג.ר.מ|Tense=Past|Voice=Act	5	conj	_	_
 14	נזק	נזק	NOUN	NOUN	Gender=Masc|Number=Sing	13	obj	_	_
 15	רב	רב	ADJ	ADJ	Gender=Masc|Number=Sing	14	amod	_	SpaceAfter=No
 16	,	,	PUNCT	PUNCT	_	14	punct	_	_
@@ -4495,7 +4495,7 @@
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	20	nsubj	_	_
 20	רשאית	רשאי	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbType=Mod	21	aux	_	_
-21	לקזז	קיזז	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	14	acl:relcl	_	_
+21	לקזז	קיזז	VERB	VERB	HebBinyan=PIEL|Root=ק.ז.ז|VerbForm=Inf|Voice=Act	14	acl:relcl	_	_
 22-23	אותו	_	_	_	_	_	_	_	_
 22	את_	את_	ADP	ADP	Case=Acc	23	case:acc	_	_
 23	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	obj	_	_
@@ -4514,8 +4514,8 @@
 3-4	העמותה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
-5	מתכוונת	התכוון	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
-6	להגיש	הגיש	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
+5	מתכוונת	התכוון	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=כ.ו.נ|VerbForm=Part	0	root	_	_
+6	להגיש	הגיש	VERB	VERB	HebBinyan=HIFIL|Root=נ.ג.ש|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 7	תביעה	תביעה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obj	_	_
 8	נגדית	נגדי	ADJ	ADJ	Gender=Fem|Number=Sing	7	amod	_	_
 9	על	על	ADP	ADP	_	10	case	_	_
@@ -4528,9 +4528,9 @@
 14	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
 15	לכן	לכן	ADV	ADV	_	17	advmod	_	_
 16	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	17	nsubj	_	_
-17	מבקשת	ביקש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	conj	_	_
+17	מבקשת	ביקש	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ב.ק.ש|VerbForm=Part|Voice=Act	5	conj	_	_
 18	רשות	רשות	NOUN	NOUN	Gender=Fem|Number=Sing	17	obj	_	_
-19	להגיש	הגיש	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	18	acl	_	_
+19	להגיש	הגיש	VERB	VERB	HebBinyan=HIFIL|Root=נ.ג.ש|VerbForm=Inf|Voice=Act	18	acl	_	_
 20	כתב	כתב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	19	obj	_	_
 21	הגנה	הגנה	NOUN	NOUN	Gender=Fem|Number=Sing	20	compound:smixut	_	_
 22	כדי	כדי	ADP	ADP	_	27	mark	_	_
@@ -4540,7 +4540,7 @@
 25-26	התביעות	_	_	_	_	_	_	_	_
 25	ה	ה	DET	DET	PronType=Art	26	det:def	_	_
 26	תביעות	תביעה	NOUN	NOUN	Gender=Fem|Number=Plur	27	nsubj	_	_
-27	יידונו	נידון	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Fut|Voice=Mid	17	advcl	_	_
+27	יידונו	נידון	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ד.ו.נ|Tense=Fut|Voice=Mid	17	advcl	_	_
 28-29	בהליך	_	_	_	_	_	_	_	_
 28	ב	ב	ADP	ADP	_	29	case	_	_
 29	הליך	הליך	NOUN	NOUN	Gender=Masc|Number=Sing	27	obl	_	_
@@ -4562,15 +4562,15 @@
 9	שטרנברג	שטרנברג	PROPN	PROPN	_	8	flat:name	_	SpaceAfter=No
 10	-	-	PUNCT	PUNCT	_	9	flat:name	_	SpaceAfter=No
 11	אליעז	אליעז	PROPN	PROPN	_	9	flat:name	_	_
-12	פסקה	פסק	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	SpaceAfter=No
+12	פסקה	פסק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ס.ק|Tense=Past	0	root	_	SpaceAfter=No
 13	,	,	PUNCT	PUNCT	_	12	punct	_	_
 14	כי	כי	SCONJ	SCONJ	_	17	mark	_	_
 15-16	העמותה	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	17	nsubj	_	_
-17	תקבל	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	12	ccomp	_	_
+17	תקבל	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Fut|Voice=Act	12	ccomp	_	_
 18	רשות	רשות	NOUN	NOUN	Gender=Fem|Number=Sing	17	obj	_	_
-19	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	18	acl	_	_
+19	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|Root=ג.נ.נ|VerbForm=Inf	18	acl	_	_
 20	רק	רק	ADV	ADV	_	21	advmod	_	_
 21-22	בטענת	_	_	_	_	_	_	_	_
 21	ב	ב	ADP	ADP	_	22	case	_	_
@@ -4593,14 +4593,14 @@
 35	,	,	PUNCT	PUNCT	_	34	punct	_	_
 36-37	המורכבים	_	_	_	_	_	_	_	_
 36	ה	ה	SCONJ	SCONJ	_	37	mark	_	_
-37	מורכבים	הורכב	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	34	acl:relcl	_	_
+37	מורכבים	הורכב	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ר.כ.ב|VerbForm=Part|Voice=Pass	34	acl:relcl	_	_
 38-39	ממס	_	_	_	_	_	_	_	_
 38	מ	מ	ADP	ADP	_	39	case	_	_
 39	מס	מס	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	37	obl	_	_
 40	רכוש	רכוש	NOUN	NOUN	Gender=Masc|Number=Sing	39	compound:smixut	_	_
 41-42	ששילמה	_	_	_	_	_	_	_	_
 41	ש	ש	SCONJ	SCONJ	_	42	mark	_	_
-42	שילמה	שילם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	39	acl:relcl	_	_
+42	שילמה	שילם	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.ל.מ|Tense=Past|Voice=Act	39	acl:relcl	_	_
 43-44	העמותה	_	_	_	_	_	_	_	_
 43	ה	ה	DET	DET	PronType=Art	44	det:def	_	_
 44	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	42	nsubj	_	_
@@ -4618,7 +4618,7 @@
 53	,	,	PUNCT	PUNCT	_	47	punct	_	_
 54-55	שנשאה	_	_	_	_	_	_	_	_
 54	ש	ש	SCONJ	SCONJ	_	55	mark	_	_
-55	נשאה	נשא	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	47	acl:relcl	_	_
+55	נשאה	נשא	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ש.א|Tense=Past	47	acl:relcl	_	_
 56-57	בהם	_	_	_	_	_	_	_	_
 56	ב_	ב	ADP	ADP	_	57	case	_	_
 57	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	55	obl	_	_
@@ -4646,22 +4646,22 @@
 4	סכומים	סכום	NOUN	NOUN	Gender=Masc|Number=Plur	17	obl	_	_
 5-6	שרצתה	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	רצתה	רצה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	4	acl:relcl	_	_
+6	רצתה	רצה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ר.צ.י|Tense=Past|Voice=Act	4	acl:relcl	_	_
 7-8	העמותה	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	6	nsubj	_	_
-9	לקזז	קיזז	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	6	xcomp	_	_
+9	לקזז	קיזז	VERB	VERB	HebBinyan=PIEL|Root=ק.ז.ז|VerbForm=Inf|Voice=Act	6	xcomp	_	_
 10	בגלל	בגלל	ADP	ADP	_	12	case	_	_
 11-12	הנזקים	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	נזקים	נזק	NOUN	NOUN	Gender=Masc|Number=Plur	9	obl	_	_
 13-14	שנגרמו	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
-14	נגרמו	נגרם	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	12	acl:relcl	_	_
+14	נגרמו	נגרם	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ג.ר.מ|Tense=Past|Voice=Mid	12	acl:relcl	_	_
 15-16	לה	_	_	_	_	_	_	_	_
 15	ל_	ל	ADP	ADP	_	16	case	_	_
 16	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	14	obl	_	_
-17	קבעה	קבע	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
+17	קבעה	קבע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ב.ע|Tense=Past	0	root	_	_
 18-19	השופטת	_	_	_	_	_	_	_	SpaceAfter=No
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	שופטת	שופט	NOUN	NOUN	Gender=Fem|Number=Sing	17	nsubj	_	_
@@ -4672,7 +4672,7 @@
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	נזקים	נזק	NOUN	NOUN	Gender=Masc|Number=Plur	22	compound:smixut	_	_
 25	לא	לא	ADV	ADV	Polarity=Neg	26	advmod	_	_
-26	פורטו	פורט	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	17	ccomp	_	_
+26	פורטו	פורט	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=פ.ר.ט|Tense=Past|Voice=Pass	17	ccomp	_	_
 27-29	כראוי	_	_	_	_	_	_	_	_
 27	כ	כ	ADP	ADP	_	29	case	_	_
 28	ה_	ה	DET	DET	PronType=Art	29	det:def	_	_
@@ -4683,7 +4683,7 @@
 32-33	העמותה	_	_	_	_	_	_	_	_
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	34	nsubj	_	_
-34	מתעלמת	התעלם	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	26	conj	_	_
+34	מתעלמת	התעלם	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ע.ל.מ|VerbForm=Part	26	conj	_	_
 35-38	מהסכמתה	_	_	_	_	_	_	_	_
 35	מ	מ	ADP	ADP	_	36	case	_	_
 36	הסכמה_	הסכמה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	34	obl	_	_
@@ -4717,7 +4717,7 @@
 58	סילוק	סילוק	NOUN	NOUN	Gender=Masc|Number=Sing	47	nmod	_	_
 59-60	המגיע	_	_	_	_	_	_	_	_
 59	ה	ה	SCONJ	SCONJ	_	60	mark	_	_
-60	מגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	58	acl:relcl	_	_
+60	מגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=נ.ג.ע|VerbForm=Part|Voice=Act	58	acl:relcl	_	_
 61	עבור	עבור	ADP	ADP	_	62	case	_	_
 62	מע"ם	מע"ם	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	60	obl	_	SpaceAfter=No
 63	"	"	PUNCT	PUNCT	_	47	punct	_	SpaceAfter=No
@@ -4728,7 +4728,7 @@
 1	הואיל	הואיל	CCONJ	CCONJ	_	3	mark	_	_
 2-3	וניתנה	_	_	_	_	_	_	_	_
 2	ו	ו	CCONJ	CCONJ	_	1	fixed	_	_
-3	ניתנה	ניתן	VERB	VERB	_	15	advcl	_	_
+3	ניתנה	ניתן	VERB	VERB	HebBinyan=NIFAL|Root=נ.ת.נ	15	advcl	_	_
 4-6	הסכמתה	_	_	_	_	_	_	_	_
 4	הסכמה_	הסכמה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	3	nsubj	_	_
 5	_של_	של	ADP	ADP	_	6	case:gen	_	_
@@ -4744,7 +4744,7 @@
 13	אין	אין	ADV	ADV	Polarity=Neg	15	advmod	_	_
 14	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
 15	יכולה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	16	aux	_	_
-16	לתבוע	תבע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+16	לתבוע	תבע	VERB	VERB	HebBinyan=PAAL|Root=ת.ב.ע|VerbForm=Inf|Voice=Act	0	root	_	_
 17	פיצויים	פיצוי	NOUN	NOUN	Gender=Masc|Number=Plur	16	obj	_	_
 18-19	עליו	_	_	_	_	_	_	_	SpaceAfter=No
 18	על_	על	ADP	ADP	_	19	case	_	_
@@ -4756,7 +4756,7 @@
 1-2	השופטת	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	שופטת	שופט	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	ציינה	ציין	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+3	ציינה	ציין	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=צ.י.נ|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	3	punct	_	_
 5	כי	כי	SCONJ	SCONJ	_	12	mark	_	_
 6-8	במקרה	_	_	_	_	_	_	_	_
@@ -4765,7 +4765,7 @@
 8	מקרה	מקרה	NOUN	NOUN	Gender=Masc|Number=Sing	12	obl	_	_
 9-10	הנדון	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
-10	נדון	נדון	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	8	amod	_	_
+10	נדון	נדון	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ד.ו.נ|VerbForm=Part|Voice=Mid	8	amod	_	_
 11	"	"	PUNCT	PUNCT	_	12	punct	_	SpaceAfter=No
 12	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	3	ccomp	_	_
 13-14	בתובענה	_	_	_	_	_	_	_	_
@@ -4776,7 +4776,7 @@
 16	סדר	סדר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	18	nmod	_	_
 17	-	-	PUNCT	PUNCT	_	18	punct	_	SpaceAfter=No
 18	דין	דין	NOUN	NOUN	Gender=Masc|Number=Sing	14	nmod	_	_
-19	מקוצר	קוצר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	18	amod	_	SpaceAfter=No
+19	מקוצר	קוצר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ק.צ.ר|VerbForm=Part|Voice=Pass	18	amod	_	SpaceAfter=No
 20	,	,	PUNCT	PUNCT	_	14	punct	_	_
 21-24	שעילתה	_	_	_	_	_	_	_	_
 21	ש	ש	SCONJ	SCONJ	_	27	mark	_	_
@@ -4789,7 +4789,7 @@
 27	יתרת	יתרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	14	acl:relcl	_	_
 28-29	המגיע	_	_	_	_	_	_	_	_
 28	ה	ה	SCONJ	SCONJ	_	29	mark	_	_
-29	מגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	27	compound:smixut	_	_
+29	מגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=נ.ג.ע|VerbForm=Part|Voice=Act	27	compound:smixut	_	_
 30-32	לתובעת	_	_	_	_	_	_	_	_
 30	ל	ל	ADP	ADP	_	32	case	_	_
 31	ה_	ה	DET	DET	PronType=Art	32	det:def	_	_
@@ -4808,7 +4808,7 @@
 1-2	העמותה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	עירערה	ערער	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+3	עירערה	ערער	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ע.ר.ע.ר|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	3	punct	_	_
 5	באמצעות	באמצעות	ADP	ADP	_	6	case	_	_
 6	עו"ד	עו"ד	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	3	obl	_	_
@@ -4845,7 +4845,7 @@
 4	,	,	PUNCT	PUNCT	_	2	punct	_	_
 5-6	שכתב	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	כתב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	acl:relcl	_	_
+6	כתב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ת.ב|Tense=Past|Voice=Act	2	acl:relcl	_	_
 7	את	את	ADP	ADP	Case=Acc	11	case:acc	_	_
 8	פסק	פסק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 9	-	-	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
@@ -4853,14 +4853,14 @@
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	דין	דין	NOUN	NOUN	Gender=Masc|Number=Sing	6	obj	_	_
 12	,	,	PUNCT	PUNCT	_	13	punct	_	_
-13	ציין	ציין	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+13	ציין	ציין	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=צ.י.נ|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 14	,	,	PUNCT	PUNCT	_	13	punct	_	_
 15	כי	כי	SCONJ	SCONJ	_	27	mark	_	_
 16	אמנם	אמנם	ADV	ADV	_	27	advmod	_	_
 17-18	ההתחייבות	_	_	_	_	_	_	_	_
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	התחייבות	התחייבות	NOUN	NOUN	Gender=Fem|Number=Sing	27	nsubj	_	_
-19	לשלם	שילם	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	18	acl	_	_
+19	לשלם	שילם	VERB	VERB	HebBinyan=PIEL|Root=ש.ל.מ|VerbForm=Inf|Voice=Act	18	acl	_	_
 20	את	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 21-22	המע"ם	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
@@ -4875,7 +4875,7 @@
 28	ל	ל	ADP	ADP	_	30	case	_	_
 29	ה_	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	27	obl	_	_
-31	לעכב	עיכב	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	13	ccomp	_	_
+31	לעכב	עיכב	VERB	VERB	HebBinyan=PIEL|Root=ע.כ.ב|VerbForm=Inf|Voice=Act	13	ccomp	_	_
 32	את	את	ADP	ADP	Case=Acc	33	case:acc	_	_
 33	מסירת	מסירה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	31	obj	_	_
 34-35	הדירות	_	_	_	_	_	_	_	_
@@ -4895,13 +4895,13 @@
 3	לכאורה	לכאורה	ADV	ADV	HebSource=ConvUncertainHead	2	advmod	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	5	punct	_	_
 5	אין	אין	AUX	AUX	VerbType=Mod	6	aux	_	_
-6	להסיק	הסיק	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+6	להסיק	הסיק	VERB	VERB	HebBinyan=HIFIL|Root=נ.ס.ק|VerbForm=Inf|Voice=Act	0	root	_	_
 7-9	שהחברה	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	חברה	חברה	NOUN	NOUN	Gender=Fem|Number=Sing	10	nsubj	_	_
 10	זכאית	זכאי	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbType=Mod	11	aux	_	_
-11	לעכב	עיכב	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	6	advcl	_	_
+11	לעכב	עיכב	VERB	VERB	HebBinyan=PIEL|Root=ע.כ.ב|VerbForm=Inf|Voice=Act	6	advcl	_	_
 12	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 13	מסירת	מסירה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	11	obj	_	_
 14-15	הדירות	_	_	_	_	_	_	_	_
@@ -4909,7 +4909,7 @@
 15	דירות	דירה	NOUN	NOUN	Gender=Fem|Number=Plur	13	compound:smixut	_	_
 16-17	כשישולם	_	_	_	_	_	_	_	_
 16	כש	כש	SCONJ	SCONJ	Case=Tem	17	mark	_	_
-17	ישולם	שולם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	11	advcl	_	_
+17	ישולם	שולם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ש.ל.מ|Tense=Fut|Voice=Pass	11	advcl	_	_
 18-19	המע"ם	_	_	_	_	_	_	_	SpaceAfter=No
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	מע"ם	מע"ם	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	17	dep	_	_
@@ -4918,7 +4918,7 @@
 # sent_id = 5897
 # text = עוד קבע השופט, כי אף שהעמותה קיבלה עליה חיוב זה בזיכרון הדברים, המשנה לכאורה את ההסדר הקודם, אין להסיק מכך כלל ועיקר כי היא ויתרה על טענותיה בדבר האיחור במסירת הדירות, ככל שהדבר אינו קשור לסיכום בזיכרון הדברים בעניין תשלום המע"ם.
 1	עוד	עוד	ADV	ADV	_	2	advmod	_	_
-2	קבע	קבע	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	0	root	_	_
+2	קבע	קבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ב.ע|Tense=Past	0	root	_	_
 3-4	השופט	_	_	_	_	_	_	_	SpaceAfter=No
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	שופט	שופט	NOUN	NOUN	Gender=Masc|Number=Sing	2	nsubj	_	_
@@ -4929,7 +4929,7 @@
 8	ש	ש	SCONJ	SCONJ	_	7	fixed	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	11	nsubj	_	_
-11	קיבלה	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	30	advcl	_	_
+11	קיבלה	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Past|Voice=Act	30	advcl	_	_
 12-13	עליה	_	_	_	_	_	_	_	_
 12	על_	על	ADP	ADP	_	13	case	_	_
 13	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	11	obl	_	_
@@ -4944,7 +4944,7 @@
 20	,	,	PUNCT	PUNCT	_	14	punct	_	_
 21-22	המשנה	_	_	_	_	_	_	_	_
 21	ה	ה	SCONJ	SCONJ	_	22	mark	_	_
-22	משנה	_	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	14	acl:relcl	_	_
+22	משנה	_	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ש.נ.י|VerbForm=Part|Voice=Act	14	acl:relcl	_	_
 23	לכאורה	לכאורה	ADV	ADV	_	22	advmod	_	_
 24	את	את	ADP	ADP	Case=Acc	26	case:acc	_	_
 25-26	ההסדר	_	_	_	_	_	_	_	_
@@ -4955,7 +4955,7 @@
 28	קודם	קודם	ADJ	ADJ	Gender=Masc|Number=Sing	26	amod	_	_
 29	,	,	PUNCT	PUNCT	_	30	punct	_	_
 30	אין	אין	AUX	AUX	VerbType=Mod	31	aux	_	_
-31	להסיק	הסיק	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	2	ccomp	_	_
+31	להסיק	הסיק	VERB	VERB	HebBinyan=HIFIL|Root=נ.ס.ק|VerbForm=Inf|Voice=Act	2	ccomp	_	_
 32-33	מכך	_	_	_	_	_	_	_	_
 32	מ	מ	ADP	ADP	_	33	case	_	_
 33	כך	כך	PRON	PRON	Person=3|PronType=Dem	31	obl	_	_
@@ -4965,7 +4965,7 @@
 36	עיקר	עיקר	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	34	fixed	_	_
 37	כי	כי	SCONJ	SCONJ	_	39	mark	_	_
 38	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	39	nsubj	_	_
-39	ויתרה	ויתר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	31	ccomp	_	_
+39	ויתרה	ויתר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ו.ת.ר|Tense=Past|Voice=Act	31	ccomp	_	_
 40	על	על	ADP	ADP	_	41	case	_	_
 41-43	טענותיה	_	_	_	_	_	_	_	_
 41	טענה_	טענה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	39	obl	_	_
@@ -4990,7 +4990,7 @@
 55	ה	ה	DET	DET	PronType=Art	56	det:def	_	_
 56	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	58	nsubj	_	_
 57	אינו	אינו	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	58	advmod	_	_
-58	קשור	קשר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	39	obl	_	_
+58	קשור	קשר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ק.ש.ר|VerbForm=Part|Voice=Act	39	obl	_	_
 59-61	לסיכום	_	_	_	_	_	_	_	_
 59	ל	ל	ADP	ADP	_	61	case	_	_
 60	ה_	ה	DET	DET	PronType=Art	61	det:def	_	_
@@ -5017,7 +5017,7 @@
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	דברים	דבר	NOUN	NOUN	Gender=Masc|Number=Plur	1	compound:smixut	_	_
 4	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Emp|Reflex=Yes	1	nmod	_	_
-5	קובע	קבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	קובע	קבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ק.ב.ע|VerbForm=Part|Voice=Act	0	root	_	_
 6	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 7-9	זיקתו	_	_	_	_	_	_	_	_
 7	זיקה_	זיקה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	5	obj	_	_
@@ -5040,7 +5040,7 @@
 21	משום	משום	SCONJ	SCONJ	_	23	mark	_	_
 22-23	שנאמר	_	_	_	_	_	_	_	_
 22	ש	ש	SCONJ	SCONJ	_	21	fixed	_	_
-23	נאמר	נאמר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	20	conj	_	_
+23	נאמר	נאמר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Mid	20	conj	_	_
 24-25	בו	_	_	_	_	_	_	_	_
 24	ב_	ב	ADP	ADP	_	25	case	_	_
 25	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	23	obl	_	_
@@ -5054,7 +5054,7 @@
 32-33	הצדדים	_	_	_	_	_	_	_	_
 32	ה	ה	DET	DET	PronType=Art	33	det:def	_	_
 33	צדדים	צד	NOUN	NOUN	Gender=Masc|Number=Plur	28	nmod	_	_
-34	עומדים	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	23	ccomp	_	_
+34	עומדים	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ע.מ.ד|VerbForm=Part|Voice=Act	23	ccomp	_	_
 35	בעינם	בעין	ADV	ADV	_	34	advmod	_	SpaceAfter=No
 36	.	.	PUNCT	PUNCT	_	5	punct	_	_
 
@@ -5064,7 +5064,7 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	שופט	שופט	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 3	לוין	לוין	PROPN	PROPN	_	2	flat:name	_	_
-4	ציטט	ציטט	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	ציטט	ציטט	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=צ.ט.ט|Tense=Past|Voice=Act	0	root	_	_
 5-8	מספרו	_	_	_	_	_	_	_	_
 5	מ	מ	ADP	ADP	_	6	case	_	_
 6	ספר_	ספר	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
@@ -5101,7 +5101,7 @@
 30	ל	ל	ADP	ADP	_	31	case	_	_
 31	מתן	מתן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	29	nmod	_	_
 32	רשות	רשות	NOUN	NOUN	Gender=Fem|Number=Sing	31	compound:smixut	_	_
-33	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	32	acl	_	_
+33	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|Root=ג.נ.נ|VerbForm=Inf	32	acl	_	_
 34	"	"	PUNCT	PUNCT	_	35	punct	_	SpaceAfter=No
 35	די	די	ADV	ADV	_	4	ccomp	_	_
 36-37	לו	_	_	_	_	_	_	_	_
@@ -5113,7 +5113,7 @@
 40	ה_	ה	DET	DET	PronType=Art	41	det:def	_	_
 41	נתבע	נתבע	NOUN	NOUN	Gender=Masc|Number=Sing	37	dep	_	_
 42	)	)	PUNCT	PUNCT	_	41	punct	_	_
-43	להראות	הראה	VERB	VERB	VerbForm=Inf	35	xcomp	_	_
+43	להראות	הראה	VERB	VERB	HebBinyan=HIFIL|Root=ר.א.י|VerbForm=Inf	35	xcomp	_	_
 44	כי	כי	SCONJ	SCONJ	_	45	dep	_	_
 45	הגנה	הגנה	NOUN	NOUN	Gender=Fem|Number=Sing	43	obl	_	_
 46	אפשרית	אפשרי	ADJ	ADJ	Gender=Fem|Number=Sing	45	amod	_	_
@@ -5139,18 +5139,18 @@
 61	ה	ה	DET	DET	PronType=Art	62	det:def	_	_
 62	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	63	nsubj	_	_
 63	חייב	חייב	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	64	aux	_	_
-64	ליתן	נתן	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	35	conj	_	_
+64	ליתן	נתן	VERB	VERB	HebBinyan=PAAL|Root=נ.ת.נ|VerbForm=Inf|Voice=Act	35	conj	_	_
 65	רשות	רשות	NOUN	NOUN	Gender=Fem|Number=Sing	64	obj	_	_
-66	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	65	acl	_	SpaceAfter=No
+66	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|Root=ג.נ.נ|VerbForm=Inf	65	acl	_	SpaceAfter=No
 67	,	,	PUNCT	PUNCT	_	63	punct	_	_
 68-69	שאם	_	_	_	_	_	_	_	_
 68	ש	ש	SCONJ	SCONJ	_	63	advcl	_	_
 69	אם	אם	SCONJ	SCONJ	_	71	dep	_	_
 70	לא	לא	ADV	ADV	Polarity=Neg	71	advmod	_	_
-71	יעשה	נעשה	VERB	VERB	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing|Person=3|Tense=Fut	68	dep	_	_
+71	יעשה	נעשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Root=ע.ש.י|Tense=Fut	68	dep	_	_
 72	כן	כן	ADV	ADV	_	71	advmod	_	SpaceAfter=No
 73	,	,	PUNCT	PUNCT	HebSource=ConvUncertainHead	71	dep	_	_
-74	יכריע	הכריע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Tense=Fut|Voice=Act	71	dep	_	_
+74	יכריע	הכריע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Root=כ.ר.ע|Tense=Fut|Voice=Act	71	dep	_	_
 75	למעשה	למעשה	ADV	ADV	HebSource=ConvUncertainHead	71	advmod	_	_
 76	כבר	כבר	ADV	ADV	_	77	advmod	_	_
 77-78	בתובענה	_	_	_	_	_	_	_	_
@@ -5162,8 +5162,8 @@
 81	ו	ו	CCONJ	CCONJ	HebSource=ConvUncertainHead	68	dep	_	_
 82	ה	ה	DET	DET	PronType=Art	83	det:def	_	_
 83	נתבע	נתבע	NOUN	NOUN	Gender=Masc|Number=Sing	84	nsubj	_	_
-84	יצא	יצא	VERB	VERB	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing|Person=3|Tense=Past	68	dep	_	_
-85	מקופח	קופח	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	84	advmod	_	SpaceAfter=No
+84	יצא	יצא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Root=י.צ.א|Tense=Past	68	dep	_	_
+85	מקופח	קופח	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ק.פ.ח|VerbForm=Part|Voice=Pass	84	advmod	_	SpaceAfter=No
 86	"	"	PUNCT	PUNCT	_	4	punct	_	SpaceAfter=No
 87	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
@@ -5194,7 +5194,7 @@
 17	ה	ה	SCONJ	SCONJ	_	18	mark	_	_
 18	ראויה	ראוי	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbType=Mod	20	aux	_	_
 19	לכאורה	לכאורה	ADV	ADV	_	18	advmod	_	_
-20	להישמע	נשמע	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	15	acl:relcl	_	SpaceAfter=No
+20	להישמע	נשמע	VERB	VERB	HebBinyan=NIFAL|Root=ש.מ.ע|VerbForm=Inf|Voice=Mid	15	acl:relcl	_	SpaceAfter=No
 21	,	,	PUNCT	PUNCT	_	18	punct	_	_
 22	כי	כי	SCONJ	SCONJ	_	25	mark	_	_
 23-24	התביעה	_	_	_	_	_	_	_	_
@@ -5206,7 +5206,7 @@
 # sent_id = 5901
 # text = הוא ציטט עוד מהספר, כי "טענת קיזוז היא טענת הגנה ככל טענה אחרת, ובעטיה תינתן לנתבע הרשות להתגונן כל אימת שהדין המהותי מכיר בה".
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	ציטט	ציטט	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	ציטט	ציטט	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=צ.ט.ט|Tense=Past|Voice=Act	0	root	_	_
 3	עוד	עוד	ADV	ADV	_	2	advmod	_	_
 4-6	מהספר	_	_	_	_	_	_	_	SpaceAfter=No
 4	מ	מ	ADP	ADP	_	6	case	_	_
@@ -5230,7 +5230,7 @@
 21	עט_	עט	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	24	obl	_	_
 22	_של_	של	ADP	ADP	_	23	case:gen	_	_
 23	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	21	nmod:poss	_	_
-24	תינתן	ניתן	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	13	conj	_	_
+24	תינתן	ניתן	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=נ.ת.נ|Tense=Fut|Voice=Mid	13	conj	_	_
 25-27	לנתבע	_	_	_	_	_	_	_	_
 25	ל	ל	ADP	ADP	_	27	case	_	_
 26	ה_	ה	DET	DET	PronType=Art	27	det:def	_	_
@@ -5238,7 +5238,7 @@
 28-29	הרשות	_	_	_	_	_	_	_	_
 28	ה	ה	DET	DET	PronType=Art	29	det:def	_	_
 29	רשות	רשות	NOUN	NOUN	Gender=Fem|Number=Sing	24	nsubj	_	_
-30	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	29	acl	_	_
+30	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|Root=ג.נ.נ|VerbForm=Inf	29	acl	_	_
 31	כל	כול	DET	DET	Definite=Cons|HebSource=ConvUncertainHead	30	dep	_	_
 32	אימת	אימת	ADP	ADP	HebSource=ConvUncertainHead	31	dep	_	_
 33-35	שהדין	_	_	_	_	_	_	_	_
@@ -5248,7 +5248,7 @@
 36-37	המהותי	_	_	_	_	_	_	_	_
 36	ה	ה	DET	DET	PronType=Art	37	det:def	_	_
 37	מהותי	מהותי	ADJ	ADJ	Gender=Masc|Number=Sing	35	amod	_	_
-38	מכיר	הכיר	VERB	VERB	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part	31	dep	_	_
+38	מכיר	הכיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|Root=נ.כ.ר|VerbForm=Part	31	dep	_	_
 39-40	בה	_	_	_	_	_	_	_	SpaceAfter=No
 39	ב_	ב	ADP	ADP	_	40	case	_	_
 40	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	38	obl	_	_
@@ -5262,17 +5262,17 @@
 2	מכיוון	מכיוון	SCONJ	SCONJ	_	4	case	_	_
 3-4	שהוכרע	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	הוכרע	הוכרע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	12	obl	_	_
+4	הוכרע	הוכרע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=כ.ר.ע|Tense=Past|Voice=Pass	12	obl	_	_
 5	כי	כי	SCONJ	SCONJ	_	8	mark	_	_
 6-7	העמותה	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	עמותה	עמותה	NOUN	NOUN	Gender=Fem|Number=Sing	8	nsubj	_	_
 8	רשאית	רשאי	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbType=Mod	9	aux	_	_
-9	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	4	ccomp	_	SpaceAfter=No
+9	להתגונן	התגונן	VERB	VERB	HebBinyan=HITPAEL|Root=ג.נ.נ|VerbForm=Inf	4	ccomp	_	SpaceAfter=No
 10	,	,	PUNCT	PUNCT	_	12	punct	_	_
 11	גם	גם	ADV	ADV	_	12	advmod	_	_
 12	אין	אין	AUX	AUX	VerbType=Mod	13	aux	_	_
-13	לשלול	שלל	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+13	לשלול	שלל	VERB	VERB	HebBinyan=PAAL|Root=ש.ל.ל|VerbForm=Inf|Voice=Act	0	root	_	_
 14-15	ממנה	_	_	_	_	_	_	_	_
 14	ממנה	ממנה	ADP	ADP	_	15	case	_	_
 15	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	13	obl	_	_
@@ -5287,7 +5287,7 @@
 23	-	-	PUNCT	PUNCT	_	24	punct	_	SpaceAfter=No
 24	מתן	מתן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	13	obl	_	_
 25	רשות	רשות	NOUN	NOUN	Gender=Fem|Number=Sing	24	compound:smixut	_	_
-26	להגיש	הגיש	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	24	acl	_	_
+26	להגיש	הגיש	VERB	VERB	HebBinyan=HIFIL|Root=נ.ג.ש|VerbForm=Inf|Voice=Act	24	acl	_	_
 27	כתב	כתב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	26	obj	_	_
 28	הגנה	הגנה	NOUN	NOUN	Gender=Fem|Number=Sing	27	compound:smixut	_	SpaceAfter=No
 29	.	.	PUNCT	PUNCT	_	12	punct	_	_
@@ -5302,7 +5302,7 @@
 5-6	הדין	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	דין	דין	NOUN	NOUN	Gender=Masc|Number=Sing	2	compound:smixut	_	_
-7	מעיר	העיר	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+7	מעיר	העיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ע.ו.ר|VerbForm=Part	0	root	_	_
 8-9	השופט	_	_	_	_	_	_	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	שופט	שופט	NOUN	NOUN	Gender=Masc|Number=Sing	7	nsubj	_	_
@@ -5318,14 +5318,14 @@
 18-19	העליון	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	עליון	עליון	ADJ	ADJ	Gender=Masc|Number=Sing	17	amod	_	_
-20	הורה	הורה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	7	ccomp	_	_
+20	הורה	הורה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ר.י|Tense=Past|Voice=Act	7	ccomp	_	_
 21-22	לשני	_	_	_	_	_	_	_	_
 21	ל	ל	ADP	ADP	_	24	case	_	_
 22	שני	שני	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	24	nummod	_	_
 23-24	הצדדים	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	צדדים	צד	NOUN	NOUN	Gender=Masc|Number=Plur	20	obl	_	_
-25	להגיש	הגיש	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	20	xcomp	_	_
+25	להגיש	הגיש	VERB	VERB	HebBinyan=HIFIL|Root=נ.ג.ש|VerbForm=Inf|Voice=Act	20	xcomp	_	_
 26	סיכומים	סיכום	NOUN	NOUN	Gender=Masc|Number=Plur	25	obj	_	_
 27-28	בכתב	_	_	_	_	_	_	_	SpaceAfter=No
 27	ב	ב	ADP	ADP	_	28	case	_	_
@@ -5361,7 +5361,7 @@
 6-7	הצדדים	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	צדדים	צד	NOUN	NOUN	Gender=Masc|Number=Plur	5	compound:smixut	_	_
-8	העתירו	העתיר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+8	העתירו	העתיר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ע.ת.ר|Tense=Past|Voice=Act	0	root	_	_
 9	על	על	ADP	ADP	_	13	case	_	_
 10	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 11	-	-	PUNCT	PUNCT	_	13	punct	_	SpaceAfter=No
@@ -5374,7 +5374,7 @@
 17	ככל	ככל	SCONJ	SCONJ	_	19	case	_	_
 18-19	שנדבה	_	_	_	_	_	_	_	_
 18	ש	ש	SCONJ	SCONJ	_	19	mark	_	_
-19	נדבה	נידב	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	8	obl	_	_
+19	נדבה	נידב	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.ד.ב|Tense=Past|Voice=Act	8	obl	_	_
 20-22	רוחם	_	_	_	_	_	_	_	_
 20	רוח_	רוח	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	19	nsubj	_	_
 21	_של_	של	ADP	ADP	_	22	case:gen	_	_
@@ -5386,7 +5386,7 @@
 25	ו	ו	CCONJ	CCONJ	_	28	cc	_	_
 26	ככל	ככל	SCONJ	SCONJ	_	28	case	_	_
 27	אשר	אשר	SCONJ	SCONJ	_	28	mark	_	_
-28	העלה	העלה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	19	conj	_	_
+28	העלה	העלה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ע.ל.י|Tense=Past|Voice=Act	19	conj	_	_
 29-31	קולמוסם	_	_	_	_	_	_	_	SpaceAfter=No
 29	קולמוס_	קולמוס	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	28	nsubj	_	_
 30	_של_	של	ADP	ADP	_	31	case:gen	_	_
@@ -5396,7 +5396,7 @@
 # sent_id = 5905
 # text = כך זכינו, שסיכומי המערערים השתרעו על 24 (עשרים וארבעה !) עמודים.
 1	כך	כך	ADV	ADV	_	2	advmod	_	_
-2	זכינו	זכה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+2	זכינו	זכה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=ז.כ.י|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	PUNCT	_	2	punct	_	_
 4-5	שסיכומי	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	2	ccomp	_	_
@@ -5404,7 +5404,7 @@
 6-7	המערערים	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	מערערים	מערער	NOUN	NOUN	Gender=Masc|Number=Plur	5	compound:smixut	_	_
-8	השתרעו	השתרע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|HebSource=ConvUncertainHead|Number=Plur|Person=3|Tense=Past	4	dep	_	_
+8	השתרעו	השתרע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|HebSource=ConvUncertainHead|Number=Plur|Person=3|Root=שׂ.ר.ע|Tense=Past	4	dep	_	_
 9	על	על	ADP	ADP	_	10	case	_	_
 10	24	24	NUM	NUM	_	8	obl	_	_
 11	(	(	PUNCT	PUNCT	_	10	appos	_	SpaceAfter=No
@@ -5423,7 +5423,7 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	משיבים	משיב	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
-4	נותרו	נותר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+4	נותרו	נותר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=י.ת.ר|Tense=Past|Voice=Mid	0	root	_	_
 5	חייבים	חייב	NOUN	NOUN	Gender=Masc|Number=Plur	4	dep	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	4	punct	_	_
 7-10	וסיכומיהם	_	_	_	_	_	_	_	_
@@ -5431,7 +5431,7 @@
 8	סיכום_	סיכום	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	31	nsubj	_	_
 9	_של_	של	ADP	ADP	_	10	case:gen	_	_
 10	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	8	nmod:poss	_	_
-11	השתרעו	השתרע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|HebSource=ConvUncertainHead|Number=Plur|Person=3|Tense=Past	31	dep	_	_
+11	השתרעו	השתרע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|HebSource=ConvUncertainHead|Number=Plur|Person=3|Root=שׂ.ר.ע|Tense=Past	31	dep	_	_
 12	על	על	ADP	ADP	_	13	case	_	_
 13	25	25	NUM	NUM	_	31	obl	_	_
 14	(	(	PUNCT	PUNCT	_	13	appos	_	SpaceAfter=No
@@ -5455,7 +5455,7 @@
 29-30	המשיבה	_	_	_	_	_	_	_	_
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	משיבה	משיב	NOUN	NOUN	Gender=Fem|Number=Sing	28	compound:smixut	_	_
-31	השתרעה	השתרע	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	4	conj	_	_
+31	השתרעה	השתרע	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=שׂ.ר.ע|Tense=Past	4	conj	_	_
 32	על	על	ADP	ADP	_	34	case	_	_
 33	תשעה	תשעה	NUM	NUM	Gender=Masc|Number=Sing	34	nummod	_	_
 34	עמודים	עמוד	NOUN	NOUN	Gender=Masc|Number=Plur	31	obl	_	SpaceAfter=No
@@ -5474,7 +5474,7 @@
 7	עמודי	עמוד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	10	obl	_	_
 8	סיכומים	סיכום	NOUN	NOUN	Gender=Masc|Number=Plur	7	compound:smixut	_	_
 9	לא	לא	ADV	ADV	Polarity=Neg	10	advmod	_	_
-10	חסכו	חסך	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	35	advcl	_	_
+10	חסכו	חסך	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ח.ס.כ|Tense=Past|Voice=Act	35	advcl	_	_
 11	באי	_	NOUN	NOUN	Definite=Cons	13	nmod	_	SpaceAfter=No
 12	-	-	PUNCT	PUNCT	_	13	punct	_	SpaceAfter=No
 13	כוח	כוח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	10	nsubj	_	_
@@ -5484,7 +5484,7 @@
 16-17	ולא	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 17	לא	לא	ADV	ADV	Polarity=Neg	18	advmod	_	_
-18	קפצו	קיפץ	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	10	conj	_	_
+18	קפצו	קיפץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ק.פ.צ|Tense=Past	10	conj	_	_
 19-21	ידם	_	_	_	_	_	_	_	SpaceAfter=No
 19	יד_	יד	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	18	obj	_	_
 20	_של_	של	ADP	ADP	_	21	case:gen	_	_
@@ -5506,7 +5506,7 @@
 33-34	הטענות	_	_	_	_	_	_	_	_
 33	ה	ה	DET	DET	PronType=Art	34	det:def	_	_
 34	טענות	טענה	NOUN	NOUN	Gender=Fem|Number=Plur	32	compound:smixut	_	_
-35	קימצו	קימץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+35	קימצו	קימץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ק.מ.צ|Tense=Past|Voice=Act	0	root	_	_
 36	באי	_	NOUN	NOUN	Definite=Cons	38	nmod	_	SpaceAfter=No
 37	-	-	PUNCT	PUNCT	_	38	punct	_	SpaceAfter=No
 38	כוח	כוח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	35	nsubj	_	_
@@ -5514,12 +5514,12 @@
 39	ה	ה	DET	DET	PronType=Art	40	det:def	_	_
 40	צדדים	צד	NOUN	NOUN	Gender=Masc|Number=Plur	38	compound:smixut	_	_
 41	גם	גם	ADV	ADV	_	42	advmod	_	_
-42	קימצו	קימץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	35	parataxis	_	SpaceAfter=No
+42	קימצו	קימץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ק.מ.צ|Tense=Past|Voice=Act	35	parataxis	_	SpaceAfter=No
 43	,	,	PUNCT	PUNCT	_	35	punct	_	_
 44-45	ולא	_	_	_	_	_	_	_	_
 44	ו	ו	CCONJ	CCONJ	_	46	cc	_	_
 45	לא	לא	ADV	ADV	Polarity=Neg	46	advmod	_	_
-46	הותירו	הותיר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	35	conj	_	_
+46	הותירו	הותיר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=י.ת.ר|Tense=Past|Voice=Act	35	conj	_	_
 47	בין	בין	ADP	ADP	_	49	case	_	_
 48-49	השורות	_	_	_	_	_	_	_	_
 48	ה	ה	DET	DET	PronType=Art	49	det:def	_	_
@@ -5538,7 +5538,7 @@
 # text = על כך נענשו שני הצדדים.
 1	על	על	ADP	ADP	_	2	case	_	_
 2	כך	כך	PRON	PRON	Person=3|PronType=Dem	3	obl	_	_
-3	נענשו	נענש	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+3	נענשו	נענש	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ע.נ.ש|Tense=Past|Voice=Mid	0	root	_	_
 4	שני	שני	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	6	nummod	_	_
 5-6	הצדדים	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -5551,7 +5551,7 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	מערערים	מערער	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
-4	זכו	זכה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	זכו	זכה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ז.כ.י|Tense=Past|Voice=Act	0	root	_	_
 5-6	לכיסוי	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	כיסוי	כיסוי	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
@@ -5566,7 +5566,7 @@
 13-14	המשיבים	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	משיבים	משיב	NOUN	NOUN	Gender=Masc|Number=Plur	15	nsubj	_	_
-15	שילמו	שילם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	4	conj	_	_
+15	שילמו	שילם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ש.ל.מ|Tense=Past|Voice=Act	4	conj	_	_
 16	5,000	5,000	NUM	NUM	_	17	nummod	_	_
 17	ש"ח	ש"ח	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	15	obj	_	_
 18-19	לאוצר	_	_	_	_	_	_	_	_
@@ -5595,7 +5595,7 @@
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	מאה	מאה	NOUN	NOUN	_	6	nmod	_	_
 12	,	,	PUNCT	PUNCT	_	13	punct	_	_
-13	הנחיל	הנחיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+13	הנחיל	הנחיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ח.ל|Tense=Past|Voice=Act	0	root	_	_
 14-15	לנו	_	_	_	_	_	_	_	_
 14	ל_	ל	ADP	ADP	_	15	case	_	_
 15	_אנחנו	הוא	PRON	PRON	Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	13	obl	_	_
@@ -5633,7 +5633,7 @@
 5	אופה_	אופה	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	3	advmod	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
 7	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nmod:poss	_	_
-8	נפתח	נפתח	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+8	נפתח	נפתח	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=פ.ת.ח|Tense=Past|Voice=Mid	0	root	_	_
 9	ערב	ערב	NOUN	NOUN	Gender=Masc|Number=Sing	8	nsubj	_	_
 10	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	9	det	_	SpaceAfter=No
 11	.	.	PUNCT	PUNCT	_	8	punct	_	_
@@ -5644,7 +5644,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	מוסיקה	מוזיקה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
 3	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	det	_	_
-4	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+4	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=מ.צ.א|VerbForm=Part|Voice=Mid	0	root	_	_
 5	מבט	מבט	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 6	אל	אל	ADP	ADP	_	7	case	_	_
 7	עולם	עולם	NOUN	NOUN	Gender=Masc|Number=Sing	5	nmod	_	_
@@ -5665,13 +5665,13 @@
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	מורכבים	מורכב	ADJ	ADJ	Gender=Masc|Number=Plur	16	conj	_	_
 20	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	21	advmod	_	_
-21	מתרחקים	התרחק	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	7	acl:relcl	_	_
+21	מתרחקים	התרחק	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ר.ח.ק|VerbForm=Part	7	acl:relcl	_	_
 22-23	ממרכז	_	_	_	_	_	_	_	_
 22	מ	מ	ADP	ADP	_	23	case	_	_
 23	מרכז	מרכז	NOUN	NOUN	Gender=Masc|Number=Sing	21	obl	_	_
 24-25	המקרין	_	_	_	_	_	_	_	_
 24	ה	ה	SCONJ	SCONJ	_	25	mark	_	_
-25	מקרין	הקרין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	23	acl:relcl	_	_
+25	מקרין	הקרין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ק.ר.נ|VerbForm=Part|Voice=Act	23	acl:relcl	_	_
 26	עידון	עידון	NOUN	NOUN	Gender=Masc|Number=Sing	25	obj	_	_
 27	רב	רב	ADJ	ADJ	Gender=Masc|Number=Sing	26	amod	_	_
 28-29	ויופי	_	_	_	_	_	_	_	_
@@ -5723,7 +5723,7 @@
 31	זקן	זקן	ADJ	ADJ	Gender=Masc|Number=Sing	29	amod	_	_
 32-33	שאמר	_	_	_	_	_	_	_	_
 32	ש	ש	SCONJ	SCONJ	_	33	mark	_	_
-33	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	29	acl:relcl	_	_
+33	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	29	acl:relcl	_	_
 34	למה	למה	ADV	ADV	PronType=Int	33	obj	_	SpaceAfter=No
 35	?	?	PUNCT	PUNCT	HebSource=ConvUncertainHead	1	dep	_	_
 
@@ -5733,10 +5733,10 @@
 2	,	,	PUNCT	PUNCT	_	4	punct	_	_
 3-4	שדוקלם	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	דוקלם	_	VERB	VERB	_	0	root	_	_
+4	דוקלם	_	VERB	VERB	HebBinyan=PUAL|Root=ד.ק.ל.מ	0	root	_	_
 5-6	כששזורים	_	_	_	_	_	_	_	_
 5	כש	כש	SCONJ	SCONJ	Case=Tem	6	mark	_	_
-6	שזורים	שזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	4	advcl	_	_
+6	שזורים	שזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ז.ר.י|VerbForm=Part|Voice=Act	4	advcl	_	_
 7-8	בו	_	_	_	_	_	_	_	_
 7	ב_	ב	ADP	ADP	_	8	case	_	_
 8	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	obl	_	_
@@ -5755,7 +5755,7 @@
 4	"	"	PUNCT	PUNCT	_	5	punct	_	SpaceAfter=No
 5	פרפורמרית	פרפורמרית	NOUN	NOUN	_	0	root	_	SpaceAfter=No
 6	"	"	PUNCT	PUNCT	_	5	punct	_	_
-7	משכנעת	שכנע	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	amod	_	_
+7	משכנעת	שכנע	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ש.כ.נ.ע|VerbForm=Part|Voice=Act	5	amod	_	_
 8-11	שקולה	_	_	_	_	_	_	_	_
 8	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
 9	קול_	קול	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
@@ -5787,7 +5787,7 @@
 3-4	הקליטות	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	קליטות	קליט	ADJ	ADJ	Gender=Fem|Number=Plur	2	amod	_	_
-5	לוו	לווה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	0	root	_	_
+5	לוו	לווה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=ל.ו.י|Tense=Past	0	root	_	_
 6-7	במוסיקה	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	מוסיקה	מוזיקה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
@@ -5806,7 +5806,7 @@
 4-5	שראוי	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
 5	ראוי	ראוי	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	6	aux	_	_
-6	לשים	שם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	acl:relcl	_	_
+6	לשים	שם	VERB	VERB	HebBinyan=PAAL|Root=ש.ו.פ|VerbForm=Inf|Voice=Act	3	acl:relcl	_	_
 7	לב	לב	NOUN	NOUN	Gender=Masc|Number=Sing	6	obj	_	_
 8-11	להתפתחותו	_	_	_	_	_	_	_	SpaceAfter=No
 8	ל	ל	ADP	ADP	_	9	case	_	_
@@ -5833,7 +5833,7 @@
 12	בכורה	בכורה	NOUN	NOUN	Gender=Fem|Number=Sing	3	appos	_	SpaceAfter=No
 13	)	)	PUNCT	PUNCT	_	12	punct	_	_
 14	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
-15	מטפל	טיפל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+15	מטפל	טיפל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ט.פ.ל|VerbForm=Part|Voice=Act	0	root	_	_
 16-17	בצורה	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	צורה	צורה	NOUN	NOUN	Gender=Fem|Number=Sing	15	obl	_	_
@@ -5841,12 +5841,12 @@
 19-21	במשותף	_	_	_	_	_	_	_	SpaceAfter=No
 19	ב	ב	ADP	ADP	_	21	case	_	_
 20	ה_	ה	DET	DET	PronType=Art	21	det:def	_	_
-21	משותף	שותף	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	15	obl	_	_
+21	משותף	שותף	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ש.ת.פ|VerbForm=Part|Voice=Pass	15	obl	_	_
 22	,	,	PUNCT	PUNCT	_	21	punct	_	_
 23-25	בשונה	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	25	case	_	_
 24	ה_	ה	DET	DET	PronType=Art	25	det:def	_	_
-25	שונה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	21	conj	_	_
+25	שונה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ש.נ.י|VerbForm=Part|Voice=Act	21	conj	_	_
 26-29	ובאופייני	_	_	_	_	_	_	_	_
 26	ו	ו	CCONJ	CCONJ	_	29	cc	_	_
 27	ב	ב	ADP	ADP	_	29	case	_	_
@@ -5880,7 +5880,7 @@
 # sent_id = 5919
 # text = הוא מעוניין באמת ובתמים בשאלות הנצחיות, אך ניסוחן כאן, דומני, טרם הגיע למלוא המשקל הרעיוני וההבעתי.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	מעוניין	עונין	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+2	מעוניין	עונין	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ע.נ.י.נ|VerbForm=Part|Voice=Pass	0	root	_	_
 3	באמת	באמת	ADV	ADV	_	2	advmod	_	_
 4-5	ובתמים	_	_	_	_	_	_	_	_
 4	ו	ו	CCONJ	CCONJ	_	3	fixed	_	_
@@ -5903,7 +5903,7 @@
 18	דומני	_	NOUN	NOUN	_	21	obl	_	SpaceAfter=No
 19	,	,	PUNCT	PUNCT	_	21	punct	_	_
 20	טרם	טרם	ADV	ADV	_	21	advmod	_	_
-21	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Tense=Past|Voice=Act	2	dep	_	_
+21	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Root=נ.ג.ע|Tense=Past|Voice=Act	2	dep	_	_
 22-23	למלוא	_	_	_	_	_	_	_	_
 22	ל	ל	ADP	ADP	_	23	case	_	_
 23	מלוא	מלוא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	21	obl	_	_
@@ -5934,7 +5934,7 @@
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	רביעיית	רביעייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	conj	_	_
 10	פסנתר	פסנתר	NOUN	NOUN	Gender=Masc|Number=Sing	9	compound:smixut	_	_
-11	מוגדר	הוגדר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+11	מוגדר	הוגדר	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ג.ד.ר|VerbForm=Part|Voice=Pass	0	root	_	_
 12-13	בצדק	_	_	_	_	_	_	_	_
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	צדק	צדק	NOUN	NOUN	Gender=Masc|Number=Sing	11	obl	_	_
@@ -5977,7 +5977,7 @@
 14-15	שאינה	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
 15	אינה	אינו	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	16	advmod	_	_
-16	מוסיפה	הוסיף	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	8	conj	_	_
+16	מוסיפה	הוסיף	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=י.ס.פ|VerbForm=Part|Voice=Act	8	conj	_	_
 17	הרבה	הרבה	ADV	ADV	_	16	advmod	_	_
 18	על	על	ADP	ADP	_	20	case	_	_
 19-20	שהיה	_	_	_	_	_	_	_	SpaceAfter=No
@@ -5994,7 +5994,7 @@
 4-5	האי	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	אי	אי	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	3	nmod	_	_
-6	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|HebSource=ConvUncertainLabel|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	3	nmod	_	SpaceAfter=No
+6	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|HebSource=ConvUncertainLabel|Number=Sing|Person=1,2,3|Root=ר.א.י|VerbForm=Part|Voice=Mid	3	nmod	_	SpaceAfter=No
 7	"	"	PUNCT	PUNCT	_	3	punct	_	_
 8	(	(	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
 9	ארבעה	ארבעה	NUM	NUM	Gender=Masc|Number=Sing	11	det	_	_
@@ -6024,7 +6024,7 @@
 27	ישראלית	ישראלי	ADJ	ADJ	Gender=Fem|Number=Sing	25	amod	_	_
 28-29	המושכת	_	_	_	_	_	_	_	_
 28	ה	ה	DET	DET	PronType=Art	29	det:def	_	_
-29	מושכת	משך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	25	acl	_	_
+29	מושכת	משך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=מ.ש.כ|VerbForm=Part|Voice=Act	25	acl	_	_
 30-31	ובעלת	_	_	_	_	_	_	_	_
 30	ו	ו	CCONJ	CCONJ	_	31	cc	_	_
 31	בעלת	בעל	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	29	conj	_	_
@@ -6051,7 +6051,7 @@
 # text = כך גם היה ביצועה בידי הנגנים, המנצח טלגם והזמרת וייזל-קפסוטו.
 1	כך	כך	ADV	ADV	_	3	advmod	_	_
 2	גם	גם	ADV	ADV	_	3	advmod	_	_
-3	היה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+3	היה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 4-6	ביצועה	_	_	_	_	_	_	_	_
 4	ביצוע_	ביצוע	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 5	_של_	של	ADP	ADP	_	6	case:gen	_	_
@@ -6077,7 +6077,7 @@
 # sent_id = 5924
 # text = הכל יודעים שיש שלוש מדינות בלטיות: אסטוניה, לטוויה וליטא.
 1	הכל	הכיל	NOUN	NOUN	_	2	nsubj	_	_
-2	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	שיש	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
 4	יש	יש	VERB	VERB	HebExistential=True	2	ccomp	_	_
@@ -6146,7 +6146,7 @@
 5	סיוט	סיוט	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 6-7	למשרטטי	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
-7	משרטטי	שרטט	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	5	nmod	_	_
+7	משרטטי	שרטט	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ש.ר.ט.ט|VerbForm=Part|Voice=Act	5	nmod	_	_
 8	מפות	מפה	NOUN	NOUN	Gender=Fem|Number=Plur	7	compound:smixut	_	SpaceAfter=No
 9	:	:	PUNCT	PUNCT	_	5	punct	_	_
 10	קלינינגרד	קלינינגרד	PROPN	PROPN	_	5	dep	_	_
@@ -6188,14 +6188,14 @@
 15	לעתים	לעתים	ADV	ADV	_	18	advmod	_	_
 16	קרובות	קרוב	ADJ	ADJ	Gender=Fem|Number=Plur	15	fixed	_	_
 17	אינה	אינו	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	18	advmod	_	_
-18	מזוהה	זוהה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	6	acl:relcl	_	_
+18	מזוהה	זוהה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ז.ה.י|VerbForm=Part|Voice=Pass	6	acl:relcl	_	_
 19-20	בשם	_	_	_	_	_	_	_	SpaceAfter=No
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	שם	שם	NOUN	NOUN	Gender=Masc|Number=Sing	18	obl	_	_
 21	,	,	PUNCT	PUNCT	_	6	punct	_	_
 22-23	השוכנת	_	_	_	_	_	_	_	_
 22	ה	ה	SCONJ	SCONJ	_	23	mark	_	_
-23	שוכנת	שכן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
+23	שוכנת	שכן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ש.כ.נ|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
 24	בין	בין	ADP	ADP	_	25	case	_	_
 25	ליטא	ליטא	PROPN	PROPN	_	23	obl	_	_
 26-27	ופולין	_	_	_	_	_	_	_	SpaceAfter=No
@@ -6209,7 +6209,7 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	אזור	אזור	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 3	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	4	cop	_	_
-4	שקוע	_	VERB	VERB	HebBinyan=PAAL|Voice=Act	0	root	_	_
+4	שקוע	_	VERB	VERB	HebBinyan=PAAL|Root=ש.ק.ע|Voice=Act	0	root	_	_
 5-6	בתרדמה	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	תרדמה	תרדמה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
@@ -6221,8 +6221,8 @@
 11	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 12	עכשיו	עכשיו	ADV	ADV	_	14	advmod	_	_
 13	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
-14	מתחיל	התחיל	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	4	conj	_	_
-15	להתעורר	התעורר	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	14	xcomp	_	SpaceAfter=No
+14	מתחיל	התחיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ת.ח.ל|VerbForm=Part	4	conj	_	_
+15	להתעורר	התעורר	VERB	VERB	HebBinyan=HITPAEL|Root=ע.ו.ר|VerbForm=Inf	14	xcomp	_	SpaceAfter=No
 16	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 5930
@@ -6242,13 +6242,13 @@
 # text = איש, כולל אזרחים סובייטים, לא הורשה לנסוע אליו.
 1	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	8	nsubj	_	SpaceAfter=No
 2	,	,	PUNCT	PUNCT	_	4	punct	_	_
-3	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	case	_	_
+3	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	4	case	_	_
 4	אזרחים	אזרח	NOUN	NOUN	Gender=Masc|Number=Plur	1	appos	_	_
 5	סובייטים	סובייטי	ADJ	ADJ	Gender=Masc|Number=Plur	4	amod	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	4	punct	_	_
 7	לא	לא	ADV	ADV	Polarity=Neg	8	advmod	_	_
-8	הורשה	הורשה	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
-9	לנסוע	נסע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	8	xcomp	_	_
+8	הורשה	הורשה	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ר.ש.י|Tense=Past|Voice=Pass	0	root	_	_
+9	לנסוע	נסע	VERB	VERB	HebBinyan=PAAL|Root=נ.ס.ע|VerbForm=Inf|Voice=Act	8	xcomp	_	_
 10-11	אליו	_	_	_	_	_	_	_	SpaceAfter=No
 10	אל_	אל	ADP	ADP	_	11	case	_	_
 11	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	obl	_	_
@@ -6276,7 +6276,7 @@
 14	,	,	PUNCT	PUNCT	_	3	punct	_	_
 15-16	ששכן	_	_	_	_	_	_	_	_
 15	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
-16	שכן	שכן	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	acl:relcl	_	_
+16	שכן	שכן	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.כ.נ|Tense=Past|Voice=Act	3	acl:relcl	_	_
 17-18	בקניגסברג	_	_	_	_	_	_	_	SpaceAfter=No
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	קניגסברג	קניגסברג	PROPN	PROPN	_	16	obl	_	_
@@ -6298,10 +6298,10 @@
 31	ש	ש	SCONJ	SCONJ	_	34	mark	_	_
 32	ב_	ב	ADP	ADP	_	33	case	_	_
 33	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	34	obl	_	_
-34	חי	חי	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	30	acl:relcl	_	_
+34	חי	חי	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.י.י|Tense=Past|Voice=Act	30	acl:relcl	_	_
 35-36	ופעל	_	_	_	_	_	_	_	_
 35	ו	ו	CCONJ	CCONJ	_	36	cc	_	_
-36	פעל	פעל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	34	conj	_	_
+36	פעל	פעל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ע.ל|Tense=Past|Voice=Act	34	conj	_	_
 37	עמנואל	עמנואל	PROPN	PROPN	_	34	nsubj	_	_
 38	קאנט	קאנט	PROPN	PROPN	_	37	flat:name	_	SpaceAfter=No
 39	.	.	PUNCT	PUNCT	_	3	punct	_	_
@@ -6311,7 +6311,7 @@
 1-2	ב1945	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	1945	1945	NUM	NUM	_	3	obl	_	_
-3	שונה	שונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+3	שונה	שונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ש.נ.י|Tense=Past|Voice=Pass	0	root	_	_
 4-6	שמה	_	_	_	_	_	_	_	_
 4	שם_	שם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 5	_של_	של	ADP	ADP	_	6	case:gen	_	_
@@ -6329,7 +6329,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	יוני	יון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	obl	_	_
 3	1989	1989	NUM	NUM	_	2	compound:smixut	_	_
-4	הגיעו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	הגיעו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=נ.ג.ע|Tense=Past|Voice=Act	0	root	_	_
 5	הלמוט	הלמוט	PROPN	PROPN	_	4	nsubj	_	_
 6	קוהל	קוהל	PROPN	PROPN	_	5	flat:name	_	_
 7-8	ומיכאיל	_	_	_	_	_	_	_	_
@@ -6344,7 +6344,7 @@
 13	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
 14	לפיו	לפיו	ADP	ADP	_	15	case	_	_
 15	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	obl	_	_
-16	ישמש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	11	acl:relcl	_	_
+16	ישמש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.מ.ש|Tense=Fut|Voice=Act	11	acl:relcl	_	_
 17	אזור	אזור	NOUN	NOUN	Gender=Masc|Number=Sing	16	nsubj	_	_
 18	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	17	det	_	_
 19-20	כמקום	_	_	_	_	_	_	_	_
@@ -6362,7 +6362,7 @@
 29	גרמנית	גרמנית	PROPN	PROPN	_	28	compound:smixut	_	_
 30-31	שתהווה	_	_	_	_	_	_	_	_
 30	ש	ש	SCONJ	SCONJ	_	32	mark	_	_
-31	תהווה	היווה	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	32	aux	_	_
+31	תהווה	היווה	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ה.ו.י|Tense=Fut|Voice=Act	32	aux	_	_
 32	חלק	חלק	NOUN	NOUN	Gender=Masc|Number=Sing	27	acl:relcl	_	_
 33	אינטגרלי	אינטגרלי	ADJ	ADJ	Gender=Masc|Number=Sing	32	amod	_	_
 34-35	מברית	_	_	_	_	_	_	_	SpaceAfter=No
@@ -6377,13 +6377,13 @@
 # sent_id = 5935
 # text = בון ראתה בהסכם זה אמצעי לבלום את גל המהגרים הגרמנים שהגיעו מברית-המועצות.
 1	בון	בון	PROPN	PROPN	_	2	nsubj	_	_
-2	ראתה	ראה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	ראתה	ראה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ר.א.י|Tense=Past|Voice=Act	0	root	_	_
 3-4	בהסכם	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	הסכם	הסכם	NOUN	NOUN	Gender=Masc|Number=Sing	2	obl	_	_
 5	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	4	det	_	_
 6	אמצעי	אמצעי	NOUN	NOUN	Gender=Masc|Number=Sing	2	obj	_	_
-7	לבלום	בלם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	6	acl	_	_
+7	לבלום	בלם	VERB	VERB	HebBinyan=PAAL|Root=ב.ל.מ|VerbForm=Inf|Voice=Act	6	acl	_	_
 8	את	את	ADP	ADP	Case=Acc	9	case:acc	_	_
 9	גל	גל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obj	_	_
 10-11	המהגרים	_	_	_	_	_	_	_	_
@@ -6394,7 +6394,7 @@
 13	גרמנים	גרמני	ADJ	ADJ	Gender=Masc|Number=Plur	11	amod	_	_
 14-15	שהגיעו	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
-15	הגיעו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	11	acl:relcl	_	_
+15	הגיעו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=נ.ג.ע|Tense=Past|Voice=Act	11	acl:relcl	_	_
 16-17	מברית	_	_	_	_	_	_	_	SpaceAfter=No
 16	מ	מ	ADP	ADP	_	17	case	_	_
 17	ברית	ברית	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	15	obl	_	_
@@ -6417,10 +6417,10 @@
 7	ל	ל	ADP	ADP	_	8	case	_	_
 8	בעיה	בעיה	NOUN	NOUN	Gender=Fem|Number=Sing	6	nmod	_	_
 9	לאומית	לאומי	ADJ	ADJ	Gender=Fem|Number=Sing	8	amod	_	_
-10	טורדת	טרד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	8	amod	_	_
+10	טורדת	טרד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ט.ר.ד|VerbForm=Part|Voice=Act	8	amod	_	_
 11-12	שנמשכה	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-12	נמשכה	נמשך	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	8	acl:relcl	_	_
+12	נמשכה	נמשך	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.ש.כ|Tense=Past|Voice=Mid	8	acl:relcl	_	_
 13	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	12	dep	_	SpaceAfter=No
 14	.	.	PUNCT	PUNCT	_	6	punct	_	_
 
@@ -6441,7 +6441,7 @@
 12-13	שהיתה	_	_	_	_	_	_	_	_
 12	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
 13	היתה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	14	cop	_	_
-14	ידועה	ידע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	8	acl:relcl	_	_
+14	ידועה	ידע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	8	acl:relcl	_	_
 15-17	בשם	_	_	_	_	_	_	_	_
 15	ב	ב	ADP	ADP	_	17	case	_	_
 16	ה_	ה	DET	DET	PronType=Art	17	det:def	_	_
@@ -6469,7 +6469,7 @@
 6-7	לבריה"ם	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	בריה"ם	בריה"ם	PROPN	PROPN	Abbr=Yes	2	nmod	_	_
-8	הכריז	הכריז	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+8	הכריז	הכריז	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=כ.ר.ז|Tense=Past|Voice=Act	0	root	_	_
 9	סטלין	סטלין	PROPN	PROPN	_	8	nsubj	_	_
 10	על	על	ADP	ADP	_	13	case	_	_
 11	כל	כול	DET	DET	Definite=Cons	13	det	_	_
@@ -6478,7 +6478,7 @@
 13	גרמנים	גרמני	NOUN	NOUN	Gender=Masc|Number=Plur	8	obl	_	_
 14-15	שחיו	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
-15	חיו	חי	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Mood=Imp|Number=Plur|Person=2|Voice=Act	13	acl:relcl	_	_
+15	חיו	חי	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Mood=Imp|Number=Plur|Person=2|Root=ח.י.י|Voice=Act	13	acl:relcl	_	_
 16-17	בברית	_	_	_	_	_	_	_	SpaceAfter=No
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	ברית	ברית	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	15	obl	_	_
@@ -6497,14 +6497,14 @@
 # sent_id = 5939
 # text = הוא פירק את הרפובליקה והיגלה את הגרמנים לרפובליקות במרכז-אסיה, בעיקר לקזחסטן.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	פירק	פירק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+2	פירק	פירק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=פ.ר.ק|Tense=Past|Voice=Act	0	root	_	_
 3	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 4-5	הרפובליקה	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	רפובליקה	רפובליקה	NOUN	NOUN	Gender=Fem|Number=Sing	2	obj	_	_
 6-7	והיגלה	_	_	_	_	_	_	_	_
 6	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
-7	היגלה	הגלה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+7	היגלה	הגלה	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ג.ל.י|Tense=Past|Voice=Act	2	conj	_	_
 8	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 9-10	הגרמנים	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -6535,7 +6535,7 @@
 5-6	הרוסים	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	רוסים	רוסי	NOUN	NOUN	Gender=Masc|Number=Plur	7	nsubj	_	_
-7	סיפחו	סיפח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	26	advcl	_	_
+7	סיפחו	סיפח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ס.פ.ח|Tense=Past|Voice=Act	26	advcl	_	_
 8	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 9-10	הקצה	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -6558,7 +6558,7 @@
 23	מזרח	מזרח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	25	nmod	_	SpaceAfter=No
 24	-	-	PUNCT	PUNCT	_	25	punct	_	SpaceAfter=No
 25	פרוסיה	פרוסיה	PROPN	PROPN	_	19	nmod	_	_
-26	גורשה	גורש	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+26	גורשה	גורש	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Root=ג.ר.ש|Tense=Past|Voice=Pass	0	root	_	_
 27-28	האוכלוסייה	_	_	_	_	_	_	_	_
 27	ה	ה	DET	DET	PronType=Art	28	det:def	_	_
 28	אוכלוסייה	אוכלוסייה	NOUN	NOUN	Gender=Fem|Number=Sing	26	nsubj	_	_
@@ -6569,10 +6569,10 @@
 
 # sent_id = 5941
 # text = רבים מתו כאשר עשו דרכם מערבה למחנות עקורים.
-1	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	nsubj	_	_
-2	מתו	מת	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+1	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ר.ב.י|VerbForm=Part|Voice=Act	2	nsubj	_	_
+2	מתו	מת	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=מ.ו.ת|Tense=Past|Voice=Act	0	root	_	_
 3	כאשר	כאשר	SCONJ	SCONJ	_	4	mark	_	_
-4	עשו	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	2	advcl	_	_
+4	עשו	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	2	advcl	_	_
 5-7	דרכם	_	_	_	_	_	_	_	_
 5	דרך_	דרך	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	4	obj	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
@@ -6586,8 +6586,8 @@
 
 # sent_id = 5942
 # text = רבים התיישבו לבסוף במערב-גרמניה ובאוסטריה.
-1	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	nsubj	_	_
-2	התיישבו	התיישב	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
+1	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ר.ב.י|VerbForm=Part|Voice=Act	2	nsubj	_	_
+2	התיישבו	התיישב	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=י.ש.ב|Tense=Past	0	root	_	_
 3	לבסוף	לבסוף	ADV	ADV	_	2	advmod	_	_
 4-5	במערב	_	_	_	_	_	_	_	SpaceAfter=No
 4	ב	ב	ADP	ADP	_	7	case	_	_
@@ -6615,7 +6615,7 @@
 8	ב	ב	ADP	ADP	_	9	case	_	_
 9	1989	1989	NUM	NUM	_	3	nmod	_	_
 10	,	,	PUNCT	PUNCT	_	11	punct	_	_
-11	הקימה	הקים	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+11	הקימה	הקים	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ק.ו.מ|Tense=Past|Voice=Act	0	root	_	_
 12	מוסקווה	מוסקבה	PROPN	PROPN	_	11	nsubj	_	_
 13	ועדה	ועדה	NOUN	NOUN	Gender=Fem|Number=Sing	11	obj	_	_
 14-15	לפתרון	_	_	_	_	_	_	_	_
@@ -6632,7 +6632,7 @@
 1-2	הגרמנים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	גרמנים	גרמני	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
-3	התייחסו	התייחס	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	0	root	_	_
+3	התייחסו	התייחס	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=י.ח.ס|Tense=Past	0	root	_	_
 4-5	לוועדה	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	5	case	_	_
 5	וועדה	ועדה	NOUN	NOUN	Gender=Fem|Number=Sing	3	obl	_	_
@@ -6662,7 +6662,7 @@
 2	שאלה	שאלה	NOUN	NOUN	Gender=Fem|Number=Sing	11	nsubj	_	_
 3-4	שעמדה	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	עמדה	עמד	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	2	acl:relcl	_	_
+4	עמדה	עמד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.מ.ד|Tense=Past	2	acl:relcl	_	_
 5-8	בפניהם	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	פנים_	פנים	NOUN	NOUN	Definite=Def|Gender=Fem,Masc|Number=Plur	4	obl	_	_
@@ -6670,7 +6670,7 @@
 8	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	6	nmod:poss	_	_
 9	היתה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	11	cop	_	_
 10	היכן	היכן	ADV	ADV	PronType=Int	11	advmod	_	_
-11	למקם	מיקם	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	0	root	_	_
+11	למקם	מיקם	VERB	VERB	HebBinyan=PIEL|Root=מ.ק.מ|VerbForm=Inf|Voice=Act	0	root	_	_
 12-13	אותה	_	_	_	_	_	_	_	SpaceAfter=No
 12	את_	את_	ADP	ADP	Case=Acc	13	case:acc	_	_
 13	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	11	obj	_	_
@@ -6684,7 +6684,7 @@
 3-4	ה60	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	60	60	NUM	NUM	_	2	compound:smixut	_	_
-5	ביטלה	ביטל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	ביטלה	ביטל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ב.ט.ל|Tense=Past|Voice=Act	0	root	_	_
 6	למעשה	למעשה	ADV	ADV	_	5	advmod	_	_
 7-8	המפלגה	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -6700,7 +6700,7 @@
 15	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 16	ביטול	ביטול	NOUN	NOUN	Gender=Masc|Number=Sing	18	nsubj	_	_
 17	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	16	det	_	_
-18	הצמיח	הצמיח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	conj	_	_
+18	הצמיח	הצמיח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.מ.ח|Tense=Past|Voice=Act	5	conj	_	_
 19	דרישות	דרישה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	18	obj	_	_
 20	גרמנים	גרמני	NOUN	NOUN	Gender=Masc|Number=Plur	19	compound:smixut	_	_
 21-22	להקמת	_	_	_	_	_	_	_	_
@@ -6732,14 +6732,14 @@
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	קזחסטן	קזחסטן	PROPN	PROPN	_	5	nmod	_	_
 9	,	,	PUNCT	PUNCT	_	10	punct	_	_
-10	גילה	גילה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+10	גילה	גילה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ג.ל.י|Tense=Past|Voice=Act	0	root	_	_
 11-12	ב8891	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	1988	1988	NUM	NUM	_	10	obl	_	_
 13	כי	כי	SCONJ	SCONJ	_	16	mark	_	_
 14	דרישה	דרישה	NOUN	NOUN	Gender=Fem|Number=Sing	16	nsubj	_	_
 15	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	14	det	_	_
-16	קיבלה	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	ccomp	_	_
+16	קיבלה	קיבל	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Past|Voice=Act	10	ccomp	_	_
 17	תמיכה	תמיכה	NOUN	NOUN	Gender=Fem|Number=Sing	16	obj	_	_
 18-21	שבשתיקה	_	_	_	_	_	_	_	_
 18	ש	ש	SCONJ	SCONJ	_	21	case	_	_
@@ -6753,14 +6753,14 @@
 25	,	,	PUNCT	PUNCT	_	23	punct	_	_
 26-27	שהוציא	_	_	_	_	_	_	_	_
 26	ש	ש	SCONJ	SCONJ	_	27	mark	_	_
-27	הוציא	הוציא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	23	acl:relcl	_	_
+27	הוציא	הוציא	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.צ.א|Tense=Past|Voice=Act	23	acl:relcl	_	_
 28-29	ב2891	_	_	_	_	_	_	_	_
 28	ב	ב	ADP	ADP	_	29	case	_	_
 29	1982	1982	NUM	NUM	_	27	obl	_	_
 30	צו	צו	NOUN	NOUN	Gender=Masc|Number=Sing	27	obj	_	_
 31-32	המאשר	_	_	_	_	_	_	_	_
 31	ה	ה	SCONJ	SCONJ	_	32	mark	_	_
-32	מאשר	אישר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	30	acl:relcl	_	_
+32	מאשר	אישר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=א.ש.ר|VerbForm=Part|Voice=Act	30	acl:relcl	_	_
 33	את	את	ADP	ADP	Case=Acc	34	case:acc	_	_
 34-36	שובם	_	_	_	_	_	_	_	_
 34	__	_	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	32	obj	_	_
@@ -6784,7 +6784,7 @@
 2-3	הרוסים	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	רוסים	רוסי	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	_
-4	מתנגדים	התנגד	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	0	root	_	_
+4	מתנגדים	התנגד	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=נ.ג.ד|VerbForm=Part	0	root	_	_
 5	נחרצות	נחרצות	ADV	ADV	_	4	advmod	_	_
 6-7	למתן	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
@@ -6815,7 +6815,7 @@
 9	מ	מ	ADP	ADP	HebSource=ConvUncertainHead	8	dep	_	_
 10	רוסיה	רוסיה	PROPN	PROPN	HebSource=ConvUncertainHead	8	dep	_	_
 11	,	,	PUNCT	PUNCT	_	12	punct	_	_
-12	שולב	שולב	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+12	שולב	שולב	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ש.ל.ב|Tense=Past|Voice=Pass	0	root	_	_
 13-15	ברפובליקה	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	15	case	_	_
 14	ה_	ה	DET	DET	PronType=Art	15	det:def	_	_
@@ -6834,12 +6834,12 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	קרמלין	קרמלין	PROPN	PROPN	_	4	dep	_	_
 3	גם	גם	ADV	ADV	_	4	advmod	_	_
-4	השתעשע	השתעשע	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+4	השתעשע	השתעשע	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ש.ע.ש.ע|Tense=Past	0	root	_	_
 5-7	ברעיון	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	רעיון	רעיון	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
-8	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	7	acl	_	_
+8	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|Root=ק.ו.מ|VerbForm=Inf|Voice=Act	7	acl	_	_
 9	רפובליקה	רפובליקה	NOUN	NOUN	Gender=Fem|Number=Sing	8	obj	_	_
 10	גרמנית	גרמני	ADJ	ADJ	Gender=Fem|Number=Sing	9	amod	_	_
 11-13	בפינה	_	_	_	_	_	_	_	_
@@ -6864,7 +6864,7 @@
 4	,	,	PUNCT	PUNCT	_	3	punct	_	_
 5-6	בדומה	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
-6	דומה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	dep	_	_
+6	דומה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ד.מ.י|VerbForm=Part|Voice=Act	3	dep	_	_
 7-9	לרוסים	_	_	_	_	_	_	_	SpaceAfter=No
 7	ל	ל	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -6874,7 +6874,7 @@
 12	מוכנים	מוכן	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbType=Mod	0	root	_	_
 13-14	שיקרעו	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
-14	יקרעו	קרע	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut	12	ccomp	_	_
+14	יקרעו	קרע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ק.ר.ע|Tense=Fut	12	ccomp	_	_
 15	חלקים	חלק	NOUN	NOUN	Gender=Masc|Number=Plur	14	obj	_	_
 16-19	משטחם	_	_	_	_	_	_	_	SpaceAfter=No
 16	מ	מ	ADP	ADP	_	15	dep	_	_
@@ -6885,7 +6885,7 @@
 21-22	והם	_	_	_	_	_	_	_	_
 21	ו	ו	CCONJ	CCONJ	_	23	cc	_	_
 22	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	23	nsubj	_	_
-23	יצאו	יצא	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	12	conj	_	_
+23	יצאו	יצא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.צ.א|Tense=Past	12	conj	_	_
 24-25	להפגנות	_	_	_	_	_	_	_	_
 24	ל	ל	ADP	ADP	_	25	case	_	_
 25	הפגנות	הפגנה	NOUN	NOUN	Gender=Fem|Number=Plur	23	obl	_	_
@@ -6898,11 +6898,11 @@
 # sent_id = 5952
 # text = כך התקבלה ההחלטה למקם את הרפובליקה הגרמנית החדשה בקלינינגרד אובלסט, לשעבר מזרח-פרוסיה הגרמנית.
 1	כך	כך	ADV	ADV	_	2	advmod	_	_
-2	התקבלה	התקבל	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+2	התקבלה	התקבל	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Past	0	root	_	_
 3-4	ההחלטה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	החלטה	החלטה	NOUN	NOUN	Gender=Fem|Number=Sing	2	nsubj	_	_
-5	למקם	מיקם	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	4	acl	_	_
+5	למקם	מיקם	VERB	VERB	HebBinyan=PIEL|Root=מ.ק.מ|VerbForm=Inf|Voice=Act	4	acl	_	_
 6	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 7-8	הרפובליקה	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -6950,7 +6950,7 @@
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	מועצות	מועצה	NOUN	NOUN	Gender=Fem|HebSource=ConvUncertainLabel|Number=Plur	15	nmod	_	_
 19	,	,	PUNCT	PUNCT	_	20	punct	_	_
-20	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+20	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 21-22	בראיון	_	_	_	_	_	_	_	_
 21	ב	ב	ADP	ADP	_	22	case	_	_
 22	ראיון	ראיון	NOUN	NOUN	Gender=Masc|Number=Sing	20	obl	_	_
@@ -6987,12 +6987,12 @@
 50	אפשר	אפשר	AUX	AUX	VerbType=Mod	53	aux	_	_
 51	יהיה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	50	cop	_	_
 52	אז	אז	ADV	ADV	_	50	advmod	_	_
-53	להאשים	האשים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	44	conj	_	_
+53	להאשים	האשים	VERB	VERB	HebBinyan=HIFIL|Root=א.ש.מ|VerbForm=Inf|Voice=Act	44	conj	_	_
 54	גרמנים	גרמני	NOUN	NOUN	Gender=Masc|Number=Plur	53	obj	_	_
 55-56	שהם	_	_	_	_	_	_	_	_
 55	ש	ש	SCONJ	SCONJ	_	57	mark	_	_
 56	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	57	nsubj	_	_
-57	לוקחים	לקח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	53	advcl	_	_
+57	לוקחים	לקח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ל.ק.ח|VerbForm=Part|Voice=Act	53	advcl	_	_
 58	אדמות	אדמה	NOUN	NOUN	Gender=Fem|Number=Plur	57	obj	_	_
 59	(	(	PUNCT	PUNCT	_	61	punct	_	SpaceAfter=No
 60-61	מאחרים	_	_	_	_	_	_	_	SpaceAfter=No
@@ -7009,11 +7009,11 @@
 3-4	האחרון	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	אחרון	אחרון	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-5	צעדה	צעד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	צעדה	צעד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=צ.ע.ד|Tense=Past|Voice=Act	0	root	_	_
 6-7	ההצעה	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	הצעה	הצעה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
-8	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	7	acl	_	_
+8	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|Root=ק.ו.מ|VerbForm=Inf|Voice=Act	7	acl	_	_
 9	מולדת	מולדת	NOUN	NOUN	Gender=Fem|Number=Sing	8	obj	_	_
 10-12	למיעוט	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	12	case	_	_
@@ -7046,7 +7046,7 @@
 32	ליטרטורה	ליטרטורה	PROPN	PROPN	_	28	appos	_	_
 33	גזאטי	גזאטי	PROPN	PROPN	_	32	flat:name	_	SpaceAfter=No
 34	"	"	PUNCT	PUNCT	_	32	punct	_	_
-35	ערך	ערך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	advcl	_	_
+35	ערך	ערך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ר.כ|Tense=Past|Voice=Act	5	advcl	_	_
 36	משאל	משאל	NOUN	NOUN	Gender=Masc|Number=Sing	35	obj	_	_
 37-39	בנושא	_	_	_	_	_	_	_	_
 37	ב	ב	ADP	ADP	_	39	case	_	_
@@ -7069,10 +7069,10 @@
 2	מ	מ	ADP	ADP	_	1	fixed	_	_
 3	80	80	NUM	NUM	_	4	nummod	_	_
 4	%	O	NOUN	NOUN	Gender=Masc|Number=Plur,Sing	5	dep	_	_
-5	אמרו	אמר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+5	אמרו	אמר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	0	root	_	_
 6	כי	כי	SCONJ	SCONJ	_	7	mark	_	_
-7	יעדיפו	העדיף	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Fut|Voice=Act	5	ccomp	_	_
-8	לעבור	עבר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	xcomp	_	_
+7	יעדיפו	העדיף	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ע.ד.פ|Tense=Fut|Voice=Act	5	ccomp	_	_
+8	לעבור	עבר	VERB	VERB	HebBinyan=PAAL|Root=ע.ב.ר|VerbForm=Inf|Voice=Act	7	xcomp	_	_
 9-10	למזרח	_	_	_	_	_	_	_	SpaceAfter=No
 9	ל	ל	ADP	ADP	_	12	case	_	_
 10	מזרח	מזרח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	nmod	_	_
@@ -7082,7 +7082,7 @@
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	צפונית	צפוני	ADJ	ADJ	Gender=Fem|Number=Sing	12	amod	_	_
 15	מאשר	מאשר	CCONJ	CCONJ	_	16	case	_	_
-16	להגר	היגר	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	7	advcl	_	_
+16	להגר	היגר	VERB	VERB	HebBinyan=PIEL|Root=ה.ג.ר|VerbForm=Inf|Voice=Act	7	advcl	_	_
 17-18	למערב	_	_	_	_	_	_	_	SpaceAfter=No
 17	ל	ל	ADP	ADP	_	20	case	_	_
 18	מערב	מערב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	20	nmod	_	_
@@ -7098,18 +7098,18 @@
 4-5	מכן	_	_	_	_	_	_	_	_
 4	מ	מן	ADP	ADP	_	5	case	_	_
 5	כן	_	ADV	ADV	_	2	advmod	_	_
-6	הודיעה	הודיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	הודיעה	הודיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ד.ע|Tense=Past|Voice=Act	0	root	_	_
 7	מוסקווה	מוסקבה	PROPN	PROPN	_	6	nsubj	_	_
 8	על	על	ADP	ADP	_	9	case	_	_
 9	תוכניות	תוכנית	NOUN	NOUN	Gender=Fem|Number=Plur	6	obl	_	_
-10	למשוך	משך	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	9	acl	_	_
+10	למשוך	משך	VERB	VERB	HebBinyan=PAAL|Root=מ.ש.כ|VerbForm=Inf|Voice=Act	9	acl	_	_
 11	גרמנים	גרמני	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Plur	10	dep	_	_
 12-13	מרפובליקות	_	_	_	_	_	_	_	_
 12	מ	מ	ADP	ADP	_	13	case	_	_
 13	רפובליקות	רפובליקה	NOUN	NOUN	Gender=Fem|Number=Plur	11	nmod	_	_
 14	סובייטיות	סובייטי	ADJ	ADJ	Gender=Fem|Number=Plur	13	amod	_	_
 15	שונות	שונה	ADJ	ADJ	Gender=Fem|Number=Plur	13	amod	_	_
-16	להתיישב	התיישב	VERB	VERB	HebBinyan=HITPAEL|HebSource=ConvUncertainHead|VerbForm=Inf	10	dep	_	_
+16	להתיישב	התיישב	VERB	VERB	HebBinyan=HITPAEL|HebSource=ConvUncertainHead|Root=י.ש.ב|VerbForm=Inf	10	dep	_	_
 17-18	בקלינינגרד	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	קלינינגרד	קלינינגרד	PROPN	PROPN	_	16	obl	_	_
@@ -7117,8 +7117,8 @@
 20	,	,	PUNCT	PUNCT	_	6	punct	_	_
 21-22	והציעה	_	_	_	_	_	_	_	_
 21	ו	ו	CCONJ	CCONJ	_	22	cc	_	_
-22	הציעה	הציע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	conj	_	_
-23	לשנות	שינה	VERB	VERB	VerbForm=Inf	22	xcomp	_	_
+22	הציעה	הציע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.צ.ע|Tense=Past|Voice=Act	6	conj	_	_
+23	לשנות	שינה	VERB	VERB	HebBinyan=PIEL|Root=ש.נ.י|VerbForm=Inf	22	xcomp	_	_
 24	את	את	ADP	ADP	Case=Acc	25	case:acc	_	_
 25	שם	שם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	23	obj	_	_
 26-27	הבירה	_	_	_	_	_	_	_	_
@@ -7139,7 +7139,7 @@
 # text = צעד נוסף נעשה ב11 באוגוסט, כאשר הוגו ורמבכר, חבר בכיר בווידרגבורט, אמר בראיון ל"סובייטסקאיה רוסיה", שאזור קניגסברג חייב להפוך לאזור אוטונומי לגרמנים בברית-המועצות.
 1	צעד	צעד	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
 2	נוסף	נוסף	ADJ	ADJ	Gender=Masc|Number=Sing	1	amod	_	_
-3	נעשה	נעשה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+3	נעשה	נעשה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Mid	0	root	_	_
 4-5	ב11	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	11	11	NUM	NUM	_	3	obl	_	_
@@ -7157,7 +7157,7 @@
 15	ב	ב	ADP	ADP	_	16	case	_	_
 16	ווידרגבורט	ווידרגבורט	PROPN	PROPN	_	13	nmod	_	_
 17	,	,	PUNCT	PUNCT	_	18	punct	_	_
-18	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	advcl	_	_
+18	אמר	אמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=א.מ.ר|Tense=Past|Voice=Act	3	advcl	_	_
 19-20	בראיון	_	_	_	_	_	_	_	_
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	ראיון	ראיון	NOUN	NOUN	Gender=Masc|Number=Sing	18	obl	_	_
@@ -7173,7 +7173,7 @@
 28	אזור	אזור	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	30	nsubj	_	_
 29	קניגסברג	קניגסברג	PROPN	PROPN	_	28	compound:smixut	_	_
 30	חייב	חייב	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	31	aux	_	_
-31	להפוך	הפך	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	18	ccomp	_	_
+31	להפוך	הפך	VERB	VERB	HebBinyan=PAAL|Root=ה.פ.כ|VerbForm=Inf|Voice=Act	18	ccomp	_	_
 32-33	לאזור	_	_	_	_	_	_	_	_
 32	ל	ל	ADP	ADP	_	33	case	_	_
 33	אזור	אזור	NOUN	NOUN	Gender=Masc|Number=Sing	31	obl	_	_
@@ -7195,14 +7195,14 @@
 # text = הוא גם ציין שיש לוותר על תוכניות ליישב את הגרמנים שוב באזור הוולגה.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	גם	גם	ADV	ADV	_	3	advmod	_	_
-3	ציין	ציין	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	ציין	ציין	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=צ.י.נ|Tense=Past|Voice=Act	0	root	_	_
 4-5	שיש	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
 5	יש	יש	AUX	AUX	VerbType=Mod	6	aux	_	_
-6	לוותר	ויתר	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	3	ccomp	_	_
+6	לוותר	ויתר	VERB	VERB	HebBinyan=PIEL|Root=ו.ת.ר|VerbForm=Inf|Voice=Act	3	ccomp	_	_
 7	על	על	ADP	ADP	_	8	case	_	_
 8	תוכניות	תוכנית	NOUN	NOUN	Gender=Fem|Number=Plur	6	obl	_	_
-9	ליישב	יישב	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	8	acl	_	_
+9	ליישב	יישב	VERB	VERB	HebBinyan=PIEL|Root=י.ש.ב|VerbForm=Inf|Voice=Act	8	acl	_	_
 10	את	את	ADP	ADP	Case=Acc	12	case:acc	_	_
 11-12	הגרמנים	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
@@ -7219,7 +7219,7 @@
 # sent_id = 5959
 # text = בינתיים מעודד הממשל הנוכחי בקלניניגרד תיירות גרמנית וגם רוצה כי יכריזו שהאובלסט הוא "אזור כלכלי מיוחד".
 1	בינתיים	בינתיים	ADV	ADV	_	2	advmod	_	_
-2	מעודד	עודד	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	מעודד	עודד	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ע.ד.ד|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	הממשל	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	ממשל	ממשל	NOUN	NOUN	Gender=Masc|Number=Sing	2	nsubj	_	_
@@ -7234,9 +7234,9 @@
 11-12	וגם	_	_	_	_	_	_	_	_
 11	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
 12	גם	גם	ADV	ADV	_	13	advmod	_	_
-13	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	conj	_	_
+13	רוצה	רצה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.צ.י|VerbForm=Part|Voice=Act	2	conj	_	_
 14	כי	כי	SCONJ	SCONJ	_	15	mark	_	_
-15	יכריזו	הכריז	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Fut|Voice=Act	13	ccomp	_	_
+15	יכריזו	הכריז	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=כ.ר.ז|Tense=Fut|Voice=Act	13	ccomp	_	_
 16-18	שהאובלסט	_	_	_	_	_	_	_	_
 16	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
@@ -7255,7 +7255,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	הצעה	הצעה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
 3	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	det	_	_
-4	דן	דן	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+4	דן	דן	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ד.ו.נ|VerbForm=Part|Voice=Act	0	root	_	_
 5	כעת	כעת	ADV	ADV	_	4	advmod	_	_
 6-7	הקרמלין	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -7275,7 +7275,7 @@
 7-8	הרביעית	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	רביעית	רביעית	NUM	NUM	Gender=Fem|Number=Sing	4	amod	_	_
-9	מתכננת	תכנן	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	19	advcl	_	_
+9	מתכננת	תכנן	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ת.כ.נ.נ|VerbForm=Part|Voice=Act	19	advcl	_	_
 10	להיות	היה	AUX	AUX	Polarity=Pos|VerbForm=Inf|VerbType=Cop	9	xcomp	_	_
 11	רק	רק	ADV	ADV	_	12	advmod	_	_
 12-13	לרפובליקה	_	_	_	_	_	_	_	_
@@ -7288,15 +7288,15 @@
 17	ל	ל	ADP	ADP	_	18	case	_	_
 18	ריבונות	ריבונות	NOUN	NOUN	Gender=Fem|Number=Sing	16	nmod	_	_
 19	יכולה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	20	aux	_	_
-20	לעלות	עלה	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+20	לעלות	עלה	VERB	VERB	HebBinyan=PAAL|Root=ע.ל.י|VerbForm=Inf|Voice=Act	0	root	_	_
 21	על	על	ADP	ADP	_	23	case	_	_
 22-23	הפרק	_	_	_	_	_	_	_	_
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
 23	פרק	פרק	NOUN	NOUN	Gender=Masc|Number=Sing	20	obl	_	_
 24	אם	אם	SCONJ	SCONJ	_	25	mark	_	_
-25	תצליח	הצליח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	19	advcl	_	_
+25	תצליח	הצליח	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ל.ח|Tense=Fut|Voice=Act	19	advcl	_	_
 26	ליטא	ליטא	PROPN	PROPN	_	25	nsubj	_	_
-27	להתנתק	התנתק	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	25	xcomp	_	_
+27	להתנתק	התנתק	VERB	VERB	HebBinyan=HITPAEL|Root=נ.ת.ק|VerbForm=Inf	25	xcomp	_	_
 28-29	מברית	_	_	_	_	_	_	_	SpaceAfter=No
 28	מ	מ	ADP	ADP	_	29	case	_	_
 29	ברית	ברית	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	27	obl	_	_
@@ -7314,7 +7314,7 @@
 4	עצמאית	עצמאי	ADJ	ADJ	Gender=Fem|Number=Sing	7	advcl	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	7	punct	_	_
 6	לא	לא	ADV	ADV	Polarity=Neg	7	advmod	_	_
-7	יהיה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
+7	יהיה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	0	root	_	_
 8-10	לרפובליקה	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	10	case	_	_
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -7344,7 +7344,7 @@
 # text = בעיית ליטא עוררה ירושה נוספת מימי סטלין, הדורשת טיפול.
 1	בעיית	בעיה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	nsubj	_	_
 2	ליטא	ליטא	PROPN	PROPN	_	1	compound:smixut	_	_
-3	עוררה	עורר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	עוררה	עורר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ע.ו.ר|Tense=Past|Voice=Act	0	root	_	_
 4	ירושה	ירושה	NOUN	NOUN	Gender=Fem|Number=Sing	3	obj	_	_
 5	נוספת	נוסף	ADJ	ADJ	Gender=Fem|Number=Sing	4	amod	_	_
 6-7	מימי	_	_	_	_	_	_	_	_
@@ -7354,7 +7354,7 @@
 9	,	,	PUNCT	PUNCT	_	4	punct	_	_
 10-11	הדורשת	_	_	_	_	_	_	_	_
 10	ה	ה	SCONJ	SCONJ	_	11	mark	_	_
-11	דורשת	דרש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	acl:relcl	_	_
+11	דורשת	דרש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ד.ר.ש|VerbForm=Part|Voice=Act	4	acl:relcl	_	_
 12	טיפול	טיפול	NOUN	NOUN	Gender=Masc|Number=Sing	11	obj	_	SpaceAfter=No
 13	.	.	PUNCT	PUNCT	_	3	punct	_	_
 
@@ -7363,9 +7363,9 @@
 1-2	ב5491	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	1945	1945	NUM	NUM	_	3	obl	_	_
-3	ניסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	ניסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.ס.י|Tense=Past|Voice=Act	0	root	_	_
 4	סטלין	סטלין	PROPN	PROPN	_	3	nsubj	_	_
-5	לפייס	פייס	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	3	xcomp	_	_
+5	לפייס	פייס	VERB	VERB	HebBinyan=PIEL|Root=פ.י.ס|VerbForm=Inf|Voice=Act	3	xcomp	_	_
 6	את	את	ADP	ADP	Case=Acc	8	case:acc	_	_
 7-8	הליטאים	_	_	_	_	_	_	_	SpaceAfter=No
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -7373,7 +7373,7 @@
 9	,	,	PUNCT	PUNCT	_	8	punct	_	_
 10-11	שזעמו	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	זעמו	זעם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	8	acl:relcl	_	_
+11	זעמו	זעם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ז.ע.מ|Tense=Past|Voice=Act	8	acl:relcl	_	_
 12-13	בצדק	_	_	_	_	_	_	_	_
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	צדק	צדק	NOUN	NOUN	Gender=Masc|Number=Sing	11	obl	_	_
@@ -7404,7 +7404,7 @@
 # sent_id = 5965
 # text = הוא ניתק את הפיסה הצפונית של מזרח-פרוסיה הידועה בשם ממלנד, המשתרעת על כ1800 קילומטרים רבועים, ואיחד אותה עם הרפובליקה הסוציאליסטית הסובייטית הליטאית.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	ניתק	ניתק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+2	ניתק	ניתק	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=נ.ת.ק|Tense=Past|Voice=Mid	0	root	_	_
 3	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 4-5	הפיסה	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
@@ -7418,7 +7418,7 @@
 11	פרוסיה	פרוסיה	PROPN	PROPN	_	5	nmod	_	_
 12-13	הידועה	_	_	_	_	_	_	_	_
 12	ה	ה	SCONJ	SCONJ	_	13	mark	_	_
-13	ידועה	ידע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	11	acl	_	_
+13	ידועה	ידע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	11	acl	_	_
 14-16	בשם	_	_	_	_	_	_	_	_
 14	ב	ב	ADP	ADP	_	16	case	_	_
 15	ה_	ה	DET	DET	PronType=Art	16	det:def	_	_
@@ -7427,7 +7427,7 @@
 18	,	,	PUNCT	PUNCT	HebSource=ConvUncertainHead	13	dep	_	_
 19-20	המשתרעת	_	_	_	_	_	_	_	_
 19	ה	ה	SCONJ	SCONJ	_	20	mark	_	_
-20	משתרעת	השתרע	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part	13	dep	_	_
+20	משתרעת	השתרע	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|Root=שׂ.ר.ע|VerbForm=Part	13	dep	_	_
 21	על	על	ADP	ADP	_	24	case	_	_
 22-23	כ1800	_	_	_	_	_	_	_	_
 22	כ	כ	ADP	ADP	_	24	det	_	_
@@ -7437,7 +7437,7 @@
 26	,	,	PUNCT	PUNCT	_	2	punct	_	_
 27-28	ואיחד	_	_	_	_	_	_	_	_
 27	ו	ו	CCONJ	CCONJ	_	28	cc	_	_
-28	איחד	איחד	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+28	איחד	איחד	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=א.ח.ד|Tense=Past|Voice=Act	2	conj	_	_
 29-30	אותה	_	_	_	_	_	_	_	_
 29	את_	את_	ADP	ADP	Case=Acc	30	case:acc	_	_
 30	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	28	obj	_	_
@@ -7464,7 +7464,7 @@
 3	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
 4	אותו_	אותו	ADP	ADP	Definite=Def	5	case:acc	_	_
 5	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	6	obj	_	_
-6	הקימו	הקים	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Plur|Person=3|Tense=Past|Voice=Act	1	dep	_	_
+6	הקימו	הקים	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|HebSource=ConvUncertainHead|Number=Plur|Person=3|Root=ק.ו.מ|Tense=Past|Voice=Act	1	dep	_	_
 7-9	במאה	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -7513,7 +7513,7 @@
 1-2	ב3291	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	1923	1923	NUM	NUM	_	3	obl	_	_
-3	פלשה	פלש	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
+3	פלשה	פלש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ל.ש|Tense=Past	0	root	_	_
 4	ליטא	ליטא	PROPN	PROPN	_	3	nsubj	_	_
 5-6	העצמאית	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -7526,7 +7526,7 @@
 10	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
 11	היתה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	13	cop	_	_
 12	אז	אז	ADV	ADV	_	13	advmod	_	_
-13	נתונה	נתן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	8	acl:relcl	_	_
+13	נתונה	נתן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ת.נ|VerbForm=Part|Voice=Act	8	acl:relcl	_	_
 14-15	לחסות	_	_	_	_	_	_	_	_
 14	ל	ל	ADP	ADP	_	15	case	_	_
 15	חסות	חסות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	13	obl	_	_
@@ -7549,10 +7549,10 @@
 29-30	הלאומים	_	_	_	_	_	_	_	_
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	לאומים	לאום	NOUN	NOUN	Gender=Masc|Number=Plur	28	compound:smixut	_	_
-31	להניע	הניע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	23	acl	_	_
+31	להניע	הניע	VERB	VERB	HebBinyan=HIFIL|Root=נ.ו.ע|VerbForm=Inf|Voice=Act	23	acl	_	_
 32	את	את	ADP	ADP	Case=Acc	33	case:acc	_	_
 33	פולין	פולין	PROPN	PROPN	HebSource=ConvUncertainHead	31	dep	_	_
-34	לסגת	נסוג	VERB	VERB	HebBinyan=NIFAL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Mid	31	dep	_	_
+34	לסגת	נסוג	VERB	VERB	HebBinyan=NIFAL|HebSource=ConvUncertainHead|Root=ס.ו.ג|VerbForm=Inf|Voice=Mid	31	dep	_	_
 35-36	מווילניוס	_	_	_	_	_	_	_	SpaceAfter=No
 35	מ	מ	ADP	ADP	_	36	case	_	_
 36	ווילניוס	ווילניוס	PROPN	PROPN	_	34	obl	_	_
@@ -7561,7 +7561,7 @@
 38	ש	ש	SCONJ	SCONJ	_	41	mark	_	_
 39	אל_	אל	ADP	ADP	_	40	case	_	_
 40	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	41	obl	_	_
-41	פלשה	פלש	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	36	acl:relcl	_	_
+41	פלשה	פלש	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ל.ש|Tense=Past	36	acl:relcl	_	_
 42-43	ב1920	_	_	_	_	_	_	_	SpaceAfter=No
 42	ב	ב	ADP	ADP	_	43	case	_	_
 43	1920	1920	NUM	NUM	_	41	obl	_	_
@@ -7577,7 +7577,7 @@
 6	,	,	PUNCT	PUNCT	_	8	punct	_	_
 7-8	בדומה	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
-8	דומה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	parataxis	_	_
+8	דומה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ד.מ.י|VerbForm=Part|Voice=Act	5	parataxis	_	_
 9-12	לשכנתה	_	_	_	_	_	_	_	_
 9	ל	ל	ADP	ADP	_	10	case	_	_
 10	שכן_	שכן	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	8	obl	_	_
@@ -7587,7 +7587,7 @@
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	ליטאית	ליטאי	ADJ	ADJ	Gender=Fem|Number=Sing	10	amod	_	_
 15	,	,	PUNCT	PUNCT	_	8	punct	_	_
-16	להיקלע	נקלע	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	0	root	_	_
+16	להיקלע	נקלע	VERB	VERB	HebBinyan=NIFAL|Root=ק.ל.ע|VerbForm=Inf|Voice=Mid	0	root	_	_
 17-18	לבעיות	_	_	_	_	_	_	_	_
 17	ל	ל	ADP	ADP	_	18	case	_	_
 18	בעיות	בעיה	NOUN	NOUN	Gender=Fem|Number=Plur	16	obl	_	_
@@ -7601,7 +7601,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	קיץ	קיץ	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
 3	1989	1989	NUM	NUM	_	2	compound:smixut	_	_
-4	פירסמו	פרסם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	פירסמו	פרסם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=פ.ר.ס.מ|Tense=Past|Voice=Act	0	root	_	_
 5	כמה	כמה	DET	DET	Definite=Cons	6	det	_	_
 6	היסטוריונים	היסטוריון	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	SpaceAfter=No
 7	,	,	PUNCT	PUNCT	_	4	punct	_	_
@@ -7610,7 +7610,7 @@
 9	כנס	כנס	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 10-11	שהתקיים	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	התקיים	התקיים	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	9	acl:relcl	_	_
+11	התקיים	התקיים	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ק.ו.מ|Tense=Past	9	acl:relcl	_	_
 12-13	בחסות	_	_	_	_	_	_	_	_
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	חסות	חסות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	11	obl	_	_
@@ -7624,7 +7624,7 @@
 19	תעודות	תעודה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obj	_	_
 20-21	המצדיקות	_	_	_	_	_	_	_	_
 20	ה	ה	SCONJ	SCONJ	_	21	mark	_	_
-21	מצדיקות	הצדיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	19	acl:relcl	_	_
+21	מצדיקות	הצדיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=צ.ד.ק|VerbForm=Part|Voice=Act	19	acl:relcl	_	_
 22	צעד	צעד	NOUN	NOUN	Gender=Masc|Number=Sing	21	obj	_	_
 23-25	כזה	_	_	_	_	_	_	_	SpaceAfter=No
 23	כ	כ	ADP	ADP	_	25	case	_	_
@@ -7638,11 +7638,11 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	היסטוריונים	היסטוריון	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	_
 3	גם	גם	ADV	ADV	_	4	advmod	_	_
-4	קראו	קרא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	קראו	קרא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ק.ר.א|Tense=Past|Voice=Act	0	root	_	_
 5	תעודות	תעודה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obj	_	_
 6-7	שהגנו	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
-7	הגנו	הגן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	5	acl:relcl	_	_
+7	הגנו	הגן	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ג.נ.נ|Tense=Past|Voice=Act	5	acl:relcl	_	_
 8	על	על	ADP	ADP	_	9	case	_	_
 9	סיפוח	סיפוח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obl	_	_
 10	מזרח	מזרח	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
@@ -7660,13 +7660,13 @@
 # text = אם אכן תוקם רפובליקה אוטונומית גרמנית שתהפוך מאוחר יותר לריבונית, יהיה העולם עד לדוגמה מעניינת של היסטוריה החוזרת על עצמה.
 1	אם	אם	SCONJ	SCONJ	_	3	mark	_	_
 2	אכן	אכן	ADV	ADV	_	3	advmod	_	_
-3	תוקם	הוקם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	17	advcl	_	_
+3	תוקם	הוקם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ק.ו.מ|Tense=Fut|Voice=Pass	17	advcl	_	_
 4	רפובליקה	רפובליקה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
 5	אוטונומית	אוטונומי	ADJ	ADJ	Gender=Fem|Number=Sing	4	amod	_	_
 6	גרמנית	גרמני	ADJ	ADJ	Gender=Fem|Number=Sing	4	amod	_	_
 7-8	שתהפוך	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-8	תהפוך	הפך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	12	aux	_	_
+8	תהפוך	הפך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ה.פ.כ|Tense=Fut|Voice=Act	12	aux	_	_
 9	מאוחר	מאוחר	ADV	ADV	_	12	advmod	_	_
 10	יותר	יותר	ADV	ADV	HebSource=ConvUncertainHead	9	fixed	_	_
 11-12	לריבונית	_	_	_	_	_	_	_	SpaceAfter=No
@@ -7686,7 +7686,7 @@
 22	היסטוריה	היסטוריה	NOUN	NOUN	Gender=Fem|Number=Sing	19	nmod	_	_
 23-24	החוזרת	_	_	_	_	_	_	_	_
 23	ה	ה	SCONJ	SCONJ	_	24	mark	_	_
-24	חוזרת	חזר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	22	acl:relcl	_	_
+24	חוזרת	חזר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ח.ז.ר|VerbForm=Part|Voice=Act	22	acl:relcl	_	_
 25	על	על	ADP	ADP	_	26	case	_	_
 26	עצמה	עצמו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	24	obl	_	SpaceAfter=No
 27	.	.	PUNCT	PUNCT	_	17	punct	_	_
@@ -7696,14 +7696,14 @@
 1	לפני	לפני	ADP	ADP	_	3	case	_	_
 2	עשר	עשר	NUM	NUM	Gender=Fem|Number=Sing	3	nummod	_	_
 3	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obl	_	_
-4	הגישה	הגיש	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	הגישה	הגיש	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Act	0	root	_	_
 5-6	הוועדה	_	_	_	_	_	_	_	SpaceAfter=No
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	וועדה	ועדה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 7	,	,	PUNCT	PUNCT	_	6	punct	_	_
 8-9	שמינה	_	_	_	_	_	_	_	_
 8	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
-9	מינה	מינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	acl:relcl	_	_
+9	מינה	מינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=מ.נ.י|Tense=Past|Voice=Act	6	acl:relcl	_	_
 10	שר	שר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	9	nsubj	_	_
 11-12	המשפטים	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
@@ -7744,7 +7744,7 @@
 6	ראש_	ראש	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
 8	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	6	nmod:poss	_	_
-9	עמד	עמד	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	2	acl:relcl	_	_
+9	עמד	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.מ.ד|Tense=Past	2	acl:relcl	_	_
 10	נשיא	נשיא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	9	nsubj	_	_
 11	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 12	-	-	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
@@ -7757,9 +7757,9 @@
 17	משה	משה	PROPN	PROPN	_	10	appos	_	_
 18	לנדוי	לנדוי	PROPN	PROPN	_	17	flat:name	_	SpaceAfter=No
 19	,	,	PUNCT	PUNCT	_	20	punct	_	_
-20	הוקמה	הוקם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+20	הוקמה	הוקם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ק.ו.מ|Tense=Past|Voice=Pass	0	root	_	_
 21	כדי	כדי	ADP	ADP	_	22	case	_	_
-22	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	20	advcl	_	_
+22	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|Root=מ.צ.א|VerbForm=Inf|Voice=Act	20	advcl	_	_
 23	פתרון	פתרון	NOUN	NOUN	Gender=Masc|Number=Sing	22	obj	_	_
 24	דחוף	דחוף	ADJ	ADJ	Gender=Masc|Number=Sing	23	amod	_	_
 25-26	למה	_	_	_	_	_	_	_	_
@@ -7767,7 +7767,7 @@
 26	מה	מה	ADV	ADV	PronType=Int	23	nmod	_	_
 27-28	שכונה	_	_	_	_	_	_	_	_
 27	ש	ש	SCONJ	SCONJ	_	28	mark	_	_
-28	כונה	כונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	26	acl:relcl	_	_
+28	כונה	כונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=כ.נ.י|Tense=Past|Voice=Pass	26	acl:relcl	_	_
 29-32	בפיה	_	_	_	_	_	_	_	_
 29	ב	ב	ADP	ADP	_	30	case	_	_
 30	פה_	פה	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	28	obl	_	_
@@ -7824,7 +7824,7 @@
 1	"	"	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 2	אם	אם	SCONJ	SCONJ	_	4	mark	_	_
 3	לא	לא	ADV	ADV	Polarity=Neg	4	advmod	_	_
-4	תימצא	נמצא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	14	advcl	_	_
+4	תימצא	נמצא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.צ.א|Tense=Fut|Voice=Mid	14	advcl	_	_
 5	בקרוב	בקרוב	ADV	ADV	_	4	advmod	_	_
 6	תרופה	תרופה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 7-8	לתיקון	_	_	_	_	_	_	_	_
@@ -7837,14 +7837,14 @@
 12	כי	כי	SCONJ	SCONJ	_	14	advmod	_	_
 13	אז	אז	ADV	ADV	_	12	fixed	_	_
 14	יש	יש	AUX	AUX	VerbType=Mod	15	aux	_	_
-15	לחשוש	חשש	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	48	obl	_	_
+15	לחשוש	חשש	VERB	VERB	HebBinyan=PAAL|Root=ח.ש.ש|VerbForm=Inf|Voice=Act	48	obl	_	_
 16-17	שבתי	_	_	_	_	_	_	_	SpaceAfter=No
 16	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
 17	בתי	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	19	nmod	_	_
 18	-	-	PUNCT	PUNCT	_	19	punct	_	SpaceAfter=No
 19	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	21	nsubj	_	_
 20	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	19	det	_	_
-21	יכרעו	כרע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Fut|Voice=Act	15	advcl	_	_
+21	יכרעו	כרע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=כ.ר.ע|Tense=Fut|Voice=Act	15	advcl	_	_
 22	תחת	תחת	ADP	ADP	_	24	case	_	_
 23-24	הנטל	_	_	_	_	_	_	_	SpaceAfter=No
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
@@ -7858,7 +7858,7 @@
 30	לא	לא	ADV	ADV	Polarity=Neg	31	advmod	_	_
 31	יוכלו	יכול	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut|VerbType=Mod	33	aux	_	_
 32	עוד	עוד	ADV	ADV	_	31	advmod	_	_
-33	לתת	נתן	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	21	conj	_	_
+33	לתת	נתן	VERB	VERB	HebBinyan=PAAL|Root=נ.ת.נ|VerbForm=Inf|Voice=Act	21	conj	_	_
 34-36	לציבור	_	_	_	_	_	_	_	_
 34	ל	ל	ADP	ADP	_	36	case	_	_
 35	ה_	ה	DET	DET	PronType=Art	36	det:def	_	_
@@ -7872,12 +7872,12 @@
 41	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	42	nsubj	_	_
 42	זכאי	זכאי	ADJ	ADJ	Gender=Masc|Number=Sing	39	acl:relcl	_	_
 43-45	לקבלו	_	_	_	_	_	_	_	SpaceAfter=No
-43	לקבלו	_	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	42	xcomp	_	_
+43	לקבלו	_	VERB	VERB	HebBinyan=PIEL|Root=ק.ב.ל|VerbForm=Inf|Voice=Act	42	xcomp	_	_
 44	את	את	ADP	ADP	Case=Acc	45	case	_	_
 45	_הוא	הוא	PRON	PRON	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	43	obj	_	_
 46	"	"	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 47	,	,	PUNCT	PUNCT	_	48	punct	_	_
-48	כתבה	כתב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+48	כתבה	כתב	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ת.ב|Tense=Past|Voice=Act	0	root	_	_
 49	ועדת	ועדה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	48	nsubj	_	_
 50	לנדוי	לנדוי	PROPN	PROPN	_	49	compound:smixut	_	_
 51-52	בדין	_	_	_	_	_	_	_	_
@@ -7899,10 +7899,10 @@
 3	עשור	עשור	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	_
 4-5	שחלף	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	חלף	חלף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	acl:relcl	_	_
+5	חלף	חלף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ל.פ|Tense=Past|Voice=Act	3	acl:relcl	_	_
 6	מאז	מאז	ADV	ADV	_	5	advmod	_	_
 7	לא	לא	ADV	ADV	Polarity=Neg	8	advmod	_	_
-8	מומשו	מומש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+8	מומשו	מומש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=מ.מ.ש|Tense=Past|Voice=Pass	0	root	_	_
 9	המלצות	המלצה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	8	nsubj	_	_
 10-11	הוועדה	_	_	_	_	_	_	_	SpaceAfter=No
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
@@ -7919,7 +7919,7 @@
 19-20	המשפט	_	_	_	_	_	_	_	_
 19	ה	ה	DET	DET	PronType=Art	20	det:def	_	_
 20	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	15	nmod	_	_
-21	החמיר	החמיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	8	conj	_	SpaceAfter=No
+21	החמיר	החמיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.מ.ר|Tense=Past|Voice=Act	8	conj	_	SpaceAfter=No
 22	.	.	PUNCT	PUNCT	_	8	punct	_	_
 
 # sent_id = 5976
@@ -7929,8 +7929,8 @@
 2	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
 3-4	שעברה	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	עברה	עבר	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	2	acl:relcl	_	_
-5	היו	_	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+4	עברה	עבר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past	2	acl:relcl	_	_
+5	היו	_	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 6-7	בבית	_	_	_	_	_	_	_	SpaceAfter=No
 6	ב	ב	ADP	ADP	_	10	case	_	_
 7	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	10	nmod	_	_
@@ -7948,7 +7948,7 @@
 16	תלויים	תלוי	ADJ	ADJ	Gender=Masc|Number=Plur	15	amod	_	_
 17-18	ועומדים	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
-18	עומדים	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	16	conj	_	_
+18	עומדים	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ע.מ.ד|VerbForm=Part|Voice=Act	16	conj	_	_
 19	(	(	PUNCT	PUNCT	_	22	punct	_	SpaceAfter=No
 20	לעומת	לעומת	ADP	ADP	_	22	case	_	_
 21-22	כ3,001	_	_	_	_	_	_	_	_
@@ -8020,7 +8020,7 @@
 8-9	המשפט	_	_	_	_	_	_	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod	_	_
-10	פוגע	פגע	VERB	VERB	VerbForm=Part	0	root	_	SpaceAfter=No
+10	פוגע	פגע	VERB	VERB	HebBinyan=PAAL|Root=פ.ג.ע|VerbForm=Part	0	root	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	10	punct	_	_
 12	כמובן	כמובן	ADV	ADV	_	10	advmod	_	SpaceAfter=No
 13	,	,	PUNCT	PUNCT	_	10	punct	_	_
@@ -8043,21 +8043,21 @@
 6-7	המשפטיים	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	משפטיים	משפטי	ADJ	ADJ	Gender=Masc|Number=Plur	5	amod	_	_
-8	מתארך	התארך	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	12	obl	_	_
+8	מתארך	התארך	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=א.ר.כ|VerbForm=Part	12	obl	_	_
 9-10	והולך	_	_	_	_	_	_	_	SpaceAfter=No
 9	ו	ו	CCONJ	CCONJ	_	10	cc	_	_
-10	הולך	הלך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	8	conj	_	_
+10	הולך	הלך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ה.ל.כ|VerbForm=Part|Voice=Act	8	conj	_	_
 11	,	,	PUNCT	PUNCT	_	12	punct	_	_
 12	נאלצים	_	AUX	AUX	VerbType=Mod	14	aux	_	_
 13	אזרחים	אזרח	NOUN	NOUN	Gender=Masc|Number=Plur	12	nsubj	_	_
-14	להסכים	הסכים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+14	להסכים	הסכים	VERB	VERB	HebBinyan=HIFIL|Root=ס.כ.מ|VerbForm=Inf|Voice=Act	0	root	_	_
 15-16	לפשרות	_	_	_	_	_	_	_	_
 15	ל	ל	ADP	ADP	_	16	case	_	_
 16	פשרות	פשרה	NOUN	NOUN	Gender=Fem|Number=Plur	14	obl	_	_
 17	בלתי	בלתי	ADV	ADV	Prefix=Yes	18	compound:affix	_	_
-18	צודקות	צדק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	16	amod	_	SpaceAfter=No
+18	צודקות	צדק	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=צ.ד.ק|VerbForm=Part|Voice=Act	16	amod	_	SpaceAfter=No
 19	,	,	PUNCT	PUNCT	_	12	punct	_	_
-20	מתרחבת	התרחב	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	12	conj	_	_
+20	מתרחבת	התרחב	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ר.ח.ב|VerbForm=Part	12	conj	_	_
 21-22	התופעה	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	תופעה	תופעה	NOUN	NOUN	Gender=Fem|Number=Sing	20	nsubj	_	_
@@ -8075,14 +8075,14 @@
 32	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	28	nsubj	_	_
 33-34	המנצלים	_	_	_	_	_	_	_	_
 33	ה	ה	SCONJ	SCONJ	_	34	mark	_	_
-34	מנצלים	ניצל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	32	dep	_	_
+34	מנצלים	ניצל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|Root=נ.צ.ל|VerbForm=Part|Voice=Act	32	dep	_	_
 35	את	את	ADP	ADP	Case=Acc	36	case:acc	_	_
 36	התמשכות	התמשכות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	34	obj	_	_
 37-38	הדיון	_	_	_	_	_	_	_	_
 37	ה	ה	DET	DET	PronType=Art	38	det:def	_	_
 38	דיון	דיון	NOUN	NOUN	Gender=Masc|Number=Sing	36	compound:smixut	_	_
 39	כדי	כדי	ADP	ADP	_	40	case	_	_
-40	ללחוץ	לחץ	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	34	advcl	_	_
+40	ללחוץ	לחץ	VERB	VERB	HebBinyan=PAAL|Root=ל.ח.צ|VerbForm=Inf|Voice=Act	34	advcl	_	_
 41	על	על	ADP	ADP	_	43	case	_	_
 42-43	הצד	_	_	_	_	_	_	_	_
 42	ה	ה	DET	DET	PronType=Art	43	det:def	_	_
@@ -8090,7 +8090,7 @@
 44-45	השני	_	_	_	_	_	_	_	_
 44	ה	ה	DET	DET	PronType=Art	45	det:def	_	_
 45	שני	שני	NUM	NUM	Gender=Masc|Number=Sing	43	amod	_	_
-46	לוותר	ויתר	VERB	VERB	HebBinyan=PIEL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	40	dep	_	SpaceAfter=No
+46	לוותר	ויתר	VERB	VERB	HebBinyan=PIEL|HebSource=ConvUncertainHead|Root=ו.ת.ר|VerbForm=Inf|Voice=Act	40	dep	_	SpaceAfter=No
 47	.	.	PUNCT	PUNCT	_	12	punct	_	_
 
 # sent_id = 5979
@@ -8099,7 +8099,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	יוני	יון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	4	obl	_	_
 3	88	88	NUM	NUM	_	2	compound:smixut	_	_
-4	הגיש	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	הגיש	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Act	0	root	_	_
 5	שר	שר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	nsubj	_	_
 6-7	המשפטים	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -8135,7 +8135,7 @@
 30-31	ההצעה	_	_	_	_	_	_	_	_
 30	ה	ה	DET	DET	PronType=Art	31	det:def	_	_
 31	הצעה	הצעה	NOUN	NOUN	Gender=Fem|Number=Sing	32	nsubj	_	_
-32	נכשלה	נכשל	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	conj	_	_
+32	נכשלה	נכשל	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=כ.ש.ל|Tense=Past|Voice=Mid	4	conj	_	_
 33-35	בקריאה	_	_	_	_	_	_	_	_
 33	ב	ב	ADP	ADP	_	35	case	_	_
 34	ה_	ה	DET	DET	PronType=Art	35	det:def	_	_
@@ -8151,7 +8151,7 @@
 2-3	המתנגדים	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	מתנגדים	מתנגד	NOUN	NOUN	Gender=Masc|Number=Plur	4	nsubj	_	_
-4	הכירו	הכיר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	הכירו	הכיר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=נ.כ.ר|Tense=Past|Voice=Act	0	root	_	_
 5-7	בצורך	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -8161,7 +8161,7 @@
 9	רפורמה	רפורמה	NOUN	NOUN	Gender=Fem|Number=Sing	7	nmod	_	_
 10	,	,	PUNCT	PUNCT	_	4	punct	_	_
 11	אך	אך	CCONJ	CCONJ	_	12	cc	_	_
-12	נכנעו	נכנע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	4	conj	_	_
+12	נכנעו	נכנע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=כ.נ.ע|Tense=Past|Voice=Mid	4	conj	_	_
 13-16	למאבקם	_	_	_	_	_	_	_	_
 13	ל	ל	ADP	ADP	_	14	case	_	_
 14	מאבק_	מאבק	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
@@ -8188,13 +8188,13 @@
 1-2	השופטים	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	שופטים	שופט	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
-3	ראו	ראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	ראו	ראה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ר.א.י|Tense=Past|Voice=Act	0	root	_	_
 4-6	בהצעה	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	הצעה	הצעה	NOUN	NOUN	Gender=Fem|Number=Sing	3	obl	_	_
 7	ניסיון	ניסיון	NOUN	NOUN	Gender=Masc|Number=Sing	3	obj	_	_
-8	לפגוע	פגע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	acl	_	_
+8	לפגוע	פגע	VERB	VERB	HebBinyan=PAAL|Root=פ.ג.ע|VerbForm=Inf|Voice=Act	7	acl	_	_
 9-12	במעמדם	_	_	_	_	_	_	_	SpaceAfter=No
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	מעמד_	מעמד	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	8	obl	_	_
@@ -8210,12 +8210,12 @@
 3	משפטים	משפט	NOUN	NOUN	Gender=Masc|Number=Plur	1	compound:smixut	_	_
 4	דן	דן	PROPN	PROPN	_	1	flat:name	_	_
 5	מרידור	מרידור	PROPN	PROPN	_	1	flat:name	_	_
-6	בחר	בחר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	בחר	בחר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ב.ח.ר|Tense=Past|Voice=Act	0	root	_	_
 7-8	בדרך	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	דרך	דרך	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
 9	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	8	amod	_	_
-10	לפתור	פתר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	8	acl	_	_
+10	לפתור	פתר	VERB	VERB	HebBinyan=PAAL|Root=פ.ת.ר|VerbForm=Inf|Voice=Act	8	acl	_	_
 11	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 12-13	הבעיה	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
@@ -8237,8 +8237,8 @@
 26-27	שהם	_	_	_	_	_	_	_	_
 26	ש	ש	SCONJ	SCONJ	_	28	mark	_	_
 27	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	28	nsubj	_	_
-28	מוסמכים	הוסמך	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	25	acl:relcl	_	_
-29	לדון	דן	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	28	xcomp	_	_
+28	מוסמכים	הוסמך	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ס.מ.כ|VerbForm=Part|Voice=Pass	25	acl:relcl	_	_
+29	לדון	דן	VERB	VERB	HebBinyan=PAAL|Root=ד.ו.נ|VerbForm=Inf|Voice=Act	28	xcomp	_	_
 30-31	בהם	_	_	_	_	_	_	_	_
 30	ב_	ב	ADP	ADP	_	31	case	_	_
 31	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	29	obl	_	_
@@ -8255,7 +8255,7 @@
 40-41	התביעה	_	_	_	_	_	_	_	_
 40	ה	ה	DET	DET	PronType=Art	41	det:def	_	_
 41	תביעה	תביעה	NOUN	NOUN	Gender=Fem|Number=Sing	39	compound:smixut	_	_
-42	לפתוח	פתח	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	39	acl	_	_
+42	לפתוח	פתח	VERB	VERB	HebBinyan=PAAL|Root=פ.ת.ח|VerbForm=Inf|Voice=Act	39	acl	_	_
 43-44	בהליכים	_	_	_	_	_	_	_	_
 43	ב	ב	ADP	ADP	_	44	case	_	_
 44	הליכים	הליך	NOUN	NOUN	Gender=Masc|Number=Plur	42	obl	_	_
@@ -8280,7 +8280,7 @@
 # sent_id = 5983
 # text = במקביל הוגדלו המשאבים של בתי-משפט השלום והורחבו התקנים שלהם, מתוך כוונה להקטין את משקלם הסגולי של בתי-המשפט המחוזיים במערכת המשפטית.
 1	במקביל	במקביל	ADV	ADV	_	2	advmod	_	_
-2	הוגדלו	הוגדל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+2	הוגדלו	הוגדל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=ג.ד.ל|Tense=Past|Voice=Pass	0	root	_	_
 3-4	המשאבים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	משאבים	משאב	NOUN	NOUN	Gender=Masc|Number=Plur	2	nsubj	_	_
@@ -8293,7 +8293,7 @@
 10	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	8	nmod	_	_
 11-12	והורחבו	_	_	_	_	_	_	_	_
 11	ו	ו	CCONJ	CCONJ	_	12	cc	_	_
-12	הורחבו	הורחב	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	2	conj	_	_
+12	הורחבו	הורחב	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=ר.ח.ב|Tense=Past|Voice=Pass	2	conj	_	_
 13-14	התקנים	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	תקנים	תקן	NOUN	NOUN	Gender=Masc|Number=Plur	12	nsubj	_	_
@@ -8303,7 +8303,7 @@
 17	,	,	PUNCT	PUNCT	_	12	punct	_	_
 18	מתוך	מתוך	ADP	ADP	_	19	case	_	_
 19	כוונה	כוונה	NOUN	NOUN	Gender=Fem|Number=Sing	12	obl	_	_
-20	להקטין	הקטין	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	19	acl	_	_
+20	להקטין	הקטין	VERB	VERB	HebBinyan=HIFIL|Root=ק.ט.נ|VerbForm=Inf|Voice=Act	19	acl	_	_
 21	את	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 22-24	משקלם	_	_	_	_	_	_	_	_
 22	משקל_	משקל	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	20	obj	_	_
@@ -8336,7 +8336,7 @@
 2	צעדים	צעד	NOUN	NOUN	Gender=Masc|Number=Plur	5	nsubj	_	_
 3	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	2	det	_	_
 4	לא	לא	ADV	ADV	Polarity=Neg	5	advmod	_	_
-5	הספיקו	הספיק	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
+5	הספיקו	הספיק	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ס.פ.ק|Tense=Past|Voice=Act	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	5	punct	_	_
 7-8	ויש	_	_	_	_	_	_	_	_
 7	ו	ו	CCONJ	CCONJ	_	8	cc	_	_
@@ -8344,7 +8344,7 @@
 9	משפטנים	משפטן	NOUN	NOUN	Gender=Masc|Number=Plur	8	nsubj	_	_
 10-11	הטוענים	_	_	_	_	_	_	_	SpaceAfter=No
 10	ה	ה	SCONJ	SCONJ	_	11	mark	_	_
-11	טוענים	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	9	acl:relcl	_	_
+11	טוענים	טען	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ט.ע.נ|VerbForm=Part|Voice=Act	9	acl:relcl	_	_
 12	,	,	PUNCT	PUNCT	_	11	punct	_	_
 13	כי	כי	SCONJ	SCONJ	_	19	mark	_	_
 14-15	התוצאה	_	_	_	_	_	_	_	_
@@ -8396,12 +8396,12 @@
 13-14	השלום	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	שלום	שלום	NOUN	NOUN	Gender=Masc|Number=Sing	12	nmod	_	_
-15	ערוכים	ערך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	5	dep	_	_
+15	ערוכים	ערך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Plur|Person=1,2,3|Root=ע.ר.כ|VerbForm=Part|Voice=Act	5	dep	_	_
 16-17	מבחינה	_	_	_	_	_	_	_	_
 16	מ	מ	ADP	ADP	_	17	case	_	_
 17	בחינה	בחינה	NOUN	NOUN	Gender=Fem|Number=Sing	5	nmod	_	_
 18	מנהלית	מנהלי	ADJ	ADJ	Gender=Fem|Number=Sing	17	amod	_	_
-19	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	5	xcomp	_	_
+19	להתמודד	התמודד	VERB	VERB	HebBinyan=HITPAEL|Root=מ.ד.ד|VerbForm=Inf	5	xcomp	_	_
 20	עם	עם	ADP	ADP	_	22	case	_	_
 21-22	הגידול	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
@@ -8418,12 +8418,12 @@
 29	ו	ו	CCONJ	CCONJ	_	31	cc	_	_
 30	היום	היום	ADV	ADV	_	31	advmod	_	_
 31	צריך	צריך	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	32	aux	_	_
-32	להמתין	המתין	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	5	conj	_	_
+32	להמתין	המתין	VERB	VERB	HebBinyan=HIFIL|Root=מ.ת.נ|VerbForm=Inf|Voice=Act	5	conj	_	_
 33	חודשים	חודש	NOUN	NOUN	Gender=Masc|Number=Plur	32	obl	_	_
 34	עד	עד	ADP	ADP	_	36	mark	_	_
 35-36	שמתחיל	_	_	_	_	_	_	_	_
 35	ש	ש	SCONJ	SCONJ	_	34	fixed	_	_
-36	מתחיל	התחיל	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	32	advcl	_	_
+36	מתחיל	התחיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ת.ח.ל|VerbForm=Part	32	advcl	_	_
 37-38	הדיון	_	_	_	_	_	_	_	_
 37	ה	ה	DET	DET	PronType=Art	38	det:def	_	_
 38	דיון	דיון	NOUN	NOUN	Gender=Masc|Number=Sing	36	nsubj	_	_
@@ -8433,7 +8433,7 @@
 41	תביעה	תביעה	NOUN	NOUN	Gender=Fem|Number=Sing	38	nmod	_	_
 42-43	המוגשת	_	_	_	_	_	_	_	_
 42	ה	ה	SCONJ	SCONJ	_	43	mark	_	_
-43	מוגשת	הוגש	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	41	acl:relcl	_	_
+43	מוגשת	הוגש	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=נ.ג.ש|VerbForm=Part|Voice=Pass	41	acl:relcl	_	_
 44-45	להם	_	_	_	_	_	_	_	SpaceAfter=No
 44	ל_	ל	ADP	ADP	_	45	case	_	_
 45	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	43	obl	_	_
@@ -8455,7 +8455,7 @@
 10	ועדת	ועדה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	9	compound:smixut	_	_
 11	לנדוי	לנדוי	PROPN	PROPN	_	10	compound:smixut	_	SpaceAfter=No
 12	,	,	PUNCT	PUNCT	_	13	punct	_	_
-13	הגיש	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+13	הגיש	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Act	0	root	_	_
 14	כעת	כעת	ADV	ADV	_	13	advmod	_	_
 15-17	לכנסת	_	_	_	_	_	_	_	_
 15	ל	ל	ADP	ADP	_	17	case	_	_
@@ -8478,14 +8478,14 @@
 29	,	,	PUNCT	PUNCT	_	20	punct	_	_
 30-31	שנועדה	_	_	_	_	_	_	_	_
 30	ש	ש	SCONJ	SCONJ	_	31	mark	_	_
-31	נועדה	נועד	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	20	acl:relcl	_	_
-32	לייעל	ייעל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	31	xcomp	_	_
+31	נועדה	נועד	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.ע.ד|Tense=Past|Voice=Mid	20	acl:relcl	_	_
+32	לייעל	ייעל	VERB	VERB	HebBinyan=PIEL|Root=י.ע.ל|VerbForm=Inf|Voice=Act	31	xcomp	_	_
 33	את	את	ADP	ADP	Case=Acc	35	case:acc	_	_
 34-35	המערכת	_	_	_	_	_	_	_	_
 34	ה	ה	DET	DET	PronType=Art	35	det:def	_	_
 35	מערכת	מערכת	NOUN	NOUN	Gender=Fem|Number=Sing	32	obj	_	_
 36	בלי	בלי	ADP	ADP	_	37	case	_	_
-37	לפגוע	פגע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	32	advcl	_	_
+37	לפגוע	פגע	VERB	VERB	HebBinyan=PAAL|Root=פ.ג.ע|VerbForm=Inf|Voice=Act	32	advcl	_	_
 38-39	במעמד	_	_	_	_	_	_	_	_
 38	ב	ב	ADP	ADP	_	39	case	_	_
 39	מעמד	מעמד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	37	obl	_	_
@@ -8516,7 +8516,7 @@
 2	מועד	מועד	NOUN	NOUN	Gender=Masc|Number=Sing	9	nsubj:cop	_	_
 3-4	המוצע	_	_	_	_	_	_	_	_
 3	ה	ה	SCONJ	SCONJ	_	4	mark	_	_
-4	מוצע	הוצע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	2	acl:relcl	_	_
+4	מוצע	הוצע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=י.צ.ע|VerbForm=Part|Voice=Pass	2	acl:relcl	_	_
 5-7	לרפורמה	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -8528,7 +8528,7 @@
 12-13	והיא	_	_	_	_	_	_	_	_
 12	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 13	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
-14	תיעשה	נעשה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	9	conj	_	_
+14	תיעשה	נעשה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Fut|Voice=Mid	9	conj	_	_
 15-16	בשלב	_	_	_	_	_	_	_	_
 15	ב	ב	ADP	ADP	_	16	case	_	_
 16	שלב	שלב	NOUN	NOUN	Gender=Masc|Number=Sing	14	obl	_	_
@@ -8543,7 +8543,7 @@
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	הצעה	הצעה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
 5	,	,	PUNCT	PUNCT	_	6	punct	_	_
-6	תורכב	הורכב	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	0	root	_	_
+6	תורכב	הורכב	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ר.כ.ב|Tense=Fut|Voice=Pass	0	root	_	_
 7	מערכת	מערכת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	nsubj	_	_
 8	בתי	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	nmod	_	SpaceAfter=No
 9	-	-	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
@@ -8592,7 +8592,7 @@
 3-4	הראשונה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	2	amod	_	_
-5	תוקם	הוקם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	0	root	_	_
+5	תוקם	הוקם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ק.ו.ם|Tense=Fut|Voice=Pass	0	root	_	_
 6	באמצעות	באמצעות	ADP	ADP	_	7	case	_	_
 7	איחוד	איחוד	NOUN	NOUN	Gender=Masc|Number=Sing	5	obl	_	_
 8	מנהלי	מנהלי	ADJ	ADJ	Gender=Masc|Number=Sing	7	amod	_	_
@@ -8624,7 +8624,7 @@
 4-5	החדשה	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	חדשה	חדש	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
-6	תישמר	נשמר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	0	root	_	_
+6	תישמר	נשמר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.מ.ר|Tense=Fut|Voice=Mid	0	root	_	_
 7-8	ההבחנה	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	הבחנה	הבחנה	NOUN	NOUN	Gender=Fem|Number=Sing	6	nsubj	_	_
@@ -8648,7 +8648,7 @@
 23-24	השופטים	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	שופטים	שופט	NOUN	NOUN	Gender=Masc|Number=Plur	22	compound:smixut	_	_
-25	ייעשה	נעשה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	6	conj	_	_
+25	ייעשה	נעשה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Fut|Voice=Mid	6	conj	_	_
 26	על	על	ADP	ADP	_	28	case	_	_
 27	פי	פה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	26	fixed	_	_
 28-30	רמתם	_	_	_	_	_	_	_	SpaceAfter=No
@@ -8662,14 +8662,14 @@
 1	לעומת	לעומת	ADP	ADP	_	2	case	_	_
 2	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	4	obl	_	SpaceAfter=No
 3	,	,	PUNCT	PUNCT	_	4	punct	_	_
-4	תבוטל	בוטל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	0	root	_	_
+4	תבוטל	בוטל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Root=ב.ט.ל|Tense=Fut|Voice=Pass	0	root	_	_
 5	חציצת	חציצה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	4	nsubj	_	_
 6-7	הסמכות	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	סמכות	סמכות	NOUN	NOUN	Gender=Fem|Number=Sing	5	compound:smixut	_	_
 8-9	הנהוגה	_	_	_	_	_	_	_	_
 8	ה	ה	SCONJ	SCONJ	_	9	mark	_	_
-9	נהוגה	נהג	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	acl:relcl	_	_
+9	נהוגה	נהג	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ה.ג|VerbForm=Part|Voice=Act	5	acl:relcl	_	_
 10	כעת	כעת	ADV	ADV	_	9	advmod	_	_
 11	בין	בין	ADP	ADP	_	13	case	_	_
 12	שני	שני	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	13	nummod	_	_
@@ -8684,7 +8684,7 @@
 19	ו	ו	CCONJ	CCONJ	_	22	cc	_	_
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
 21	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	22	nsubj	_	_
-22	יבטיח	הבטיח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	4	conj	_	_
+22	יבטיח	הבטיח	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ב.ט.ח|Tense=Fut|Voice=Act	4	conj	_	_
 23	זרימת	זרימה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	22	obj	_	_
 24	תיקים	תיק	NOUN	NOUN	Gender=Masc|Number=Plur	23	compound:smixut	_	_
 25	חופשית	חופשי	ADJ	ADJ	Gender=Fem|Number=Sing	23	amod	_	_
@@ -8735,7 +8735,7 @@
 9-10	המשפט	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	6	compound:smixut	_	_
-11	יתרום	תרם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+11	יתרום	תרם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ת.ר.מ|Tense=Fut|Voice=Act	0	root	_	_
 12-13	לייעול	_	_	_	_	_	_	_	_
 12	ל	ל	ADP	ADP	_	13	case	_	_
 13	ייעול	ייעול	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	11	obl	_	_
@@ -8759,7 +8759,7 @@
 9-10	הראשונה	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	8	amod	_	_
-11	יהיו	_	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
+11	יהיו	_	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	0	root	_	_
 12	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	11	nsubj	_	_
 13-14	וסגן	_	_	_	_	_	_	_	_
 13	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
@@ -8775,7 +8775,7 @@
 22-23	והוא	_	_	_	_	_	_	_	_
 22	ו	ו	CCONJ	CCONJ	_	24	cc	_	_
 23	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	24	nsubj	_	_
-24	יחולק	חולק	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	11	conj	_	_
+24	יחולק	חולק	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ח.ל.ק|Tense=Fut|Voice=Pass	11	conj	_	_
 25-26	למחלקות	_	_	_	_	_	_	_	_
 25	ל	ל	ADP	ADP	_	26	case	_	_
 26	מחלקות	מחלקה	NOUN	NOUN	Gender=Fem|Number=Plur	24	obl	_	_
@@ -8795,7 +8795,7 @@
 # text = כמו כן תהיה בכל בית-משפט כזה מחלקת ערעורים, שתדון בערעורים על החלטות של בית-המשפט לתביעות קטנות, של בית-המשפט לעניינים מקומיים, של שופטי תעבורה ושל ראש ההוצאה לפועל.
 1	כמו	כמו	ADP	ADP	_	2	case	_	_
 2	כן	כן	PRON	PRON	Person=3|PronType=Dem	3	obl	_	_
-3	תהיה	_	VERB	VERB	Gender=Fem|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
+3	תהיה	_	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	0	root	_	_
 4-5	בכל	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	8	case	_	_
 5	כל	כול	DET	DET	Definite=Cons	8	det	_	_
@@ -8811,7 +8811,7 @@
 14	,	,	PUNCT	PUNCT	_	12	punct	_	_
 15-16	שתדון	_	_	_	_	_	_	_	_
 15	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
-16	תדון	דן	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Fut	12	acl:relcl	_	_
+16	תדון	דן	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ד.ו.נ|Tense=Fut	12	acl:relcl	_	_
 17-19	בערעורים	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	19	case	_	_
 18	ה_	ה	DET	DET	PronType=Art	19	det:def	_	_
@@ -8891,7 +8891,7 @@
 5-6	לערעורים	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	ערעורים	ערעור	NOUN	NOUN	Gender=Masc|Number=Plur	4	nmod	_	_
-7	ידון	נידון	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	0	root	_	_
+7	ידון	נידון	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ד.ו.נ|Tense=Fut	0	root	_	_
 8-9	בכל	_	_	_	_	_	_	_	_
 8	ב	ב	ADP	ADP	_	11	case	_	_
 9	כל	כול	DET	DET	Definite=Cons	11	det	_	_
@@ -8913,7 +8913,7 @@
 1-2	בכך	_	_	_	_	_	_	_	_
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	כך	כך	PRON	PRON	Person=3|PronType=Dem	3	obl	_	_
-3	יקבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+3	יקבל	קיבל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ק.ב.ל|Tense=Fut|Voice=Act	0	root	_	_
 4-5	עליו	_	_	_	_	_	_	_	_
 4	עליו	עליו	ADP	ADP	_	5	case	_	_
 5	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	obl	_	_
@@ -8924,7 +8924,7 @@
 9	משימות	משימה	NOUN	NOUN	Gender=Fem|Number=Plur	3	obj	_	_
 10-11	המוטלות	_	_	_	_	_	_	_	_
 10	ה	ה	SCONJ	SCONJ	_	11	mark	_	_
-11	מוטלות	הוטל	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	9	acl:relcl	_	_
+11	מוטלות	הוטל	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=נ.ט.ל|VerbForm=Part|Voice=Pass	9	acl:relcl	_	_
 12	כעת	כעת	ADV	ADV	_	11	advmod	_	_
 13	על	על	ADP	ADP	_	15	case	_	_
 14-15	השופטים	_	_	_	_	_	_	_	_
@@ -8954,7 +8954,7 @@
 3	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	6	nsubj	_	_
 4	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	3	det	_	_
 5	יהיה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	6	cop	_	_
-6	מורכב	הורכב	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+6	מורכב	הורכב	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ר.כ.ב|VerbForm=Part|Voice=Pass	0	root	_	_
 7-8	ממחלקה	_	_	_	_	_	_	_	_
 7	מ	מ	ADP	ADP	_	8	case	_	_
 8	מחלקה	מחלקה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
@@ -8971,7 +8971,7 @@
 17	ראש_	ראש	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	20	obl	_	_
 18	_של_	של	ADP	ADP	_	19	case:gen	_	_
 19	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	nmod:poss	_	_
-20	יעמוד	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Fut|Voice=Act	6	conj	_	_
+20	יעמוד	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.מ.ד|Tense=Fut|Voice=Act	6	conj	_	_
 21	נשיא	נשיא	NOUN	NOUN	Gender=Masc|Number=Sing	20	nsubj	_	SpaceAfter=No
 22	.	.	PUNCT	PUNCT	_	6	punct	_	_
 
@@ -8985,7 +8985,7 @@
 5-6	העליון	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	עליון	עליון	ADJ	ADJ	Gender=Masc|Number=Sing	4	amod	_	_
-7	יישאר	נשאר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	0	root	_	_
+7	יישאר	נשאר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ש.א.ר|Tense=Fut|Voice=Mid	0	root	_	_
 8-10	במבנה	_	_	_	_	_	_	_	_
 8	ב	ב	ADP	ADP	_	10	case	_	_
 9	ה_	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -8996,7 +8996,7 @@
 13	,	,	PUNCT	PUNCT	_	7	punct	_	_
 14-15	וישמש	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
-15	ישמש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	7	conj	_	_
+15	ישמש	שימש	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.מ.ש|Tense=Fut|Voice=Act	7	conj	_	_
 16	ערכאת	ערכאה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	15	dep	_	_
 17	ערעור	ערעור	NOUN	NOUN	Gender=Masc|Number=Sing	16	compound:smixut	_	_
 18	על	על	ADP	ADP	_	19	case	_	_
@@ -9032,7 +9032,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	דרך	דרך	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
 3	זו	זו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	det	_	_
-4	יובטח	הובטח	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	0	root	_	SpaceAfter=No
+4	יובטח	הובטח	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ב.ט.ח|Tense=Fut|Voice=Pass	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	4	punct	_	_
 6-7	שבית	_	_	_	_	_	_	_	SpaceAfter=No
 6	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
@@ -9044,13 +9044,13 @@
 11-12	העליון	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	עליון	עליון	ADJ	ADJ	Gender=Masc|Number=Sing	10	amod	_	_
-13	ימשיך	המשיך	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	4	ccomp	_	_
-14	לקבוע	קבע	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	13	xcomp	_	_
+13	ימשיך	המשיך	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=מ.ש.כ|Tense=Fut|Voice=Act	4	ccomp	_	_
+14	לקבוע	קבע	VERB	VERB	HebBinyan=PAAL|Root=ק.ב.ע|VerbForm=Inf|Voice=Act	13	xcomp	_	_
 15	הלכות	הלכה	NOUN	NOUN	Gender=Fem|Number=Plur	14	obj	_	_
 16	חשובות	חשוב	ADJ	ADJ	Gender=Fem|Number=Plur	15	amod	_	_
 17-18	וידון	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
-18	ידון	דן	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	13	conj	_	_
+18	ידון	דן	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ד.ו.נ|Tense=Fut	13	conj	_	_
 19-20	בעניינים	_	_	_	_	_	_	_	_
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	עניינים	עניין	NOUN	NOUN	Gender=Masc|Number=Plur	18	obl	_	_
@@ -9062,7 +9062,7 @@
 # text = סמכויות בג"ץ יישארו בידי בית-המשפט העליון, חוץ מהסמכות בעניין משמורת קטינים, שתועבר לערכאה הראשונה.
 1	סמכויות	סמכות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	3	nsubj	_	_
 2	בג"ץ	בג"ץ	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	1	compound:smixut	_	_
-3	יישארו	נשאר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Fut|Voice=Mid	0	root	_	_
+3	יישארו	נשאר	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ש.א.ר|Tense=Fut|Voice=Mid	0	root	_	_
 4	בידי	בידי	ADP	ADP	_	8	case	_	_
 5	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 6	-	-	PUNCT	PUNCT	_	8	punct	_	SpaceAfter=No
@@ -9086,7 +9086,7 @@
 20	,	,	PUNCT	PUNCT	_	15	punct	_	_
 21-22	שתועבר	_	_	_	_	_	_	_	_
 21	ש	ש	SCONJ	SCONJ	_	22	mark	_	_
-22	תועבר	הועבר	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	15	acl:relcl	_	_
+22	תועבר	הועבר	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Fut|Voice=Pass	15	acl:relcl	_	_
 23-25	לערכאה	_	_	_	_	_	_	_	_
 23	ל	ל	ADP	ADP	_	25	case	_	_
 24	ה_	ה	DET	DET	PronType=Art	25	det:def	_	_
@@ -9108,7 +9108,7 @@
 7	ח"כ	ח"ך	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	3	nmod:poss	_	_
 8	שטרית	שטרית	PROPN	PROPN	_	7	flat:name	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	10	punct	_	_
-10	תוגדל	הוגדל	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	0	root	_	_
+10	תוגדל	הוגדל	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ג.ד.ל|Tense=Fut|Voice=Pass	0	root	_	_
 11	סמכות	סמכות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	10	nsubj	_	_
 12-13	השופטים	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
@@ -9129,7 +9129,7 @@
 23	שופטת	שופט	NOUN	NOUN	Gender=Fem|Number=Sing	21	nmod	_	_
 24-25	ותצומצם	_	_	_	_	_	_	_	_
 24	ו	ו	CCONJ	CCONJ	_	25	cc	_	_
-25	תצומצם	צומצם	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	10	conj	_	_
+25	תצומצם	צומצם	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Root=צ.מ.צ.מ|Tense=Fut|Voice=Pass	10	conj	_	_
 26	סמכות	סמכות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	25	nsubj	_	_
 27	שר	שר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	26	compound:smixut	_	_
 28-29	המשפטים	_	_	_	_	_	_	_	SpaceAfter=No
@@ -9144,8 +9144,8 @@
 3-4	המשפטים	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	משפטים	משפט	NOUN	NOUN	Gender=Masc|Number=Plur	2	compound:smixut	_	_
-5	מוסמך	הוסמך	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
-6	למנות	מינה	VERB	VERB	VerbForm=Inf	5	xcomp	_	_
+5	מוסמך	הוסמך	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ס.מ.כ|VerbForm=Part|Voice=Pass	0	root	_	_
+6	למנות	מינה	VERB	VERB	HebBinyan=PIEL|Root=מ.נ.י|VerbForm=Inf	5	xcomp	_	_
 7	נשיאים	נשיא	NOUN	NOUN	Gender=Masc|Number=Plur	6	obj	_	_
 8-9	וסגני	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
@@ -9176,8 +9176,8 @@
 
 # sent_id = 6005
 # text = מוצע להעביר סמכות זאתו לוועדה לבחירת שופטים, כדי לשמור על עצמאות הרשות השופטת.
-1	מוצע	הוצע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
-2	להעביר	העביר	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	1	xcomp	_	_
+1	מוצע	הוצע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=י.צ.ע|VerbForm=Part|Voice=Pass	0	root	_	_
+2	להעביר	העביר	VERB	VERB	HebBinyan=HIFIL|Root=ע.ב.ר|VerbForm=Inf|Voice=Act	1	xcomp	_	_
 3	סמכות	סמכות	NOUN	NOUN	Gender=Fem|Number=Sing	2	obj	_	_
 4	זאתו	_	X	X	Xtra=Junk	2	dep	_	_
 5-7	לוועדה	_	_	_	_	_	_	_	_
@@ -9190,7 +9190,7 @@
 10	שופטים	שופט	NOUN	NOUN	Gender=Masc|Number=Plur	9	compound:smixut	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	1	punct	_	_
 12	כדי	כדי	ADP	ADP	_	13	case	_	_
-13	לשמור	שמר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	1	advcl	_	_
+13	לשמור	שמר	VERB	VERB	HebBinyan=PAAL|Root=ש.מ.ר|VerbForm=Inf|Voice=Act	1	advcl	_	_
 14	על	על	ADP	ADP	_	15	case	_	_
 15	עצמאות	עצמאות	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	13	obl	_	_
 16-17	הרשות	_	_	_	_	_	_	_	_
@@ -9205,8 +9205,8 @@
 # text = כמו כן מוצע לשנות את החוק, המסמיך את שר המשפטים לזמן את הוועדה למינוי שופטים רק "משראה" שיש למנות שופט.
 1	כמו	כמו	ADP	ADP	_	2	case	_	_
 2	כן	כן	PRON	PRON	Person=3|PronType=Dem	3	obl	_	_
-3	מוצע	הוצע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
-4	לשנות	שינה	VERB	VERB	VerbForm=Inf	3	xcomp	_	_
+3	מוצע	הוצע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=י.צ.ע|VerbForm=Part|Voice=Pass	0	root	_	_
+4	לשנות	שינה	VERB	VERB	HebBinyan=PIEL|Root=ש.נ.י|VerbForm=Inf	3	xcomp	_	_
 5	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 6-7	החוק	_	_	_	_	_	_	_	SpaceAfter=No
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -9214,13 +9214,13 @@
 8	,	,	PUNCT	PUNCT	_	7	punct	_	_
 9-10	המסמיך	_	_	_	_	_	_	_	_
 9	ה	ה	SCONJ	SCONJ	_	10	mark	_	_
-10	מסמיך	הסמיך	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	7	acl:relcl	_	_
+10	מסמיך	הסמיך	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ס.מ.כ|VerbForm=Part|Voice=Act	7	acl:relcl	_	_
 11	את	את	ADP	ADP	Case=Acc	12	case:acc	_	_
 12	שר	שר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	10	obj	_	_
 13-14	המשפטים	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	משפטים	משפט	NOUN	NOUN	Gender=Masc|Number=Plur	12	compound:smixut	_	_
-15	לזמן	זימן	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	10	xcomp	_	_
+15	לזמן	זימן	VERB	VERB	HebBinyan=PIEL|Root=ז.מ.נ|VerbForm=Inf|Voice=Act	10	xcomp	_	_
 16	את	את	ADP	ADP	Case=Acc	18	case:acc	_	_
 17-18	הוועדה	_	_	_	_	_	_	_	_
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
@@ -9238,7 +9238,7 @@
 27-28	שיש	_	_	_	_	_	_	_	_
 27	ש	ש	SCONJ	SCONJ	_	28	mark	_	_
 28	יש	יש	AUX	AUX	VerbType=Mod	29	aux	_	_
-29	למנות	מינה	VERB	VERB	VerbForm=Inf	25	ccomp	_	_
+29	למנות	מינה	VERB	VERB	HebBinyan=PIEL|Root=מ.נ.י|VerbForm=Inf	25	ccomp	_	_
 30	שופט	שופט	NOUN	NOUN	Gender=Masc|Number=Sing	29	obj	_	SpaceAfter=No
 31	.	.	PUNCT	PUNCT	_	3	punct	_	_
 
@@ -9248,11 +9248,11 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	מקום	מקום	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 3	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	2	det	_	_
-4	ייקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	0	root	_	SpaceAfter=No
+4	ייקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ק.ב.ע|Tense=Fut|Voice=Mid	0	root	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	4	punct	_	_
 6	כי	כי	SCONJ	SCONJ	_	15	mark	_	_
 7	כאשר	כאשר	SCONJ	SCONJ	_	8	mark	_	_
-8	תתפנה	התפנה	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	15	advcl	_	_
+8	תתפנה	התפנה	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=פ.נ.י|Tense=Fut	15	advcl	_	_
 9	משרת	משרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	8	nsubj	_	_
 10	שופט	שופט	NOUN	NOUN	Gender=Masc|Number=Sing	9	compound:smixut	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	15	punct	_	_
@@ -9261,7 +9261,7 @@
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	שר	שר	NOUN	NOUN	Gender=Masc|Number=Sing	15	nsubj	_	_
 15	חייב	חייב	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	16	aux	_	_
-16	לזמן	זימן	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	4	ccomp	_	_
+16	לזמן	זימן	VERB	VERB	HebBinyan=PIEL|Root=ז.מ.נ|VerbForm=Inf|Voice=Act	4	ccomp	_	_
 17	את	את	ADP	ADP	Case=Acc	19	case:acc	_	_
 18-19	הוועדה	_	_	_	_	_	_	_	SpaceAfter=No
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
@@ -9271,7 +9271,7 @@
 # sent_id = 6008
 # text = כדי להגדיל את השפעת השופטים על תפקוד המערכת מוצע להקים מועצת שופטים, המורכבת מנשיאי בתי-המשפט ונציגים של בתי-המשפט למיניהם, ובכלל זה בית-הדין לעבודה.
 1	כדי	כדי	ADP	ADP	_	2	case	_	_
-2	להגדיל	הגדיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	11	advcl	_	_
+2	להגדיל	הגדיל	VERB	VERB	HebBinyan=HIFIL|Root=ג.ד.ל|VerbForm=Inf|Voice=Act	11	advcl	_	_
 3	את	את	ADP	ADP	Case=Acc	4	case:acc	_	_
 4	השפעת	השפעה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	2	obj	_	_
 5-6	השופטים	_	_	_	_	_	_	_	_
@@ -9282,14 +9282,14 @@
 9-10	המערכת	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	מערכת	מערכת	NOUN	NOUN	Gender=Fem|Number=Sing	8	compound:smixut	_	_
-11	מוצע	הוצע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
-12	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	11	xcomp	_	_
+11	מוצע	הוצע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=י.צ.ע|VerbForm=Part|Voice=Pass	0	root	_	_
+12	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|Root=ק.ו.מ|VerbForm=Inf|Voice=Act	11	xcomp	_	_
 13	מועצת	מועצה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	12	obj	_	_
 14	שופטים	שופט	NOUN	NOUN	Gender=Masc|Number=Plur	13	compound:smixut	_	SpaceAfter=No
 15	,	,	PUNCT	PUNCT	_	13	punct	_	_
 16-17	המורכבת	_	_	_	_	_	_	_	_
 16	ה	ה	SCONJ	SCONJ	_	17	mark	_	_
-17	מורכבת	הורכב	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	13	acl:relcl	_	_
+17	מורכבת	הורכב	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ר.כ.ב|VerbForm=Part|Voice=Pass	13	acl:relcl	_	_
 18-19	מנשיאי	_	_	_	_	_	_	_	_
 18	מ	מ	ADP	ADP	_	19	case	_	_
 19	נשיאי	נשיא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	17	obl	_	_
@@ -9334,7 +9334,7 @@
 1	סמכויות	סמכות	NOUN	NOUN	Gender=Fem|Number=Plur	4	nsubj	_	_
 2	גוף	גוף	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainLabel|Number=Sing	1	nmod	_	_
 3	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	2	det	_	_
-4	יעוגנו	עוגן	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Fut|Voice=Pass	0	root	_	_
+4	יעוגנו	עוגן	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=ע.ג.נ|Tense=Fut|Voice=Pass	0	root	_	_
 5-7	בחוק	_	_	_	_	_	_	_	SpaceAfter=No
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -9343,7 +9343,7 @@
 9-10	והוא	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
 10	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
-11	יתוקצב	תוקצב	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	4	conj	_	_
+11	יתוקצב	תוקצב	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ת.ק.צ.ב|Tense=Fut|Voice=Pass	4	conj	_	_
 12-13	מקופת	_	_	_	_	_	_	_	_
 12	מ	מ	ADP	ADP	_	13	case	_	_
 13	קופת	קופה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	11	obl	_	_
@@ -9356,7 +9356,7 @@
 # text = במקביל, תוקם מועצת נשיאים גוף מצומצם, שיהיה אחראי לניהול מערכת בתי-המשפט.
 1	במקביל	במקביל	ADV	ADV	_	3	advmod	_	SpaceAfter=No
 2	,	,	PUNCT	PUNCT	_	3	punct	_	_
-3	תוקם	הוקם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	0	root	_	_
+3	תוקם	הוקם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ק.ו.מ|Tense=Fut|Voice=Pass	0	root	_	_
 4	מועצת	מועצה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	3	nsubj	_	_
 5	נשיאים	נשיא	NOUN	NOUN	Gender=Masc|Number=Plur	4	compound:smixut	_	_
 6	גוף	גוף	NOUN	NOUN	Gender=Masc|Number=Sing	4	nmod	_	_
@@ -9383,7 +9383,7 @@
 2-3	הנשיאים	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	נשיאים	נשיא	NOUN	NOUN	Gender=Masc|Number=Plur	1	compound:smixut	_	_
-4	תמיין	מיין	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+4	תמיין	מיין	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=מ.י.נ|Tense=Fut|Voice=Act	0	root	_	_
 5	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 6-7	השופטים	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -9414,7 +9414,7 @@
 # text = היא גם תמנה את ראשי המחלקות בערכאה זאת ובבית-המשפט לערעורים (את הנשיאים תמנה הוועדה לבחירת שופטים).
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	גם	גם	ADV	ADV	_	3	advmod	_	_
-3	תמנה	מינה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Fut	0	root	_	_
+3	תמנה	מינה	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=מ.נ.י|Tense=Fut	0	root	_	_
 4	את	את	ADP	ADP	Case=Acc	5	case:acc	_	_
 5	ראשי	ראש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	3	obj	_	_
 6-7	המחלקות	_	_	_	_	_	_	_	_
@@ -9440,7 +9440,7 @@
 21-22	הנשיאים	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	נשיאים	נשיא	NOUN	NOUN	Gender=Masc|Number=Plur	23	obj	_	_
-23	תמנה	מינה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Fut	3	parataxis	_	_
+23	תמנה	מינה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=מ.נ.י|Tense=Fut	3	parataxis	_	_
 24-25	הוועדה	_	_	_	_	_	_	_	_
 24	ה	ה	DET	DET	PronType=Art	25	det:def	_	_
 25	וועדה	ועדה	NOUN	NOUN	Gender=Fem|Number=Sing	23	nsubj	_	_
@@ -9455,12 +9455,12 @@
 # text = ימים אלה מתקיימת במילאנו תערוכה יוצאת דופן של ביצים מחרסינה, שיוצרו בחצר הצאר מהמאה ה71 ועד תחילת המאה ה02.
 1	ימים	יום	NOUN	NOUN	Gender=Masc|Number=Plur	3	dep	_	_
 2	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	1	det	_	_
-3	מתקיימת	התקיים	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+3	מתקיימת	התקיים	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ק.י.מ|VerbForm=Part	0	root	_	_
 4-5	במילאנו	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	מילאנו	מילאנו	PROPN	PROPN	_	3	obl	_	_
 6	תערוכה	תערוכה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-7	יוצאת	יצא	VERB	VERB	Definite=Cons|Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	6	amod	_	_
+7	יוצאת	יצא	VERB	VERB	Definite=Cons|Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=י.צ.א|VerbForm=Part|Voice=Act	6	amod	_	_
 8	דופן	דופן	NOUN	NOUN	Gender=Fem,Masc|Number=Sing	7	compound:smixut	_	_
 9	של	של	ADP	ADP	Case=Gen	10	case:gen	_	_
 10	ביצים	ביצה	NOUN	NOUN	Gender=Fem|Number=Plur	6	nmod	_	_
@@ -9470,7 +9470,7 @@
 13	,	,	PUNCT	PUNCT	_	10	punct	_	_
 14-15	שיוצרו	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
-15	יוצרו	יוצר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	10	acl:relcl	_	_
+15	יוצרו	יוצר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=י.צ.ר|Tense=Past|Voice=Pass	10	acl:relcl	_	_
 16-17	בחצר	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	חצר	חצר	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	15	obl	_	_
@@ -9501,7 +9501,7 @@
 1-2	האוסף	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	אוסף	אוסף	NOUN	NOUN	Gender=Masc|Number=Sing	3	dep	_	_
-3	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+3	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=מ.צ.א|Tense=Past|Voice=Mid	0	root	_	_
 4-6	במוזיאון	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -9515,7 +9515,7 @@
 11	,	,	PUNCT	PUNCT	_	3	punct	_	_
 12-13	ונתגלה	_	_	_	_	_	_	_	_
 12	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
-13	נתגלה	התגלה	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	3	conj	_	_
+13	נתגלה	התגלה	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ג.ל.י|Tense=Past	3	conj	_	_
 14-15	בעת	_	_	_	_	_	_	_	_
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	עת	עת	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	13	obl	_	_
@@ -9525,7 +9525,7 @@
 19	,	,	PUNCT	PUNCT	_	17	punct	_	_
 20-21	שהובאה	_	_	_	_	_	_	_	_
 20	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
-21	הובאה	הובא	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	17	acl:relcl	_	_
+21	הובאה	הובא	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ב.ו.א|Tense=Past|Voice=Pass	17	acl:relcl	_	_
 22-23	לאיטליה	_	_	_	_	_	_	_	_
 22	ל	ל	ADP	ADP	_	23	case	_	_
 23	איטליה	איטליה	PROPN	PROPN	_	21	obl	_	_
@@ -9535,7 +9535,7 @@
 26	שנה	שנה	NOUN	NOUN	Gender=Fem|Number=Sing	21	obl	_	_
 27-28	וכללה	_	_	_	_	_	_	_	_
 27	ו	ו	CCONJ	CCONJ	_	28	cc	_	_
-28	כללה	כלל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	21	conj	_	_
+28	כללה	כלל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ל.ל|Tense=Past|Voice=Act	21	conj	_	_
 29	יצירות	יצירה	NOUN	NOUN	Gender=Fem|Number=Plur	28	obj	_	_
 30	מופלאות	מופלא	ADJ	ADJ	Gender=Fem|Number=Plur	29	amod	_	_
 31	בלתי	בלתי	ADV	ADV	Prefix=Yes	32	compound:affix	_	_
@@ -9578,16 +9578,16 @@
 1	מנהג	מנהג	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj:cop	_	_
 2	עתיק	עתיק	ADJ	ADJ	Gender=Masc|Number=Sing	1	amod	_	_
 3	הוא	הוא	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	4	cop	_	_
-4	לשלוח	שלח	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	0	root	_	_
+4	לשלוח	שלח	VERB	VERB	HebBinyan=PAAL|Root=ש.ל.ח|VerbForm=Inf|Voice=Act	0	root	_	_
 5	ביצים	ביצה	NOUN	NOUN	Gender=Fem|Number=Plur	4	obj	_	_
-6	צבועות	צבע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	5	acl	_	_
+6	צבועות	צבע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=צ.ב.ע|VerbForm=Part|Voice=Act	5	acl	_	_
 7-8	באדום	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	אדום	אדום	PROPN	PROPN	_	6	obl	_	_
 9-10	והוא	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
 10	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
-11	מיוחס	יוחס	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	4	conj	_	_
+11	מיוחס	יוחס	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=י.ח.ס|VerbForm=Part|Voice=Pass	4	conj	_	_
 12-13	לאגדה	_	_	_	_	_	_	_	_
 12	ל	ל	ADP	ADP	_	13	case	_	_
 13	אגדה	אגדה	NOUN	NOUN	Gender=Fem|Number=Sing	11	obl	_	_
@@ -9597,7 +9597,7 @@
 17	,	,	PUNCT	PUNCT	_	15	punct	_	_
 18-19	שהביאה	_	_	_	_	_	_	_	_
 18	ש	ש	SCONJ	SCONJ	_	19	mark	_	_
-19	הביאה	הביא	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	15	acl:relcl	_	_
+19	הביאה	הביא	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ב.ו.א|Tense=Past|Voice=Act	15	acl:relcl	_	_
 20	אל	אל	ADP	ADP	_	22	case	_	_
 21-22	הקיסר	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
@@ -9606,7 +9606,7 @@
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	רומא	רומא	PROPN	PROPN	_	22	nmod	_	_
 25	ביצה	ביצה	NOUN	NOUN	Gender=Fem|Number=Sing	19	obj	_	_
-26	צבועה	צבע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	25	acl	_	_
+26	צבועה	צבע	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=צ.ב.ע|VerbForm=Part|Voice=Act	25	acl	_	_
 27-28	באדום	_	_	_	_	_	_	_	_
 27	ב	ב	ADP	ADP	_	28	case	_	_
 28	אדום	אדום	PROPN	PROPN	_	26	obl	_	_
@@ -9632,7 +9632,7 @@
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	פסחא	פסחא	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod	_	_
-8	הפך	הפך	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	12	aux	_	_
+8	הפך	הפך	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ה.פ.כ|Tense=Past	12	aux	_	_
 9-10	לחלק	_	_	_	_	_	_	_	_
 9	ל	ל	ADP	ADP	_	12	case	_	_
 10	חלק	חלק	NOUN	NOUN	Gender=Masc|Number=Sing	12	det	_	_
@@ -9674,16 +9674,16 @@
 2	זמן_	זמן	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 3	_של_	של	ADP	ADP	_	4	case:gen	_	_
 4	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nmod:poss	_	_
-5	נהגו	נהג	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	0	root	_	_
+5	נהגו	נהג	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=נ.ה.ג|Tense=Past	0	root	_	_
 6	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	nsubj	_	_
 7	משפחת	משפחה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	compound:smixut	_	_
 8-9	הצאר	_	_	_	_	_	_	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	צאר	צאר	NOUN	NOUN	Gender=Masc|Number=Sing	7	compound:smixut	_	_
-10	לחלק	חילק	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	5	xcomp	_	_
+10	לחלק	חילק	VERB	VERB	HebBinyan=PIEL|Root=ח.ל.ק|VerbForm=Inf|Voice=Act	5	xcomp	_	_
 11	ביצי	ביצה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	10	obj	_	_
 12	חרסינה	חרסינה	NOUN	NOUN	Gender=Fem|Number=Sing	11	compound:smixut	_	_
-13	מצוירות	צויר	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	11	amod	_	_
+13	מצוירות	צויר	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=צ.י.ר|VerbForm=Part|Voice=Pass	11	amod	_	_
 14-15	לבני	_	_	_	_	_	_	_	_
 14	ל	ל	ADP	ADP	_	15	case	_	_
 15	בני	בן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	10	obl	_	_
@@ -9702,7 +9702,7 @@
 
 # sent_id = 6019
 # text = היו ביצים קטנות בגודל של ביצת יונה והיו גם ביצים בגודל של ביצת בת-יענה.
-1	היו	_	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+1	היו	_	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 2	ביצים	ביצה	NOUN	NOUN	Gender=Fem|Number=Plur	1	nsubj	_	_
 3	קטנות	קטן	ADJ	ADJ	Gender=Fem|Number=Plur	2	amod	_	_
 4-5	בגודל	_	_	_	_	_	_	_	_
@@ -9713,7 +9713,7 @@
 8	יונה	יון	NOUN	NOUN	Gender=Fem|Number=Sing	7	compound:smixut	_	_
 9-10	והיו	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	10	cc	_	_
-10	היו	_	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Past	1	conj	_	_
+10	היו	_	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	1	conj	_	_
 11	גם	גם	ADV	ADV	_	12	det	_	_
 12	ביצים	ביצה	NOUN	NOUN	Gender=Fem|Number=Plur	10	nsubj	_	_
 13-14	בגודל	_	_	_	_	_	_	_	_
@@ -9732,7 +9732,7 @@
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	תחילה	תחילה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
-4	נצבעו	נצבע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+4	נצבעו	נצבע	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=צ.ב.ע|Tense=Past|Voice=Mid	0	root	_	_
 5-6	הביצים	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	ביצים	ביצה	NOUN	NOUN	Gender=Fem|Number=Plur	4	nsubj	_	_
@@ -9756,7 +9756,7 @@
 2-3	הזמן	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
-4	יוצרו	יוצר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	יוצרו	יוצר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=י.צ.ר|Tense=Past|Voice=Pass	0	root	_	_
 5	ביצים	ביצה	NOUN	NOUN	Gender=Fem|Number=Plur	4	nsubj	_	_
 6-7	מחומרים	_	_	_	_	_	_	_	_
 6	מ	מ	ADP	ADP	_	7	case	_	_
@@ -9780,7 +9780,7 @@
 4-5	ה81	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	18	18	NUM	NUM	_	3	amod	_	_
-6	נוספו	נוסף	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+6	נוספו	נוסף	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=י.ס.פ|Tense=Past|Voice=Mid	0	root	_	_
 7	ביצים	ביצה	NOUN	NOUN	Gender=Fem|Number=Plur	6	nsubj	_	_
 8-9	מנייר	_	_	_	_	_	_	_	SpaceAfter=No
 8	מ	מ	ADP	ADP	_	9	case	_	_
@@ -9813,8 +9813,8 @@
 12	,	,	PUNCT	PUNCT	_	5	punct	_	_
 13-14	כשהתחילו	_	_	_	_	_	_	_	_
 13	כש	כש	SCONJ	SCONJ	Case=Tem	14	mark	_	_
-14	התחילו	התחיל	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	5	advcl	_	_
-15	לייצר	ייצר	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	14	xcomp	_	_
+14	התחילו	התחיל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ת.ח.ל|Tense=Past	5	advcl	_	_
+15	לייצר	ייצר	VERB	VERB	HebBinyan=PIEL|Root=י.צ.ר|VerbForm=Inf|Voice=Act	14	xcomp	_	_
 16	ביצים	ביצה	NOUN	NOUN	Gender=Fem|Number=Plur	15	obj	_	_
 17-18	מחרסינה	_	_	_	_	_	_	_	_
 17	מ	מ	ADP	ADP	_	18	case	_	_
@@ -9822,7 +9822,7 @@
 19	לבנה	לבן	ADJ	ADJ	Gender=Fem|Number=Sing	18	amod	_	_
 20-21	ולצייר	_	_	_	_	_	_	_	_
 20	ו	ו	CCONJ	CCONJ	_	21	cc	_	_
-21	לצייר	צייר	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	15	conj	_	_
+21	לצייר	צייר	VERB	VERB	HebBinyan=PIEL|Root=צ.י.ר|VerbForm=Inf|Voice=Act	15	conj	_	_
 22-23	עליהן	_	_	_	_	_	_	_	_
 22	על_	על	ADP	ADP	_	23	case	_	_
 23	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	21	obl	_	_
@@ -9846,7 +9846,7 @@
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	ביצים	ביצה	NOUN	NOUN	Gender=Fem|Number=Plur	5	obj	_	_
 4	היו	_	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	5	cop	_	_
-5	תולים	תלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	תולים	תלה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ת.ל.י|VerbForm=Part|Voice=Act	0	root	_	_
 6	בתוך	בתוך	ADP	ADP	_	8	case	_	_
 7-8	הבית	_	_	_	_	_	_	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
@@ -9863,7 +9863,7 @@
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	כל	כול	DET	DET	Definite=Cons	3	det	_	_
 3	ביצה	ביצה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
-4	ניקבו	ניקב	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	ניקבו	ניקב	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=נ.ק.ב|Tense=Past|Voice=Act	0	root	_	_
 5	שני	שני	NUM	NUM	Definite=Cons|Gender=Masc|Number=Plur	6	nummod	_	_
 6	נקבים	נקב	NOUN	NOUN	Gender=Masc|Number=Plur	4	obj	_	_
 7	לאורך	לאורך	ADP	ADP	_	9	case	_	_
@@ -9880,12 +9880,12 @@
 15	תוך_	תוך	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	18	obl	_	_
 16	_של_	של	ADP	ADP	_	17	case:gen	_	_
 17	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	15	nmod:poss	_	_
-18	השחילו	השחיל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	4	conj	_	_
+18	השחילו	השחיל	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ש.ח.ל|Tense=Past|Voice=Act	4	conj	_	_
 19	סרט	סרט	NOUN	NOUN	Gender=Masc|Number=Sing	18	obj	_	SpaceAfter=No
 20	,	,	PUNCT	PUNCT	_	19	punct	_	_
 21-22	שנקשר	_	_	_	_	_	_	_	_
 21	ש	ש	SCONJ	SCONJ	_	22	mark	_	_
-22	נקשר	נקשר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	19	acl:relcl	_	_
+22	נקשר	נקשר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ק.ש.ר|Tense=Past|Voice=Mid	19	acl:relcl	_	_
 23-26	בחלקו	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	חלק_	חלק	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	22	obl	_	_
@@ -9906,7 +9906,7 @@
 2-3	הביצה	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	ביצה	ביצה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obj	_	_
-4	תלו	תלה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	תלו	תלה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ת.ל.י|Tense=Past|Voice=Act	0	root	_	_
 5-6	כאיקונין	_	_	_	_	_	_	_	SpaceAfter=No
 5	כ	כ	ADP	ADP	_	6	case	_	_
 6	איקונין	איקונין	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
@@ -9918,7 +9918,7 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	סרט	סרט	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
 3	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	4	cop	_	_
-4	שזור	שזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+4	שזור	שזר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ש.ז.ר|VerbForm=Part|Voice=Act	0	root	_	_
 5-6	בזהב	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	זהב	זהב	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
@@ -9927,7 +9927,7 @@
 8	צבע_	צבע	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	11	nsubj	_	_
 9	_של_	של	ADP	ADP	_	10	case:gen	_	_
 10	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nmod:poss	_	_
-11	תאמו	תיאם	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	4	conj	_	_
+11	תאמו	תיאם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ת.א.מ|Tense=Past	4	conj	_	_
 12	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 13	צבעי	צבע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	obj	_	_
 14-15	הציור	_	_	_	_	_	_	_	SpaceAfter=No
@@ -9941,7 +9941,7 @@
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	תערוכה	תערוכה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
-4	מוצגות	הוצג	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+4	מוצגות	הוצג	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=י.צ.ג|VerbForm=Part|Voice=Pass	0	root	_	_
 5	82	82	NUM	NUM	_	6	nummod	_	_
 6	ביצים	ביצה	NOUN	NOUN	Gender=Fem|Number=Plur	4	nsubj	_	_
 7	מתוך	מתוך	ADP	ADP	_	9	case	_	_
@@ -9957,7 +9957,7 @@
 14	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
 15	על_	על	ADP	ADP	_	16	case	_	_
 16	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	17	obl	_	_
-17	מצוירים	צויר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	6	acl:relcl	_	_
+17	מצוירים	צויר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=צ.י.ר|VerbForm=Part|Voice=Pass	6	acl:relcl	_	_
 18	העתקים	העתק	NOUN	NOUN	Gender=Masc|Number=Plur	17	nsubj	_	_
 19-20	מציורים	_	_	_	_	_	_	_	_
 19	מ	מ	ADP	ADP	_	20	case	_	_
@@ -9979,7 +9979,7 @@
 2-3	התערוכה	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	תערוכה	תערוכה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obj	_	_
-4	הביאה	הביא	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	הביאה	הביא	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ב.ו.א|Tense=Past|Voice=Act	0	root	_	_
 5-6	למילאנו	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	מילאנו	מילאנו	PROPN	PROPN	_	4	obl	_	_
@@ -9996,7 +9996,7 @@
 16-17	והיא	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
 17	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	18	nsubj	_	_
-18	חונכת	חנך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	conj	_	_
+18	חונכת	חנך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ח.נ.כ|VerbForm=Part|Voice=Act	4	conj	_	_
 19	אולם	אולם	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	18	obj	_	_
 20	תצוגות	תצוגה	NOUN	NOUN	Gender=Fem|Number=Plur	19	compound:smixut	_	_
 21-23	ברחוב	_	_	_	_	_	_	_	_
@@ -10031,7 +10031,7 @@
 9	יצירתיות	יצירתיות	NOUN	NOUN	Gender=Fem|Number=Sing	7	conj	_	SpaceAfter=No
 10	,	,	PUNCT	PUNCT	_	7	punct	_	_
 11	רצון	רצון	NOUN	NOUN	Gender=Masc|Number=Sing	7	conj	_	_
-12	להתנסות	התנסה	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	11	acl	_	_
+12	להתנסות	התנסה	VERB	VERB	HebBinyan=HITPAEL|Root=נ.ס.י|VerbForm=Inf	11	acl	_	_
 13-14	והתמדה	_	_	_	_	_	_	_	SpaceAfter=No
 13	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 14	התמדה	התמדה	NOUN	NOUN	Gender=Fem|Number=Sing	7	conj	_	_
@@ -10041,7 +10041,7 @@
 # sent_id = 6031
 # text = כך כתוב בשער גיליון מספר 102 של כתב העת למתמטיקה.
 1	כך	כך	ADV	ADV	_	2	advmod	_	_
-2	כתוב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+2	כתוב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ת.ב|VerbForm=Part|Voice=Act	0	root	_	_
 3-4	בשער	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	שער	שער	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	obl	_	_
@@ -10078,7 +10078,7 @@
 3-4	החוברת	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	חוברת	חוברת	NOUN	NOUN	Gender=Fem|Number=Sing	2	compound:smixut	_	_
-5	מופיע	הופיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	מופיע	הופיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=י.פ.ע|VerbForm=Part|Voice=Act	0	root	_	_
 6-7	המדור	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	מדור	מדור	NOUN	NOUN	Gender=Masc|Number=Sing	5	nsubj	_	_
@@ -10100,7 +10100,7 @@
 5-6	העמוד	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	עמוד	עמוד	NOUN	NOUN	Gender=Masc|Number=Sing	4	compound:smixut	_	_
-7	מכריזה	הכריז	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+7	מכריזה	הכריז	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=כ.ר.ז|VerbForm=Part|Voice=Act	0	root	_	_
 8	על	על	ADP	ADP	_	9	case	_	_
 9	פרס	פרס	NOUN	NOUN	Gender=Masc|Number=Sing	7	obl	_	_
 10-11	בסך	_	_	_	_	_	_	_	_
@@ -10128,12 +10128,12 @@
 26	בעיות	בעיה	NOUN	NOUN	Gender=Fem|Number=Plur	18	nmod	_	_
 27-28	המופיעות	_	_	_	_	_	_	_	_
 27	ה	ה	SCONJ	SCONJ	_	28	mark	_	_
-28	מופיעות	הופיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	26	acl:relcl	_	_
+28	מופיעות	הופיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=י.פ.ע|VerbForm=Part|Voice=Act	26	acl:relcl	_	_
 29-31	במדור	_	_	_	_	_	_	_	_
 29	ב	ב	ADP	ADP	_	31	case	_	_
 30	ה_	ה	DET	DET	PronType=Art	31	det:def	_	_
 31	מדור	מדור	NOUN	NOUN	Gender=Masc|Number=Sing	28	obl	_	_
-32	יגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	16	acl:relcl	_	_
+32	יגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ע|Tense=Fut|Voice=Act	16	acl:relcl	_	_
 33	ראשון	_	ADJ	ADJ	Gender=Masc|Number=Sing	32	xcomp	_	_
 34-36	למערכת	_	_	_	_	_	_	_	SpaceAfter=No
 34	ל	ל	ADP	ADP	_	36	case	_	_
@@ -10160,7 +10160,7 @@
 13-14	שהחל	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
 14	החל	החל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	appos	_	_
-15	להוציא	הוציא	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	14	xcomp	_	_
+15	להוציא	הוציא	VERB	VERB	HebBinyan=HIFIL|Root=י.צ.א|VerbForm=Inf|Voice=Act	14	xcomp	_	_
 16-18	לאור	_	_	_	_	_	_	_	_
 16	ל	ל	ADP	ADP	_	18	case	_	_
 17	ה_	ה	DET	DET	PronType=Art	18	det:def	_	_
@@ -10180,7 +10180,7 @@
 29	אלכס	אלכס	PROPN	PROPN	_	8	conj	_	_
 30	קופרמן	קופרמן	PROPN	PROPN	_	29	flat:name	_	SpaceAfter=No
 31	,	,	PUNCT	PUNCT	_	32	punct	_	_
-32	כיוונו	כיוון	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+32	כיוונו	כיוון	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=כ.ו.נ|Tense=Past|Voice=Act	0	root	_	_
 33	את	את	ADP	ADP	Case=Acc	35	case:acc	_	_
 34-35	המוצר	_	_	_	_	_	_	_	_
 34	ה	ה	DET	DET	PronType=Art	35	det:def	_	_
@@ -10209,27 +10209,27 @@
 51	אבל	אבל	CCONJ	CCONJ	_	54	cc	_	_
 52	לא	לא	ADV	ADV	Polarity=Neg	54	advmod	_	_
 53	אחת	אחת	NUM	NUM	Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	52	fixed	_	_
-54	מתברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	32	conj	_	_
+54	מתברר	התברר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ב.ר.ר|VerbForm=Part	32	conj	_	_
 55-56	שגם	_	_	_	_	_	_	_	_
 55	ש	ש	SCONJ	SCONJ	_	59	mark	_	_
 56	גם	גם	ADV	ADV	_	58	det	_	_
 57-58	המורים	_	_	_	_	_	_	_	_
 57	ה	ה	DET	DET	PronType=Art	58	det:def	_	_
 58	מורים	מורה	NOUN	NOUN	Gender=Masc|Number=Plur	59	nsubj	_	_
-59	קוראים	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	54	ccomp	_	_
+59	קוראים	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ק.ר.א|VerbForm=Part|Voice=Act	54	ccomp	_	_
 60-61	בו	_	_	_	_	_	_	_	_
 60	ב_	ב	ADP	ADP	_	61	case	_	_
 61	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	59	obl	_	_
 62-63	ונוטלים	_	_	_	_	_	_	_	_
 62	ו	ו	CCONJ	CCONJ	_	63	cc	_	_
-63	נוטלים	נטל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	59	conj	_	_
+63	נוטלים	נטל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=נ.ט.ל|VerbForm=Part|Voice=Act	59	conj	_	_
 64-65	ממנו	_	_	_	_	_	_	_	_
 64	ממנו	ממנו	ADP	ADP	_	65	case	_	_
 65	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	63	obl	_	_
 66	בעיות	בעיה	NOUN	NOUN	Gender=Fem|Number=Plur	63	obj	_	_
 67	שונות	שונה	ADJ	ADJ	Gender=Fem|Number=Plur	66	amod	_	_
 68	כדי	כדי	ADP	ADP	_	69	case	_	_
-69	לשלב	שילב	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	63	advcl	_	_
+69	לשלב	שילב	VERB	VERB	HebBinyan=PIEL|Root=ש.ל.ב|VerbForm=Inf|Voice=Act	63	advcl	_	_
 70-71	אותן	_	_	_	_	_	_	_	_
 70	את_	את_	ADP	ADP	Case=Acc	71	case:acc	_	_
 71	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	69	obj	_	_
@@ -10240,7 +10240,7 @@
 75-76	שהם	_	_	_	_	_	_	_	_
 75	ש	ש	SCONJ	SCONJ	_	77	mark	_	_
 76	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	77	nsubj	_	_
-77	מחברים	חיבר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	74	acl:relcl	_	SpaceAfter=No
+77	מחברים	חיבר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ח.ב.ר|VerbForm=Part|Voice=Act	74	acl:relcl	_	SpaceAfter=No
 78	.	.	PUNCT	PUNCT	_	32	punct	_	_
 
 # sent_id = 6036
@@ -10248,12 +10248,12 @@
 1	מי	מי	ADV	ADV	PronType=Int	7	nsubj	_	_
 2-3	שפותר	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	3	mark	_	_
-3	פותר	פתר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
+3	פותר	פתר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=פ.ת.ר|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
 4	בעיה	בעיה	NOUN	NOUN	Gender=Fem|Number=Sing	3	obj	_	_
 5	אחת	אחת	NUM	NUM	Gender=Fem|Number=Sing	4	nummod	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	7	punct	_	_
-7	מוזמן	הוזמן	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
-8	לעבור	עבר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	7	xcomp	_	_
+7	מוזמן	הוזמן	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ז.מ.נ|VerbForm=Part|Voice=Pass	0	root	_	_
+8	לעבור	עבר	VERB	VERB	HebBinyan=PAAL|Root=ע.ב.ר|VerbForm=Inf|Voice=Act	7	xcomp	_	_
 9	מיד	מייד	ADV	ADV	_	8	advmod	_	_
 10-12	לבעיה	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	12	case	_	_
@@ -10278,7 +10278,7 @@
 10-11	וכו	_	_	_	_	_	_	_	_
 10	ו	ו	ADV	ADV	_	1	advmod	_	_
 11	כו	_	ADV	ADV	_	10	fixed	_	_
-12	ממלאים	מילא	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+12	ממלאים	מילא	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=מ.ל.א|VerbForm=Part|Voice=Act	0	root	_	_
 13	את	את	ADP	ADP	Case=Acc	15	dep	_	_
 14	עמודי	עמוד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	15	dep	_	_
 15	כתב	כתב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	obj	_	_
@@ -10300,12 +10300,12 @@
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	המשך	המשך	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
-4	ישנה	_	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
+4	ישנה	_	VERB	VERB	Gender=Fem|HebBinyan=_|Number=Sing|Person=3|Root=_|Tense=Past	0	root	_	_
 5	אנציקלופדיה	אנציקלופדיה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 6	זעירה	זעיר	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
 7-8	המפרטת	_	_	_	_	_	_	_	_
 7	ה	ה	SCONJ	SCONJ	_	8	mark	_	_
-8	מפרטת	פירט	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	acl:relcl	_	_
+8	מפרטת	פירט	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=פ.ר.ט|VerbForm=Part|Voice=Act	5	acl:relcl	_	_
 9	את	את	ADP	ADP	Case=Acc	10	case:acc	_	_
 10	תולדות	תולדה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	8	obj	_	_
 11-13	חייהם	_	_	_	_	_	_	_	_
@@ -10351,7 +10351,7 @@
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	det	_	_
 6	,	,	PUNCT	PUNCT	_	7	punct	_	_
-7	מגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+7	מגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=נ.ג.ע|VerbForm=Part|Voice=Act	0	root	_	_
 8	מטח	מטח	NOUN	NOUN	Gender=Masc|Number=Sing	7	nsubj	_	_
 9	נוסף	נוסף	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
 10	של	של	ADP	ADP	Case=Gen	11	case:gen	_	_
@@ -10445,10 +10445,10 @@
 1	ו	ו	CCONJ	CCONJ	_	5	cc	_	_
 2	כך	כך	ADV	ADV	_	4	advmod	_	_
 3	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	4	nsubj	_	_
-4	נמשך	נמשך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+4	נמשך	נמשך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=מ.ש.כ|VerbForm=Part|Voice=Mid	0	root	_	_
 5-6	ונמשך	_	_	_	_	_	_	_	SpaceAfter=No
 5	ו	ו	CCONJ	CCONJ	_	6	cc	_	_
-6	נמשך	נמשך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	4	conj	_	_
+6	נמשך	נמשך	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=מ.ש.כ|VerbForm=Part|Voice=Mid	4	conj	_	_
 7	,	,	PUNCT	PUNCT	_	4	punct	_	_
 8	על	על	ADP	ADP	_	12	case	_	SpaceAfter=No
 9	-	-	PUNCT	PUNCT	_	8	fixed	_	SpaceAfter=No
@@ -10474,7 +10474,7 @@
 4-5	האחורית	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	אחורית	אחורי	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
-6	מכוסה	כוסה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+6	מכוסה	כוסה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=כ.ס.י|VerbForm=Part|Voice=Pass	0	root	_	_
 7	טבלאות	טבלאות	NOUN	NOUN	_	6	obj	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	7	punct	_	_
 9	שרטוטים	שרטוט	NOUN	NOUN	Gender=Masc|Number=Plur	7	conj	_	_
@@ -10488,7 +10488,7 @@
 # text = שם גם מודיעים העורכים שהאחריות על שגיאות כלשהן שיימצאו (אם יימצאו) מוטלת עליהם.
 1	שם	שם	ADV	ADV	_	3	advmod	_	_
 2	גם	גם	ADV	ADV	_	3	advmod	_	_
-3	מודיעים	הודיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+3	מודיעים	הודיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	0	root	_	_
 4-5	העורכים	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	עורכים	עורך	NOUN	NOUN	Gender=Masc|Number=Plur	3	nsubj	_	_
@@ -10501,12 +10501,12 @@
 11	כלשהן	כלשהו	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Ind	10	det	_	_
 12-13	שיימצאו	_	_	_	_	_	_	_	_
 12	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
-13	יימצאו	נמצא	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Fut|Voice=Mid	10	acl:relcl	_	_
+13	יימצאו	נמצא	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=מ.צ.א|Tense=Fut|Voice=Mid	10	acl:relcl	_	_
 14	(	(	PUNCT	PUNCT	_	16	punct	_	SpaceAfter=No
 15	אם	אם	SCONJ	SCONJ	_	16	mark	_	_
-16	יימצאו	נמצא	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Fut|Voice=Mid	13	parataxis	_	SpaceAfter=No
+16	יימצאו	נמצא	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=מ.צ.א|Tense=Fut|Voice=Mid	13	parataxis	_	SpaceAfter=No
 17	)	)	PUNCT	PUNCT	_	16	punct	_	_
-18	מוטלת	הוטל	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	3	ccomp	_	_
+18	מוטלת	הוטל	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=נ.ט.ל|VerbForm=Part|Voice=Pass	3	ccomp	_	_
 19-20	עליהם	_	_	_	_	_	_	_	SpaceAfter=No
 19	על_	על	ADP	ADP	_	20	case	_	_
 20	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	18	obl	_	_
@@ -10519,7 +10519,7 @@
 3-4	העת	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	עת	עת	NOUN	NOUN	Gender=Fem|Number=Sing	5	nsubj	_	_
-5	מתקיים	התקיים	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+5	מתקיים	התקיים	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ק.י.מ|VerbForm=Part	0	root	_	_
 6	ללא	ללא	ADP	ADP	_	7	case	_	_
 7	תמיכה	תמיכה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
 8	כלשהי	כלשהו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Ind	7	det	_	SpaceAfter=No
@@ -10544,7 +10544,7 @@
 12	גיליונות	גיליון	NOUN	NOUN	Gender=Masc|HebSource=ConvUncertainHead|Number=Plur	9	dep	_	_
 13-14	הרואים	_	_	_	_	_	_	_	_
 13	ה	ה	SCONJ	SCONJ	_	14	mark	_	_
-14	רואים	ראה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	12	acl:relcl	_	_
+14	רואים	ראה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ר.א.י|VerbForm=Part|Voice=Act	12	acl:relcl	_	_
 15	אור	אור	NOUN	NOUN	Gender=Masc|Number=Sing	14	dep	_	_
 16-17	בשנה	_	_	_	_	_	_	_	SpaceAfter=No
 16	ב	ב	ADP	ADP	_	17	case	_	_
@@ -10574,7 +10574,7 @@
 6	ו	ו	CCONJ	CCONJ	_	8	cc	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	ניהול	ניהול	NOUN	NOUN	Gender=Masc|Number=Sing	2	conj	_	_
-9	נעשים	נעשה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+9	נעשים	נעשה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=ע.ש.י|VerbForm=Part|Voice=Mid	0	root	_	_
 10-11	בהתנדבות	_	_	_	_	_	_	_	SpaceAfter=No
 10	ב	ב	ADP	ADP	_	11	case	_	_
 11	התנדבות	התנדבות	NOUN	NOUN	Gender=Fem|Number=Sing	9	obl	_	_
@@ -10630,7 +10630,7 @@
 12	-	-	PUNCT	PUNCT	_	11	flat:name	_	SpaceAfter=No
 13	יעקב	יעקב	PROPN	PROPN	_	11	flat:name	_	SpaceAfter=No
 14	,	,	PUNCT	PUNCT	_	15	punct	_	_
-15	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+15	קרא	קרא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ק.ר.א|Tense=Past|Voice=Act	0	root	_	_
 16-17	לשר	_	_	_	_	_	_	_	_
 16	ל	ל	ADP	ADP	_	17	case	_	_
 17	שר	שר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	15	obl	_	_
@@ -10641,12 +10641,12 @@
 21	דן	דן	PROPN	PROPN	_	17	appos	_	_
 22	מרידור	מרידור	PROPN	PROPN	_	21	flat:name	_	SpaceAfter=No
 23	,	,	PUNCT	PUNCT	_	15	punct	_	_
-24	ליזום	יזם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	15	xcomp	_	_
+24	ליזום	יזם	VERB	VERB	HebBinyan=PAAL|Root=י.ז.מ|VerbForm=Inf|Voice=Act	15	xcomp	_	_
 25	הצעות	הצעה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	24	obj	_	_
 26	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	25	compound:smixut	_	_
 27-28	שיקבעו	_	_	_	_	_	_	_	SpaceAfter=No
 27	ש	ש	SCONJ	SCONJ	_	28	mark	_	_
-28	יקבעו	קבע	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut	25	acl:relcl	_	_
+28	יקבעו	קבע	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ק.ב.ע|Tense=Fut	25	acl:relcl	_	_
 29	,	,	PUNCT	PUNCT	_	28	punct	_	_
 30	כי	כי	SCONJ	SCONJ	_	54	mark	_	_
 31	נציגי	נציג	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	54	nsubj	_	_
@@ -10682,7 +10682,7 @@
 52	מחוזיים	מחוזי	ADJ	ADJ	Gender=Masc|Number=Plur	50	amod	_	_
 53	לא	לא	ADV	ADV	Polarity=Neg	54	advmod	_	_
 54	יוכלו	יכול	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut|VerbType=Mod	55	aux	_	_
-55	להיבחר	נבחר	VERB	VERB	HebBinyan=NIFAL|VerbForm=Inf|Voice=Mid	28	ccomp	_	_
+55	להיבחר	נבחר	VERB	VERB	HebBinyan=NIFAL|Root=ב.ח.ר|VerbForm=Inf|Voice=Mid	28	ccomp	_	_
 56-59	לתפקידם	_	_	_	_	_	_	_	_
 56	ל	ל	ADP	ADP	_	57	case	_	_
 57	תפקיד_	תפקיד	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	55	obl	_	_
@@ -10708,7 +10708,7 @@
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	שר	שר	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod	_	_
 6	מרידור	מרידור	PROPN	PROPN	_	5	flat:name	_	_
-7	כתב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+7	כתב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ת.ב|Tense=Past|Voice=Act	0	root	_	_
 8	עו"ד	עו"ד	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	7	nsubj	_	_
 9	בן	בן	PROPN	PROPN	_	8	flat:name	_	SpaceAfter=No
 10	-	-	PUNCT	PUNCT	_	8	flat:name	_	SpaceAfter=No
@@ -10718,7 +10718,7 @@
 14	חברים	חבר	NOUN	NOUN	Gender=Masc|Number=Plur	25	nsubj	_	_
 15-16	העומדים	_	_	_	_	_	_	_	_
 15	ה	ה	SCONJ	SCONJ	_	16	mark	_	_
-16	עומדים	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	14	acl:relcl	_	_
+16	עומדים	עמד	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ע.מ.ד|VerbForm=Part|Voice=Act	14	acl:relcl	_	_
 17-18	בראש	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	ראש	ראש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	obl	_	_
@@ -10729,7 +10729,7 @@
 23-24	הדין	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	דין	דין	NOUN	NOUN	Gender=Masc|Number=Sing	20	compound:smixut	_	_
-25	באו	בא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	7	ccomp	_	_
+25	באו	בא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ב.ו.א|Tense=Past|Voice=Act	7	ccomp	_	_
 26	לידי	לידי	ADP	ADP	_	27	case	_	_
 27	הסכמים	הסכם	NOUN	NOUN	Gender=Masc|Number=Plur	25	obl	_	_
 28	צרי	צר	ADJ	ADJ	Definite=Cons|Gender=Masc|Number=Plur	27	amod	_	_
@@ -10737,7 +10737,7 @@
 30	,	,	PUNCT	PUNCT	_	27	punct	_	_
 31-32	המתעלמים	_	_	_	_	_	_	_	_
 31	ה	ה	SCONJ	SCONJ	_	32	mark	_	_
-32	מתעלמים	התעלם	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	27	acl:relcl	_	_
+32	מתעלמים	התעלם	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=ע.ל.מ|VerbForm=Part	27	acl:relcl	_	_
 33-35	מהאינטרס	_	_	_	_	_	_	_	_
 33	מ	מ	ADP	ADP	_	35	case	_	_
 34	ה	ה	DET	DET	PronType=Art	35	det:def	_	_
@@ -10750,7 +10750,7 @@
 39	כללי	כללי	ADJ	ADJ	Gender=Masc|Number=Sing	35	amod	_	_
 40-41	וחידשו	_	_	_	_	_	_	_	_
 40	ו	ו	CCONJ	CCONJ	_	41	cc	_	_
-41	חידשו	חידש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	32	conj	_	_
+41	חידשו	חידש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ח.ד.ש|Tense=Past|Voice=Act	32	conj	_	_
 42	את	את	ADP	ADP	Case=Acc	43	case:acc	_	_
 43-45	בחירתם	_	_	_	_	_	_	_	_
 43	בחירה_	בחירה	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	41	obj	_	_
@@ -10795,7 +10795,7 @@
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	ציבורית	ציבורי	ADJ	ADJ	Gender=Fem|Number=Sing	6	amod	_	_
 9	לא	לא	ADV	ADV	Polarity=Neg	10	advmod	_	_
-10	נמצאו	נמצא	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+10	נמצאו	נמצא	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=מ.צ.א|Tense=Past|Voice=Mid	0	root	_	_
 11	אצל	אצל	ADP	ADP	_	12	case	_	_
 12	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	10	obl	_	_
 13-17	שבידיהם	_	_	_	_	_	_	_	_
@@ -10810,13 +10810,13 @@
 20	הצבעה	הצבעה	NOUN	NOUN	Gender=Fem|Number=Sing	18	compound:smixut	_	_
 21	"	"	PUNCT	PUNCT	_	10	punct	_	SpaceAfter=No
 22	,	,	PUNCT	PUNCT	_	23	punct	_	_
-23	כתב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	parataxis	_	SpaceAfter=No
+23	כתב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ת.ב|Tense=Past|Voice=Act	10	parataxis	_	SpaceAfter=No
 24	,	,	PUNCT	PUNCT	_	23	punct	_	_
 25	"	"	PUNCT	PUNCT	_	10	punct	_	SpaceAfter=No
 26-27	והם	_	_	_	_	_	_	_	_
 26	ו	ו	CCONJ	CCONJ	HebSource=ConvUncertainHead	10	dep	_	_
 27	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	28	nsubj	_	_
-28	דאגו	דאג	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	10	parataxis	_	_
+28	דאגו	דאג	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ד.א.ג|Tense=Past|Voice=Act	10	parataxis	_	_
 29-30	לחידוש	_	_	_	_	_	_	_	_
 29	ל	ל	ADP	ADP	_	30	case	_	_
 30	חידוש	חידוש	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	28	obl	_	_
@@ -10824,7 +10824,7 @@
 32	עצמם	עצמו	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	31	compound:smixut	_	SpaceAfter=No
 33	,	,	PUNCT	PUNCT	_	28	punct	_	_
 34	במקום	במקום	ADP	ADP	_	35	case	_	_
-35	לחתור	חתר	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	28	advcl	_	_
+35	לחתור	חתר	VERB	VERB	HebBinyan=PAAL|Root=ח.ת.ר|VerbForm=Inf|Voice=Act	28	advcl	_	_
 36-37	לבחירת	_	_	_	_	_	_	_	_
 36	ל	ל	ADP	ADP	_	37	case	_	_
 37	בחירת	בחירה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	35	obl	_	_
@@ -10847,7 +10847,7 @@
 4	בחירות	בחירה	NOUN	NOUN	Gender=Fem|Number=Plur	2	conj	_	_
 5	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	2	det	_	_
 6	רק	רק	ADV	ADV	_	7	advmod	_	_
-7	מעמיקים	העמיק	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	58	advcl	_	_
+7	מעמיקים	העמיק	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ע.מ.ק|VerbForm=Part|Voice=Act	58	advcl	_	_
 8	את	את	ADP	ADP	Case=Acc	9	case:acc	_	_
 9	ליקוי	ליקוי	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obj	_	_
 10-11	המאורות	_	_	_	_	_	_	_	_
@@ -10857,7 +10857,7 @@
 12	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
 13	ב_	ב	ADP	ADP	_	14	case	_	_
 14	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	obl	_	_
-15	נמצאת	נמצא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	9	acl:relcl	_	_
+15	נמצאת	נמצא	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=מ.צ.א|VerbForm=Part|Voice=Mid	9	acl:relcl	_	_
 16	כיום	כיום	ADV	ADV	_	15	advmod	_	_
 17	לשכת	לשכה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	15	nsubj	_	_
 18	עורכי	עורך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	21	nmod	_	SpaceAfter=No
@@ -10876,7 +10876,7 @@
 29	ו	ו	CCONJ	CCONJ	_	30	cc	_	_
 30	כישורים	כישורים	NOUN	NOUN	Gender=Masc|Number=Plur	27	conj	_	_
 31	טובים	טוב	ADJ	ADJ	Gender=Masc|Number=Plur	30	amod	_	_
-32	מדירים	הדיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	15	advcl	_	_
+32	מדירים	הדיר	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=נ.ד.ר|VerbForm=Part|Voice=Act	15	advcl	_	_
 33-35	רגליהם	_	_	_	_	_	_	_	_
 33	רגל_	רגל	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Plur	32	obj	_	_
 34	_של_	של	ADP	ADP	_	35	case:gen	_	_
@@ -10897,7 +10897,7 @@
 46	מחנק	מחנק	NOUN	NOUN	Gender=Masc|Number=Sing	44	compound:smixut	_	_
 47-48	שיצרו	_	_	_	_	_	_	_	_
 47	ש	ש	SCONJ	SCONJ	_	48	mark	_	_
-48	יצרו	יצר	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	44	acl:relcl	_	_
+48	יצרו	יצר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.צ.ר|Tense=Past	44	acl:relcl	_	_
 49	חלק	חלק	NOUN	NOUN	Gender=Masc|Number=Sing	51	det	_	_
 50-53	מעסקניה	_	_	_	_	_	_	_	_
 50	מ	מ	ADP	ADP	HebSource=ConvUncertainLabel	51	case	_	_
@@ -10909,7 +10909,7 @@
 55	מרכזיים	מרכזי	ADJ	ADJ	Gender=Masc|Number=Plur	51	amod	_	_
 56	"	"	PUNCT	PUNCT	_	7	punct	_	SpaceAfter=No
 57	,	,	PUNCT	PUNCT	_	58	punct	_	_
-58	כותב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+58	כותב	כתב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ת.ב|VerbForm=Part|Voice=Act	0	root	_	_
 59	עו"ד	עו"ד	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	58	nsubj	_	_
 60	בן	בן	PROPN	PROPN	_	59	flat:name	_	SpaceAfter=No
 61	-	-	PUNCT	PUNCT	_	59	flat:name	_	SpaceAfter=No
@@ -10935,7 +10935,7 @@
 12	אבן	אבן	PROPN	PROPN	_	11	flat:name	_	_
 13	גבירול	גבירול	PROPN	PROPN	_	11	flat:name	_	SpaceAfter=No
 14	,	,	PUNCT	PUNCT	_	15	punct	_	_
-15	מבהיקה	הבהיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+15	מבהיקה	הבהיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ב.ה.ק|VerbForm=Part|Voice=Act	0	root	_	_
 16-19	בלובנה	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	לובן_	לובן	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	15	obl	_	_
@@ -10960,7 +10960,7 @@
 34	,	,	PUNCT	PUNCT	_	29	punct	_	_
 35-36	המתנשא	_	_	_	_	_	_	_	_
 35	ה	ה	SCONJ	SCONJ	_	36	mark	_	_
-36	מתנשא	התנשא	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	29	acl:relcl	_	_
+36	מתנשא	התנשא	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=נ.ש.א|VerbForm=Part	29	acl:relcl	_	_
 37	כמעט	כמעט	ADV	ADV	_	38	advmod	_	_
 38-39	לגובה	_	_	_	_	_	_	_	_
 38	ל	ל	ADP	ADP	_	39	case	_	_
@@ -10991,7 +10991,7 @@
 12	,	,	PUNCT	PUNCT	_	2	punct	_	_
 13-14	הנושא	_	_	_	_	_	_	_	_
 13	ה	ה	SCONJ	SCONJ	_	14	mark	_	_
-14	נושא	נשא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	acl:relcl	_	_
+14	נושא	נשא	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ש.א|VerbForm=Part|Voice=Act	2	acl:relcl	_	_
 15	את	את	ADP	ADP	Case=Acc	16	case:acc	_	_
 16-18	שמו	_	_	_	_	_	_	_	_
 16	שם_	שם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	14	obj	_	_
@@ -11011,7 +11011,7 @@
 # sent_id = 6055
 # text = הוא נבנה בשנות ה07 בצדו המערבי של רחוב בן-סרוק.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	נבנה	נבנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+2	נבנה	נבנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ב.נ.י|Tense=Past|Voice=Mid	0	root	_	_
 3-4	בשנות	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	שנות	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	2	obl	_	_
@@ -11055,7 +11055,7 @@
 14	רחוב	רחוב	NOUN	NOUN	Gender=Masc|Number=Sing	8	nmod:poss	_	_
 15	קצר	קצר	ADJ	ADJ	Gender=Masc|Number=Sing	14	amod	_	_
 16	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	14	det	_	_
-17	פונים	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+17	פונים	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=פ.נ.י|VerbForm=Part|Voice=Act	0	root	_	_
 18	מערבה	מערבה	ADV	ADV	_	17	advmod	_	_
 19	אל	אל	ADP	ADP	_	20	case	_	_
 20-22	שרידיו	_	_	_	_	_	_	_	_
@@ -11080,7 +11080,7 @@
 36	קטנים	קטן	ADJ	ADJ	Gender=Masc|Number=Plur	34	amod	_	_
 37-38	ומגובבים	_	_	_	_	_	_	_	SpaceAfter=No
 37	ו	ו	CCONJ	CCONJ	_	38	cc	_	_
-38	מגובבים	גובב	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	36	conj	_	_
+38	מגובבים	גובב	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ג.ב.ב|VerbForm=Part|Voice=Pass	36	conj	_	_
 39	,	,	PUNCT	PUNCT	_	34	punct	_	_
 40-44	שלחלקם	_	_	_	_	_	_	_	_
 40	ש	ש	SCONJ	SCONJ	_	42	mark	_	_
@@ -11093,7 +11093,7 @@
 47	אדומים	אדום	ADJ	ADJ	Gender=Masc|Number=Plur	45	amod	_	_
 48-49	הנאחזים	_	_	_	_	_	_	_	_
 48	ה	ה	SCONJ	SCONJ	_	49	mark	_	_
-49	נאחזים	נאחז	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	34	acl:relcl	_	_
+49	נאחזים	נאחז	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=א.ח.ז|VerbForm=Part|Voice=Mid	34	acl:relcl	_	_
 50	עדיין	עדיין	ADV	ADV	_	49	advmod	_	_
 51-52	בעקשנות	_	_	_	_	_	_	_	_
 51	ב	ב	ADP	ADP	_	52	case	_	_
@@ -11110,8 +11110,8 @@
 60	חוזרים	חוזר	ADJ	ADJ	Gender=Masc|Number=Plur	59	amod	_	_
 61-62	ונשנים	_	_	_	_	_	_	_	_
 61	ו	ו	CCONJ	CCONJ	_	62	cc	_	_
-62	נשנים	נשנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	60	conj	_	_
-63	לפנות	פינה	VERB	VERB	VerbForm=Inf	59	acl	_	_
+62	נשנים	נשנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=ש.נ.י|VerbForm=Part|Voice=Mid	60	conj	_	_
+63	לפנות	פינה	VERB	VERB	HebBinyan=PIEL|Root=פ.נ.י|VerbForm=Inf	59	acl	_	_
 64-65	אותם	_	_	_	_	_	_	_	SpaceAfter=No
 64	את_	את_	ADP	ADP	Case=Acc	65	case:acc	_	_
 65	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	63	obj	_	_
@@ -11128,9 +11128,9 @@
 5	שטח	שטח	NOUN	NOUN	Gender=Masc|Number=Sing	2	conj	_	_
 6-7	שפנה	_	_	_	_	_	_	_	SpaceAfter=No
 6	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
-7	פנה	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	5	acl:relcl	_	_
+7	פנה	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.נ.י|Tense=Past|Voice=Act	5	acl:relcl	_	_
 8	,	,	PUNCT	PUNCT	_	9	punct	_	_
-9	הקים	הקים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+9	הקים	הקים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ק.ו.מ|Tense=Past|Voice=Act	0	root	_	_
 10-11	האדריכל	_	_	_	_	_	_	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	אדריכל	אדריכל	NOUN	NOUN	Gender=Masc|Number=Sing	9	nsubj	_	_
@@ -11146,8 +11146,8 @@
 # sent_id = 6058
 # text = הוא ניסה לשוות לו מראה ייחודי וסימבולי ובחר בצורות אורגניות, המזכירות את תנועת גלי הים, אולי כרמז לימה של סלוניקי.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	ניסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
-3	לשוות	שיווה	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	2	xcomp	_	_
+2	ניסה	ניסה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=נ.ס.י|Tense=Past|Voice=Act	0	root	_	_
+3	לשוות	שיווה	VERB	VERB	HebBinyan=PIEL|Root=ש.ו.י|VerbForm=Inf|Voice=Act	2	xcomp	_	_
 4-5	לו	_	_	_	_	_	_	_	_
 4	ל_	ל	ADP	ADP	_	5	case	_	_
 5	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	obl	_	_
@@ -11158,7 +11158,7 @@
 9	סימבולי	_	ADJ	ADJ	_	7	conj	_	_
 10-11	ובחר	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
-11	בחר	בחר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	conj	_	_
+11	בחר	בחר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ב.ח.ר|Tense=Past|Voice=Act	2	conj	_	_
 12-13	בצורות	_	_	_	_	_	_	_	_
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	צורות	צורה	NOUN	NOUN	Gender=Fem|Number=Plur	11	obl	_	_
@@ -11166,7 +11166,7 @@
 15	,	,	PUNCT	PUNCT	_	13	punct	_	_
 16-17	המזכירות	_	_	_	_	_	_	_	_
 16	ה	ה	SCONJ	SCONJ	_	17	mark	_	_
-17	מזכירות	הזכיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	13	acl:relcl	_	_
+17	מזכירות	הזכיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ז.כ.ר|VerbForm=Part|Voice=Act	13	acl:relcl	_	_
 18	את	את	ADP	ADP	Case=Acc	19	case:acc	_	_
 19	תנועת	תנועה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	17	obj	_	_
 20	גלי	גל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	19	compound:smixut	_	_
@@ -11203,7 +11203,7 @@
 11	,	,	PUNCT	PUNCT	_	6	punct	_	_
 12-13	הבנוי	_	_	_	_	_	_	_	_
 12	ה	ה	SCONJ	SCONJ	_	13	mark	_	_
-13	בנוי	בנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
+13	בנוי	בנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ב.נ.י|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
 14-15	כחץ	_	_	_	_	_	_	_	_
 14	כ	כ	ADP	ADP	_	15	case	_	_
 15	חץ	חץ	NOUN	NOUN	Gender=Masc|Number=Sing	13	obl	_	_
@@ -11222,7 +11222,7 @@
 5-6	הקדמי	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	קדמי	קדמי	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-7	ממוקם	מוקם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+7	ממוקם	מוקם	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=מ.ק.מ|VerbForm=Part|Voice=Pass	0	root	_	_
 8	ארון	ארון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	nsubj	_	_
 9-10	הקודש	_	_	_	_	_	_	_	SpaceAfter=No
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -11253,7 +11253,7 @@
 12	,	,	PUNCT	PUNCT	_	8	punct	_	_
 13-14	המטילים	_	_	_	_	_	_	_	_
 13	ה	ה	SCONJ	SCONJ	_	14	mark	_	_
-14	מטילים	הטיל	VERB	VERB	Gender=Masc|Number=Plur|Person=1,2,3|VerbForm=Part	8	acl:relcl	_	_
+14	מטילים	הטיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ט.ו.ל|VerbForm=Part	8	acl:relcl	_	_
 15	אור	אור	NOUN	NOUN	Gender=Masc|Number=Sing	14	obj	_	_
 16-17	לכיוון	_	_	_	_	_	_	_	_
 16	ל	ל	ADP	ADP	_	17	case	_	_
@@ -11274,13 +11274,13 @@
 1-2	הקונכייה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	קונכייה	קונכייה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	מתרוממת	התרומם	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+3	מתרוממת	התרומם	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ר.ו.מ|VerbForm=Part	0	root	_	_
 4-5	בהדרגה	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	הדרגה	הדרגה	NOUN	NOUN	Gender=Fem|Number=Sing	3	obl	_	_
 6-7	ומגיעה	_	_	_	_	_	_	_	_
 6	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
-7	מגיעה	הגיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	conj	_	_
+7	מגיעה	הגיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=נ.ג.ע|VerbForm=Part|Voice=Act	3	conj	_	_
 8-9	לשיא	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	שיא	שיא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	obl	_	_
@@ -11297,7 +11297,7 @@
 17	,	,	PUNCT	PUNCT	_	12	punct	_	_
 18-19	הכוללת	_	_	_	_	_	_	_	_
 18	ה	ה	SCONJ	SCONJ	_	19	mark	_	_
-19	כוללת	כלל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	12	acl:relcl	_	_
+19	כוללת	כלל	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	12	acl:relcl	_	_
 20	את	את	ADP	ADP	Case=Acc	21	case:acc	_	_
 21	יציע	יציע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	19	obj	_	_
 22	עזרת	עזרה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	21	compound:smixut	_	_
@@ -11318,7 +11318,7 @@
 6-7	המעטפת	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	מעטפת	מעטפת	NOUN	NOUN	Gender=Fem|Number=Sing	2	nmod	_	_
-8	מתחלף	התחלף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+8	מתחלף	התחלף	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ח.ל.פ|VerbForm=Part	0	root	_	_
 9-11	בצפון	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	11	case	_	_
 10	ה_	ה	DET	DET	PronType=Art	11	det:def	_	_
@@ -11331,7 +11331,7 @@
 16	,	,	PUNCT	PUNCT	_	14	punct	_	_
 17-18	הנשענות	_	_	_	_	_	_	_	_
 17	ה	ה	SCONJ	SCONJ	_	18	mark	_	_
-18	נשענות	נשען	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	14	acl:relcl	_	_
+18	נשענות	נשען	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=ש.ע.נ|VerbForm=Part|Voice=Mid	14	acl:relcl	_	_
 19	על	על	ADP	ADP	_	20	case	_	_
 20	קיר	קיר	NOUN	NOUN	Gender=Masc|Number=Sing	18	obl	_	_
 21	יצוק	יצוק	ADJ	ADJ	Gender=Masc|Number=Sing	20	amod	_	_
@@ -11356,7 +11356,7 @@
 4	ל	ל	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	בניין	בניין	NOUN	NOUN	Gender=Masc|Number=Sing	3	nmod	_	_
-7	מובילה	הוביל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+7	מובילה	הוביל	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=י.ב.ל|VerbForm=Part|Voice=Act	0	root	_	_
 8	רחבה	רחבה	NOUN	NOUN	Gender=Fem|Number=Sing	7	nsubj	_	_
 9	קטנת	קטן	ADJ	ADJ	Definite=Cons|Gender=Fem|Number=Sing	11	dep	_	SpaceAfter=No
 10	-	-	PUNCT	PUNCT	_	11	punct	_	SpaceAfter=No
@@ -11379,7 +11379,7 @@
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	בניין	בניין	NOUN	NOUN	_	6	nsubj	_	_
 5	אינו	אינו	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	6	advmod	_	_
-6	ניצב	_	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1|VerbForm=Part|Voice=Mid	16	obl	_	_
+6	ניצב	_	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1|Root=י.צ.ב|VerbForm=Part|Voice=Mid	16	obl	_	_
 7-9	לרחוב	_	_	_	_	_	_	_	SpaceAfter=No
 7	ל	ל	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
@@ -11391,7 +11391,7 @@
 13	ל_	ל	ADP	ADP	_	14	case	_	_
 14	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	advmod	_	_
 15	,	,	PUNCT	PUNCT	_	16	punct	_	_
-16	נגרע	נגרע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+16	נגרע	נגרע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ג.ר.ע|Tense=Past|Voice=Mid	0	root	_	_
 17-20	מרושמה	_	_	_	_	_	_	_	_
 17	מ	מ	ADP	ADP	_	18	case	_	_
 18	רושם_	רושם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	16	obl	_	_
@@ -11402,7 +11402,7 @@
 22	ייצוגי	_	ADJ	ADJ	_	18	amod	_	_
 23-24	המצופה	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
-24	מצופה	צופה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	18	amod	_	_
+24	מצופה	צופה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=צ.פ.י|VerbForm=Part|Voice=Pass	18	amod	_	_
 25	של	של	ADP	ADP	Case=Gen	27	case:gen	_	_
 26-27	החזית	_	_	_	_	_	_	_	SpaceAfter=No
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
@@ -11411,7 +11411,7 @@
 
 # sent_id = 6066
 # text = מעוררת תמיהות העובדה שבניין כה יוצא דופן, שמסריו טכסיים-דתיים וחזותו סימבולית ורגשנית, נבנה לאורך הרחוב כבית מגורים מהשורה.
-1	מעוררת	עורר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+1	מעוררת	עורר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ע.ו.ר|VerbForm=Part|Voice=Act	0	root	_	_
 2	תמיהות	תמיהה	NOUN	NOUN	Gender=Fem|Number=Plur	1	obj	_	_
 3-4	העובדה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
@@ -11441,7 +11441,7 @@
 23	ו	ו	CCONJ	CCONJ	_	24	cc	_	_
 24	רגשנית	רגשני	ADJ	ADJ	Gender=Fem|Number=Sing	22	conj	_	_
 25	,	,	PUNCT	PUNCT	_	26	punct	_	_
-26	נבנה	נבנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	acl:relcl	_	_
+26	נבנה	נבנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ב.נ.י|Tense=Past|Voice=Mid	4	acl:relcl	_	_
 27	לאורך	לאורך	ADP	ADP	_	29	case	_	_
 28-29	הרחוב	_	_	_	_	_	_	_	_
 28	ה	ה	DET	DET	PronType=Art	29	det:def	_	_
@@ -11464,7 +11464,7 @@
 3	מיקוד	מיקוד	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
 4-5	הרווח	_	_	_	_	_	_	_	_
 4	ה	ה	SCONJ	SCONJ	_	5	mark	_	_
-5	רווח	רווח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
+5	רווח	רווח	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.ו.ח|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
 6-7	בתל	_	_	_	_	_	_	_	SpaceAfter=No
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	תל	תל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
@@ -11479,7 +11479,7 @@
 14	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
 15	ב_	ב	ADP	ADP	_	16	case	_	_
 16	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	17	obl	_	_
-17	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	13	acl:relcl	_	_
+17	נקבע	נקבע	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ק.ב.ע|VerbForm=Part|Voice=Mid	13	acl:relcl	_	_
 18-20	מיקומם	_	_	_	_	_	_	_	_
 18	מיקום_	מיקום	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	17	nsubj	_	_
 19	_של_	של	ADP	ADP	_	20	case:gen	_	_
@@ -11494,14 +11494,14 @@
 27	מקום	מקום	NOUN	NOUN	Gender=Masc|Number=Sing	18	nmod	_	_
 28-29	שנמצא	_	_	_	_	_	_	_	_
 28	ש	ש	SCONJ	SCONJ	_	29	mark	_	_
-29	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	27	acl:relcl	_	_
+29	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=מ.צ.א|VerbForm=Part|Voice=Mid	27	acl:relcl	_	_
 30-31	בו	_	_	_	_	_	_	_	_
 30	ב_	ב	ADP	ADP	_	31	case	_	_
 31	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	29	obl	_	_
 32	מגרש	מגרש	NOUN	NOUN	Gender=Masc|Number=Sing	29	nsubj	_	_
 33	זמין	זמין	ADJ	ADJ	Gender=Masc|Number=Sing	32	amod	_	SpaceAfter=No
 34	,	,	PUNCT	PUNCT	_	35	punct	_	_
-35	גורמים	גרם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+35	גורמים	גרם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ג.ר.מ|VerbForm=Part|Voice=Act	0	root	_	_
 36-38	לעיר	_	_	_	_	_	_	_	_
 36	ל	ל	ADP	ADP	_	38	case	_	_
 37	ה_	ה	DET	DET	PronType=Art	38	det:def	_	_
@@ -11528,7 +11528,7 @@
 7	כ	כ	ADP	ADP	_	9	case	_	_
 8	ה_	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	6	nmod	_	_
-10	יוצב	הוצב	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Fut|Voice=Pass	3	advcl	_	_
+10	יוצב	הוצב	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=י.צ.ב|Tense=Fut|Voice=Pass	3	advcl	_	_
 11-12	באופן	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	אופן	אופן	NOUN	NOUN	Gender=Masc|Number=Sing	10	obl	_	_
@@ -11537,7 +11537,7 @@
 14	ניתן	ניתן	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	16	aux	_	_
 15	יהיה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	14	cop	_	_
 16-18	לראותו	_	_	_	_	_	_	_	SpaceAfter=No
-16	לראותו	_	VERB	VERB	VerbForm=Inf	12	acl:relcl	_	_
+16	לראותו	_	VERB	VERB	HebBinyan=PAAL|Root=ר.א.י|VerbForm=Inf	12	acl:relcl	_	_
 17	את	את	ADP	ADP	Case=Acc	18	case	_	_
 18	_הוא	הוא	PRON	PRON	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	obj	_	_
 19	,	,	PUNCT	PUNCT	_	14	punct	_	_
@@ -11570,7 +11570,7 @@
 10	,	,	PUNCT	PUNCT	_	7	punct	_	_
 11-12	שהתפתחו	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-12	התפתחו	התפתח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	7	acl:relcl	_	_
+12	התפתחו	התפתח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=פ.ת.ח|Tense=Past	7	acl:relcl	_	_
 13-14	מצומת	_	_	_	_	_	_	_	_
 13	מ	מ	ADP	ADP	_	14	case	_	_
 14	צומת	צומת	NOUN	NOUN	Gender=Fem|Number=Sing	12	obl	_	_
@@ -11598,7 +11598,7 @@
 31	כיכר	כיכר	NOUN	NOUN	Gender=Fem|Number=Sing	28	conj	_	_
 32	אחרת	אחר	ADJ	ADJ	Gender=Fem|Number=Sing	31	amod	_	SpaceAfter=No
 33	,	,	PUNCT	PUNCT	_	34	punct	_	_
-34	נבנתה	נבנה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+34	נבנתה	נבנה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ב.נ.י|Tense=Past|Voice=Mid	0	root	_	_
 35	תל	תל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	34	nsubj	_	SpaceAfter=No
 36	-	-	PUNCT	PUNCT	_	35	flat:name	_	SpaceAfter=No
 37	אביב	אביב	NOUN	NOUN	Gender=Masc|Number=Sing	35	flat:name	_	_
@@ -11614,7 +11614,7 @@
 45	ש	ש	SCONJ	SCONJ	_	48	mark	_	_
 46	בין_	בין	ADP	ADP	_	47	case	_	_
 47	_הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	48	obl	_	_
-48	משובצים	שובץ	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	42	acl:relcl	_	_
+48	משובצים	שובץ	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ש.ב.צ|VerbForm=Part|Voice=Pass	42	acl:relcl	_	_
 49-50	כיד	_	_	_	_	_	_	_	_
 49	כ	כ	ADP	ADP	_	50	case	_	_
 50	יד	יד	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	48	obl	_	_
@@ -11626,19 +11626,19 @@
 54	ה	ה	DET	DET	PronType=Art	55	det:def	_	_
 55	מקוריות	מקורי	ADJ	ADJ	Gender=Fem|Number=Plur	50	conj	_	_
 56	מבני	מבנה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	48	nsubj	_	_
-57	צבור	צבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	56	compound:smixut	_	SpaceAfter=No
+57	צבור	צבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=_|VerbForm=Part|Voice=Act	56	compound:smixut	_	SpaceAfter=No
 58	.	.	PUNCT	PUNCT	_	34	punct	_	_
 
 # sent_id = 6070
 # text = כאשר נבנה בית הכנסת טרם נולד המושג פוסט-מודרניזם, אך התפיסה הסימבולית היתה מקובלת אז.
 1	כאשר	כאשר	SCONJ	SCONJ	_	2	mark	_	_
-2	נבנה	נבנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	7	advcl	_	_
+2	נבנה	נבנה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ב.נ.י|Tense=Past|Voice=Mid	7	advcl	_	_
 3	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	2	nsubj	_	_
 4-5	הכנסת	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	כנסת	כנסת	PROPN	PROPN	_	3	compound:smixut	_	_
 6	טרם	טרם	ADV	ADV	_	7	advmod	_	_
-7	נולד	נולד	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+7	נולד	נולד	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.ל.ד|Tense=Past|Voice=Mid	0	root	_	_
 8-9	המושג	_	_	_	_	_	_	_	_
 8	ה	ה	DET	DET	PronType=Art	9	det:def	_	_
 9	מושג	מושג	NOUN	NOUN	Gender=Masc|Number=Sing	7	nsubj	_	_
@@ -11654,7 +11654,7 @@
 17	ה	ה	DET	DET	PronType=Art	18	det:def	_	_
 18	סימבולית	_	ADJ	ADJ	_	16	amod	_	_
 19	היתה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	20	cop	_	_
-20	מקובלת	_	VERB	VERB	VerbForm=Part	7	conj	_	_
+20	מקובלת	_	VERB	VERB	HebBinyan=PUAL|Root=ק.ב.ל|VerbForm=Part	7	conj	_	_
 21	אז	אז	ADV	ADV	_	20	advmod	_	SpaceAfter=No
 22	.	.	PUNCT	PUNCT	_	7	punct	_	_
 
@@ -11665,14 +11665,14 @@
 2	מחולל_	מחולל	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	5	obl	_	_
 3	_של_	של	ADP	ADP	_	4	case:gen	_	_
 4	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nmod:poss	_	_
-5	היה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+5	היה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 6	לה	לה	PROPN	PROPN	_	5	nsubj	_	SpaceAfter=No
 7	-	-	PUNCT	PUNCT	_	6	flat:name	_	SpaceAfter=No
 8	קורוואזיה	קורוואזיה	PROPN	PROPN	_	6	flat:name	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	6	punct	_	_
 10-11	שבנה	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	בנה	בנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	6	acl:relcl	_	_
+11	בנה	בנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ב.נ.י|Tense=Past|Voice=Act	6	acl:relcl	_	_
 12	את	את	ADP	ADP	Case=Acc	14	case:acc	_	_
 13-14	הכנסייה	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
@@ -11689,7 +11689,7 @@
 # sent_id = 6072
 # text = זאת הוותה מודל חיקוי למבני דת רבים.
 1	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	3	nsubj	_	_
-2	הוותה	_	VERB	VERB	VerbForm=Part	3	aux	_	_
+2	הוותה	_	VERB	VERB	HebBinyan=PIEL|Root=ה.ו.י|VerbForm=Part	3	aux	_	_
 3	מודל	מודל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	0	root	_	_
 4	חיקוי	חיקוי	NOUN	NOUN	Gender=Masc|Number=Sing	3	compound:smixut	_	_
 5-6	למבני	_	_	_	_	_	_	_	_
@@ -11712,7 +11712,7 @@
 9	,	,	PUNCT	PUNCT	_	6	punct	_	_
 10-11	המספר	_	_	_	_	_	_	_	_
 10	ה	ה	SCONJ	SCONJ	_	11	mark	_	_
-11	מספר	סיפר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
+11	מספר	סיפר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ס.פ.ר|VerbForm=Part|Voice=Act	6	acl:relcl	_	_
 12	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 13-15	סיפורו	_	_	_	_	_	_	_	_
 13	סיפור_	סיפור	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	11	obj	_	_
@@ -11727,8 +11727,8 @@
 21	פלסטיים	פלסטי	ADJ	ADJ	Gender=Masc|Number=Plur	20	amod	_	_
 22-23	ושואף	_	_	_	_	_	_	_	_
 22	ו	ו	CCONJ	CCONJ	_	23	cc	_	_
-23	שואף	שאף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	11	conj	_	_
-24	להשפיע	השפיע	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	23	xcomp	_	_
+23	שואף	שאף	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ש.א.פ|VerbForm=Part|Voice=Act	11	conj	_	_
+24	להשפיע	השפיע	VERB	VERB	HebBinyan=HIFIL|Root=ש.פ.ע|VerbForm=Inf|Voice=Act	23	xcomp	_	_
 25	על	על	ADP	ADP	_	26	case	_	_
 26-28	קהלו	_	_	_	_	_	_	_	_
 26	קהל_	קהל	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	24	obl	_	_
@@ -11775,7 +11775,7 @@
 59	מובאות	מובאה	NOUN	NOUN	Gender=Fem|Number=Plur	54	conj	_	_
 60-61	המוטבעות	_	_	_	_	_	_	_	_
 60	ה	ה	SCONJ	SCONJ	_	61	mark	_	_
-61	מוטבעות	הוטבע	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	59	acl:relcl	_	_
+61	מוטבעות	הוטבע	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ט.ב.ע|VerbForm=Part|Voice=Pass	59	acl:relcl	_	_
 62-64	בבטון	_	_	_	_	_	_	_	_
 62	ב	ב	ADP	ADP	_	64	case	_	_
 63	ה_	ה	DET	DET	PronType=Art	64	det:def	_	_
@@ -11795,7 +11795,7 @@
 74	חלל	חלל	NOUN	NOUN	Gender=Masc|Number=Sing	36	conj	_	_
 75-76	המתקמר	_	_	_	_	_	_	_	SpaceAfter=No
 75	ה	ה	DET	DET	PronType=Art	76	det:def	_	_
-76	מתקמר	התקמר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	74	amod	_	_
+76	מתקמר	התקמר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ק.מ.ר|VerbForm=Part	74	amod	_	_
 77	,	,	PUNCT	PUNCT	_	36	punct	_	_
 78-79	הסורגים	_	_	_	_	_	_	_	_
 78	ה	ה	DET	DET	PronType=Art	79	det:def	_	_
@@ -11833,11 +11833,11 @@
 2	ראוותנות	ראוותנות	NOUN	NOUN	Gender=Fem|Number=Sing	7	nsubj	_	_
 3-4	השוצפת	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
-4	שוצפת	שצף	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	amod	_	_
+4	שוצפת	שצף	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ש.צ.פ|VerbForm=Part|Voice=Act	2	amod	_	_
 5-6	הזאת	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	2	det	_	_
-7	מגבירה	הגביר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+7	מגבירה	הגביר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ג.ב.ר|VerbForm=Part|Voice=Act	0	root	_	_
 8-9	לעוצמה	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	עוצמה	עוצמה	NOUN	NOUN	Gender=Fem|Number=Sing	7	obl	_	_
@@ -11856,7 +11856,7 @@
 2	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	כך	כך	PRON	PRON	Person=3|PronType=Dem	5	obl	_	_
-5	משתקפת	השתקף	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	1	ccomp	_	_
+5	משתקפת	השתקף	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ש.ק.פ|VerbForm=Part	1	ccomp	_	_
 6-7	הפרובלמטיקה	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
 7	פרובלמטיקה	פרובלמטיקה	NOUN	NOUN	_	5	nsubj	_	_
@@ -11887,7 +11887,7 @@
 # text = בתי כנסת נבנו ברובם תוך סיגול הסגנונות המקומיים המקובלים בזמנם, וייחודם הצטנע לארגון הפנימי, שנבע מהצרכים הטכסיים, ללא התפתחותה של סכימה ארכיטקטונית כבכנסייה הנוצרית לדורותיה.
 1	בתי	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	3	nsubj	_	_
 2	כנסת	כנסת	PROPN	PROPN	_	1	compound:smixut	_	_
-3	נבנו	נבנה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+3	נבנו	נבנה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ב.נ.י|Tense=Past|Voice=Mid	0	root	_	_
 4-7	ברובם	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	רוב_	רוב	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
@@ -11903,7 +11903,7 @@
 13	מקומיים	מקומי	ADJ	ADJ	Gender=Masc|Number=Plur	11	amod	_	_
 14-15	המקובלים	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	mark	_	_
-15	מקובלים	_	VERB	VERB	VerbForm=Part	11	acl:relcl	_	_
+15	מקובלים	_	VERB	VERB	HebBinyan=PUAL|Root=ק.ב.ל|VerbForm=Part	11	acl:relcl	_	_
 16-19	בזמנם	_	_	_	_	_	_	_	SpaceAfter=No
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	זמן_	זמן	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	15	obl	_	_
@@ -11915,7 +11915,7 @@
 22	ייחוד_	ייחוד	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	25	nsubj	_	_
 23	_של_	של	ADP	ADP	_	24	case:gen	_	_
 24	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	22	nmod:poss	_	_
-25	הצטנע	הצטנע	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	3	conj	_	_
+25	הצטנע	הצטנע	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=צ.נ.ע|Tense=Past	3	conj	_	_
 26-28	לארגון	_	_	_	_	_	_	_	_
 26	ל	ל	ADP	ADP	_	28	case	_	_
 27	ה_	ה	DET	DET	PronType=Art	28	det:def	_	_
@@ -11926,7 +11926,7 @@
 31	,	,	PUNCT	PUNCT	_	28	punct	_	_
 32-33	שנבע	_	_	_	_	_	_	_	_
 32	ש	ש	SCONJ	SCONJ	_	33	mark	_	_
-33	נבע	נבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	28	acl:relcl	_	_
+33	נבע	נבע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=נ.ב.ע|Tense=Past|Voice=Act	28	acl:relcl	_	_
 34-36	מהצרכים	_	_	_	_	_	_	_	_
 34	מ	מ	ADP	ADP	_	36	case	_	_
 35	ה	ה	DET	DET	PronType=Art	36	det:def	_	_
@@ -11960,7 +11960,7 @@
 
 # sent_id = 6079
 # text = לקחו בכך חלק גזרות השלטון והקיום היהודי כמיעוט.
-1	לקחו	לקח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+1	לקחו	לקח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ל.ק.ח|Tense=Past|Voice=Act	0	root	_	_
 2-3	בכך	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	3	case	_	_
 3	כך	כך	PRON	PRON	Person=3|PronType=Dem	1	obl	_	_
@@ -12000,14 +12000,14 @@
 12	מדינית	מדיני	ADJ	ADJ	Gender=Fem|Number=Sing	11	amod	_	_
 13	יהודית	יהודי	ADJ	ADJ	Gender=Fem|Number=Sing	11	amod	_	SpaceAfter=No
 14	,	,	PUNCT	PUNCT	_	15	punct	_	_
-15	הביאו	הביא	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+15	הביאו	הביא	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=ב.ו.א|Tense=Past|Voice=Act	0	root	_	_
 16-17	לאימוץ	_	_	_	_	_	_	_	_
 16	ל	ל	ADP	ADP	_	17	case	_	_
 17	אימוץ	אימוץ	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	15	obl	_	_
 18	כמה	כמה	DET	DET	Definite=Cons	19	det	_	_
 19	דימויים	דימוי	NOUN	NOUN	Gender=Masc|Number=Plur	17	compound:smixut	_	_
 20	ארכיטקטוניים	ארכיטקטוני	ADJ	ADJ	Gender=Masc|Number=Plur	19	amod	_	_
-21	מאפיינים	אפיין	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	19	amod	_	SpaceAfter=No
+21	מאפיינים	אפיין	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=א.פ.י.נ|VerbForm=Part|Voice=Act	19	amod	_	SpaceAfter=No
 22	.	.	PUNCT	PUNCT	_	15	punct	_	_
 
 # sent_id = 6081
@@ -12031,7 +12031,7 @@
 13	סלע	סלע	NOUN	NOUN	Gender=Masc|Number=Sing	11	compound:smixut	_	_
 14-15	שהפכה	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
-15	הפכה	הפך	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	18	aux	_	_
+15	הפכה	הפך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ה.פ.כ|Tense=Past	18	aux	_	_
 16-18	ל"מזרח	_	_	_	_	_	_	_	SpaceAfter=No
 16	ל	ל	ADP	ADP	_	18	case	_	_
 17	"	"	PUNCT	PUNCT	_	18	punct	_	_
@@ -12039,7 +12039,7 @@
 19	"	"	PUNCT	PUNCT	_	18	punct	_	_
 20-21	המסמל	_	_	_	_	_	_	_	_
 20	ה	ה	SCONJ	SCONJ	_	21	mark	_	_
-21	מסמל	סימל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	18	acl:relcl	_	_
+21	מסמל	סימל	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ס.מ.ל|VerbForm=Part|Voice=Act	18	acl:relcl	_	_
 22	את	את	ADP	ADP	Case=Acc	23	case:acc	_	_
 23	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	21	obj	_	_
 24-25	המקדש	_	_	_	_	_	_	_	_
@@ -12061,13 +12061,13 @@
 35	ה	ה	DET	DET	PronType=Art	36	det:def	_	_
 36	קשתות	קשת	NOUN	NOUN	Gender=Fem|Number=Plur	2	conj	_	_
 37	,	,	PUNCT	PUNCT	_	38	punct	_	_
-38	נעשו	נעשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+38	נעשו	נעשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ע.ש.י|Tense=Past|Voice=Mid	0	root	_	_
 39-40	מאז	_	_	_	_	_	_	_	_
 39	מ	מ	ADP	ADP	_	38	dep	_	_
 40	אז	אז	ADV	ADV	_	39	fixed	_	_
 41-42	למסמנים	_	_	_	_	_	_	_	_
 41	ל	ל	ADP	ADP	_	42	case	_	_
-42	מסמנים	סימן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	38	obl	_	_
+42	מסמנים	סימן	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ס.מ.נ|VerbForm=Part|Voice=Act	38	obl	_	_
 43-44	המקובלים	_	_	_	_	_	_	_	_
 43	ה	ה	DET	DET	PronType=Art	44	det:def	_	_
 44	מקובלים	מקובל	ADJ	ADJ	Gender=Masc|Number=Plur	42	amod	_	_
@@ -12077,7 +12077,7 @@
 47	ה	ה	DET	DET	PronType=Art	48	det:def	_	_
 48	כנסת	כנסת	PROPN	PROPN	_	46	compound:smixut	_	_
 49	אשר	אשר	SCONJ	SCONJ	_	50	mark	_	_
-50	נבנו	נבנה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	46	acl:relcl	_	_
+50	נבנו	נבנה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ב.נ.י|Tense=Past|Voice=Mid	46	acl:relcl	_	_
 51	כאן	כאן	ADV	ADV	_	50	advmod	_	SpaceAfter=No
 52	.	.	PUNCT	PUNCT	_	38	punct	_	_
 
@@ -12085,7 +12085,7 @@
 # text = טולדנו לא פנה לפתרון המקובל הזה והוא ראוי להכרה על עצם המאמץ שעשה לחרוג מהשגרתיות ומהסתמיות ולגבש ביטוי הנדסי וצורני אקספרסיווי למהותו של הבניין הפולחני, אך חבל שהדבר נעשה תוך גלישה לפתרונות עיצוביים מפוקפקים.
 1	טולדנו	טולדנו	PROPN	PROPN	_	3	nsubj	_	_
 2	לא	לא	ADV	ADV	Polarity=Neg	3	advmod	_	_
-3	פנה	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+3	פנה	פנה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.נ.י|Tense=Past|Voice=Act	0	root	_	_
 4-6	לפתרון	_	_	_	_	_	_	_	_
 4	ל	ל	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -12110,8 +12110,8 @@
 19	מאמץ	מאמץ	NOUN	NOUN	Gender=Masc|Number=Sing	15	nmod	_	_
 20-21	שעשה	_	_	_	_	_	_	_	_
 20	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
-21	עשה	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	19	acl:relcl	_	_
-22	לחרוג	חרג	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	21	xcomp	_	_
+21	עשה	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	19	acl:relcl	_	_
+22	לחרוג	חרג	VERB	VERB	HebBinyan=PAAL|Root=ח.ר.ג|VerbForm=Inf|Voice=Act	21	xcomp	_	_
 23-25	מהשגרתיות	_	_	_	_	_	_	_	_
 23	מ	מ	ADP	ADP	_	25	case	_	_
 24	ה	ה	DET	DET	PronType=Art	25	det:def	_	_
@@ -12123,7 +12123,7 @@
 29	סתמיות	סתמיות	NOUN	NOUN	Gender=Fem|Number=Sing	25	conj	_	_
 30-31	ולגבש	_	_	_	_	_	_	_	_
 30	ו	ו	CCONJ	CCONJ	_	31	cc	_	_
-31	לגבש	גיבש	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	22	conj	_	_
+31	לגבש	גיבש	VERB	VERB	HebBinyan=PIEL|Root=ג.ב.ש|VerbForm=Inf|Voice=Act	22	conj	_	_
 32	ביטוי	ביטוי	NOUN	NOUN	Gender=Masc|Number=Sing	31	obj	_	_
 33	הנדסי	הנדסי	ADJ	ADJ	Gender=Masc|Number=Sing	32	amod	_	_
 34-35	וצורני	_	_	_	_	_	_	_	_
@@ -12149,7 +12149,7 @@
 49	ש	ש	SCONJ	SCONJ	_	52	mark	_	_
 50	ה	ה	DET	DET	PronType=Art	51	det:def	_	_
 51	דבר	דבר	NOUN	NOUN	Gender=Masc|Number=Sing	52	nsubj	_	_
-52	נעשה	נעשה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	48	ccomp	_	_
+52	נעשה	נעשה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ע.ש.י|VerbForm=Part|Voice=Mid	48	ccomp	_	_
 53	תוך	תוך	ADP	ADP	_	54	case	_	_
 54	גלישה	גלישה	NOUN	NOUN	Gender=Fem|Number=Sing	52	obl	_	_
 55-56	לפתרונות	_	_	_	_	_	_	_	_
@@ -12173,7 +12173,7 @@
 1	בייחוד	בייחוד	ADV	ADV	_	3	advmod	_	_
 2-3	כשמדובר	_	_	_	_	_	_	_	_
 2	כש	כש	SCONJ	SCONJ	Case=Tem	3	mark	_	_
-3	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+3	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ד.ב.ר|VerbForm=Part|Voice=Pass	0	root	_	_
 4-5	בקנסות	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	קנסות	קנס	NOUN	NOUN	Gender=Masc|Number=Plur	3	obl	_	_
@@ -12187,7 +12187,7 @@
 12-13	שאין	_	_	_	_	_	_	_	_
 12	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
 13	אין	אין	ADV	ADV	Polarity=Neg	14	advmod	_	_
-14	נשקפת	נשקף	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	7	acl:relcl	_	_
+14	נשקפת	נשקף	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ש.ק.פ|VerbForm=Part|Voice=Mid	7	acl:relcl	_	_
 15	סכנת	סכנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	14	nsubj	_	_
 16	מאסר	מאסר	NOUN	NOUN	Gender=Masc|Number=Sing	15	compound:smixut	_	_
 17	על	על	ADP	ADP	_	20	case	_	_
@@ -12205,7 +12205,7 @@
 2	-	-	PUNCT	PUNCT	_	3	punct	_	SpaceAfter=No
 3	כן	כן	PRON	PRON	Person=3|PronType=Dem	4	advmod	_	_
 4	קשה	קשה	AUX	AUX	Gender=Masc|Number=Sing|Tense=Past|VerbType=Mod	5	aux	_	_
-5	לגבות	גבה	VERB	VERB	VerbForm=Inf	0	root	_	_
+5	לגבות	גבה	VERB	VERB	HebBinyan=PAAL|Root=ג.ב.י|VerbForm=Inf	0	root	_	_
 6	קנסות	קנס	NOUN	NOUN	Gender=Masc|Number=Plur	5	obj	_	_
 7-8	בסכומים	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
@@ -12226,7 +12226,7 @@
 20-21	שהיא	_	_	_	_	_	_	_	_
 20	ש	ש	SCONJ	SCONJ	_	19	fixed	_	_
 21	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	22	nsubj	_	_
-22	כרוכה	כרך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	advcl	_	_
+22	כרוכה	כרך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ר.כ|VerbForm=Part|Voice=Act	4	advcl	_	_
 23-24	בהפעלת	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	הפעלת	הפעלה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	22	obl	_	_
@@ -12247,7 +12247,7 @@
 6	מ	מ	ADP	ADP	_	7	case	_	_
 7	תשלום	תשלום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	nmod	_	_
 8	קנסות	קנס	NOUN	NOUN	Gender=Masc|Number=Plur	7	compound:smixut	_	_
-9	פוגעים	פגע	VERB	VERB	VerbForm=Part	15	obl	_	_
+9	פוגעים	פגע	VERB	VERB	HebBinyan=PAAL|Root=פ.ג.ע|VerbForm=Part	15	obl	_	_
 10-11	באכיפת	_	_	_	_	_	_	_	_
 10	ב	ב	ADP	ADP	_	11	case	_	_
 11	אכיפת	אכיפה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	9	obl	_	_
@@ -12255,7 +12255,7 @@
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	11	compound:smixut	_	_
 14	,	,	PUNCT	PUNCT	_	15	punct	_	_
-15	מכינים	הכין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+15	מכינים	הכין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=כ.ו.נ|VerbForm=Part|Voice=Act	0	root	_	_
 16-17	במשרד	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	משרד	משרד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	15	obl	_	_
@@ -12281,7 +12281,7 @@
 33-34	האפשרות	_	_	_	_	_	_	_	_
 33	ה	ה	DET	DET	PronType=Art	34	det:def	_	_
 34	אפשרות	אפשרות	NOUN	NOUN	Gender=Fem|Number=Sing	30	nsubj	_	_
-35	לעקל	עיקל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	34	acl	_	_
+35	לעקל	עיקל	VERB	VERB	HebBinyan=PIEL|Root=ע.ק.ל|VerbForm=Inf|Voice=Act	34	acl	_	_
 36	חשבונות	חשבון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	35	obl	_	_
 37	בנק	בנק	NOUN	NOUN	Gender=Masc|Number=Sing	36	compound:smixut	_	SpaceAfter=No
 38	.	.	PUNCT	PUNCT	_	15	punct	_	_
@@ -12297,7 +12297,7 @@
 5	,	,	PUNCT	PUNCT	_	2	punct	_	_
 6-7	שייקרא	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
-7	ייקרא	נקרא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Fut|Voice=Mid	2	acl:relcl	_	_
+7	ייקרא	נקרא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ק.ר.א|Tense=Fut|Voice=Mid	2	acl:relcl	_	_
 8	"	"	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 9	חוק	חוק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	dep	_	_
 10	גביית	גבייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	9	compound:smixut	_	_
@@ -12308,8 +12308,8 @@
 15	"	"	PUNCT	PUNCT	_	9	punct	_	SpaceAfter=No
 16	,	,	PUNCT	PUNCT	_	18	punct	_	_
 17	אינו	אינו	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	18	advmod	_	_
-18	נועד	נועד	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
-19	לשנות	שינה	VERB	VERB	VerbForm=Inf	18	xcomp	_	_
+18	נועד	נועד	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=י.ע.ד|VerbForm=Part|Voice=Mid	0	root	_	_
+19	לשנות	שינה	VERB	VERB	HebBinyan=PIEL|Root=ש.נ.י|VerbForm=Inf	18	xcomp	_	_
 20	את	את	ADP	ADP	Case=Acc	22	case:acc	_	_
 21-22	ההוראות	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
@@ -12330,13 +12330,13 @@
 32	קנסות	קנס	NOUN	NOUN	Gender=Masc|Number=Plur	30	compound:smixut	_	_
 33	,	,	PUNCT	PUNCT	_	19	punct	_	_
 34	אלא	אלא	CCONJ	CCONJ	_	35	cc	_	_
-35	להוסיף	הוסיף	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	19	conj	_	_
+35	להוסיף	הוסיף	VERB	VERB	HebBinyan=HIFIL|Root=י.ס.פ|VerbForm=Inf|Voice=Act	19	conj	_	_
 36-37	עליהן	_	_	_	_	_	_	_	_
 36	על_	על	ADP	ADP	_	37	case	_	_
 37	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	35	obl	_	_
 38-39	ולתת	_	_	_	_	_	_	_	_
 38	ו	ו	CCONJ	CCONJ	_	39	cc	_	_
-39	לתת	נתן	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	35	conj	_	_
+39	לתת	נתן	VERB	VERB	HebBinyan=PAAL|Root=נ.ת.נ|VerbForm=Inf|Voice=Act	35	conj	_	_
 40	כלים	כלי	NOUN	NOUN	Gender=Masc|Number=Plur	39	obj	_	_
 41-42	לגבייה	_	_	_	_	_	_	_	_
 41	ל	ל	ADP	ADP	_	42	case	_	_
@@ -12347,7 +12347,7 @@
 45-46	שאינה	_	_	_	_	_	_	_	_
 45	ש	ש	SCONJ	SCONJ	_	47	mark	_	_
 46	אינה	אינו	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	47	advmod	_	_
-47	מחייבת	חייב	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	44	acl:relcl	_	_
+47	מחייבת	חייב	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ח.י.ב|VerbForm=Part|Voice=Act	44	acl:relcl	_	_
 48	חדירה	חדירה	NOUN	NOUN	Gender=Fem|Number=Sing	47	obj	_	_
 49-50	לתחום	_	_	_	_	_	_	_	_
 49	ל	ל	ADP	ADP	_	50	case	_	_
@@ -12371,7 +12371,7 @@
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	הצעה	הצעה	NOUN	NOUN	Gender=Fem|Number=Sing	7	obl	_	_
 6	,	,	PUNCT	PUNCT	_	7	punct	_	_
-7	ימנה	מינה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	0	root	_	_
+7	ימנה	מינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=מ.נ.י|Tense=Fut	0	root	_	_
 8	שר	שר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	nsubj	_	_
 9-10	האוצר	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -12389,8 +12389,8 @@
 19	גופים	גוף	NOUN	NOUN	Gender=Masc|Number=Plur	16	obl	_	_
 20-21	המוסמכים	_	_	_	_	_	_	_	_
 20	ה	ה	SCONJ	SCONJ	_	21	mark	_	_
-21	מוסמכים	הוסמך	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	19	acl:relcl	_	_
-22	להטיל	הטיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	21	xcomp	_	_
+21	מוסמכים	הוסמך	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ס.מ.כ|VerbForm=Part|Voice=Pass	19	acl:relcl	_	_
+22	להטיל	הטיל	VERB	VERB	HebBinyan=HIFIL|Root=נ.ט.ל|VerbForm=Inf|Voice=Act	21	xcomp	_	_
 23	קנסות	קנס	NOUN	NOUN	Gender=Masc|Number=Plur	22	obj	_	SpaceAfter=No
 24	.	.	PUNCT	PUNCT	_	7	punct	_	_
 
@@ -12404,13 +12404,13 @@
 5-6	שיהיו	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
 6	יהיו	_	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	7	cop	_	_
-7	ממונים	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	1	acl:relcl	_	_
+7	ממונים	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=מ.נ.י|VerbForm=Part|Voice=Pass	1	acl:relcl	_	_
 8	על	על	ADP	ADP	_	9	case	_	_
 9	גביית	גבייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	obl	_	_
 10	קנסות	קנס	NOUN	NOUN	Gender=Masc|Number=Plur	9	compound:smixut	_	_
 11-12	שהטיל	_	_	_	_	_	_	_	_
 11	ש	ש	SCONJ	SCONJ	_	12	mark	_	_
-12	הטיל	הטיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	acl:relcl	_	_
+12	הטיל	הטיל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ט.ל|Tense=Past|Voice=Act	10	acl:relcl	_	_
 13	בית	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	nsubj	_	_
 14	משפט	משפט	NOUN	NOUN	Gender=Masc|Number=Sing	13	compound:smixut	_	SpaceAfter=No
 15	,	,	PUNCT	PUNCT	_	17	punct	_	_
@@ -12432,7 +12432,7 @@
 4	פקידים	פקיד	NOUN	NOUN	Gender=Masc|Number=Plur	20	nsubj	_	_
 5-6	שיעסקו	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	יעסקו	עסק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Fut|Voice=Act	4	acl:relcl	_	_
+6	יעסקו	עסק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ס.ק|Tense=Fut|Voice=Act	4	acl:relcl	_	_
 7-8	בגביית	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	גביית	גבייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	6	obl	_	_
@@ -12454,7 +12454,7 @@
 22	גופים	גוף	NOUN	NOUN	Gender=Masc|Number=Plur	20	compound:smixut	_	_
 23-24	הממונים	_	_	_	_	_	_	_	_
 23	ה	ה	SCONJ	SCONJ	_	24	mark	_	_
-24	ממונים	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	20	acl:relcl	_	_
+24	ממונים	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=מ.נ.י|VerbForm=Part|Voice=Pass	20	acl:relcl	_	_
 25	על	על	ADP	ADP	_	26	case	_	_
 26	ביצוע	ביצוע	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	24	obl	_	_
 27-28	התקנה	_	_	_	_	_	_	_	SpaceAfter=No
@@ -12467,7 +12467,7 @@
 32	כוח_	כוח	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	35	obl	_	_
 33	_של_	של	ADP	ADP	_	34	case:gen	_	_
 34	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	32	nmod:poss	_	_
-35	הוטל	הוטל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	28	acl:relcl	_	_
+35	הוטל	הוטל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=נ.ט.ל|Tense=Past|Voice=Pass	28	acl:relcl	_	_
 36-37	הקנס	_	_	_	_	_	_	_	SpaceAfter=No
 36	ה	ה	DET	DET	PronType=Art	37	det:def	_	_
 37	קנס	קנס	NOUN	NOUN	Gender=Masc|Number=Sing	35	nsubj	_	_
@@ -12479,7 +12479,7 @@
 42	גופים	גוף	NOUN	NOUN	Gender=Masc|Number=Plur	40	compound:smixut	_	_
 43-44	הממונים	_	_	_	_	_	_	_	_
 43	ה	ה	SCONJ	SCONJ	_	44	mark	_	_
-44	ממונים	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	40	acl:relcl	_	_
+44	ממונים	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=מ.נ.י|VerbForm=Part|Voice=Pass	40	acl:relcl	_	_
 45	על	על	ADP	ADP	_	46	case	_	_
 46	אכיפת	אכיפה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	44	obl	_	_
 47	אותה	אותו	PRON	PRON	Definite=Def|Gender=Fem|Number=Sing|Person=3|PronType=Prs	48	det	_	_
@@ -12507,7 +12507,7 @@
 3-4	הגבייה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	גבייה	גבייה	NOUN	NOUN	Gender=Fem|Number=Sing	2	compound:smixut	_	_
-5	יהיו	_	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
+5	יהיו	_	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	0	root	_	_
 6	סמכויות	סמכות	NOUN	NOUN	Gender=Fem|Number=Plur	5	nsubj	_	_
 7	של	של	ADP	ADP	Case=Gen	8	case:gen	_	_
 8	גובי	גוב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	6	nmod:poss	_	_
@@ -12541,7 +12541,7 @@
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	3	compound:smixut	_	_
 6	,	,	PUNCT	PUNCT	_	7	punct	_	_
-7	ירכז	ריכז	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+7	ירכז	ריכז	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=ר.כ.ז|Tense=Fut|Voice=Act	0	root	_	_
 8	משרד	משרד	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	7	dep	_	_
 9-10	האוצר	_	_	_	_	_	_	_	_
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
@@ -12575,7 +12575,7 @@
 4	ב	ב	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	מאגר	מאגר	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod	_	_
-7	יתייחסו	התייחס	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Fut	0	root	_	_
+7	יתייחסו	התייחס	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=י.ח.ס|Tense=Fut	0	root	_	_
 8	אך	אך	ADV	ADV	_	7	advmod	_	_
 9-10	ורק	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	10	cc	_	_
@@ -12589,7 +12589,7 @@
 16-17	שלא	_	_	_	_	_	_	_	_
 16	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
 17	לא	לא	ADV	ADV	Polarity=Neg	18	advmod	_	_
-18	שילמו	שילם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	14	acl:relcl	_	_
+18	שילמו	שילם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ש.ל.מ|Tense=Past|Voice=Act	14	acl:relcl	_	_
 19	את	את	ADP	ADP	Case=Acc	20	case:acc	_	_
 20	מלוא	מלוא	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	18	obj	_	_
 21-23	חובם	_	_	_	_	_	_	_	_
@@ -12603,7 +12603,7 @@
 27	,	,	PUNCT	PUNCT	_	7	punct	_	_
 28-29	וישמשו	_	_	_	_	_	_	_	_
 28	ו	ו	CCONJ	CCONJ	_	29	cc	_	_
-29	ישמשו	שימש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Fut|Voice=Act	7	conj	_	_
+29	ישמשו	שימש	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ש.מ.ש|Tense=Fut|Voice=Act	7	conj	_	_
 30-31	לגביית	_	_	_	_	_	_	_	_
 30	ל	ל	ADP	ADP	_	31	case	_	_
 31	גביית	גבייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	29	obl	_	_
@@ -12621,25 +12621,25 @@
 3	סודיות	סודיות	NOUN	NOUN	Gender=Fem|Number=Sing	1	compound:smixut	_	_
 4-5	החלים	_	_	_	_	_	_	_	_
 4	ה	ה	SCONJ	SCONJ	_	5	mark	_	_
-5	חלים	חל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
+5	חלים	חל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ח.ו.ל|VerbForm=Part|Voice=Act	1	acl:relcl	_	_
 6	על	על	ADP	ADP	_	7	case	_	_
 7	גילוי	גילוי	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	5	obl	_	_
 8	מידע	מידע	NOUN	NOUN	Gender=Masc|Number=Sing	7	compound:smixut	_	_
 9-10	הנאסף	_	_	_	_	_	_	_	_
 9	ה	ה	SCONJ	SCONJ	_	10	mark	_	_
-10	נאסף	נאסף	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	8	acl:relcl	_	_
+10	נאסף	נאסף	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=א.ס.פ|VerbForm=Part|Voice=Mid	8	acl:relcl	_	_
 11-12	לצורך	_	_	_	_	_	_	_	_
 11	ל	ל	ADP	ADP	_	12	case	_	_
 12	צורך	צורך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	10	obl	_	_
 13	גביית	גבייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	12	compound:smixut	_	_
 14	מסים	מס	NOUN	NOUN	Gender=Masc|Number=Plur	13	compound:smixut	_	_
-15	יחולו	חל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+15	יחולו	חל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ח.ו.ל|Tense=Fut|Voice=Act	0	root	_	_
 16	גם	גם	ADV	ADV	_	17	advmod	_	_
 17	על	על	ADP	ADP	_	18	case	_	_
 18	מי	מי	ADV	ADV	PronType=Int	15	obl	_	_
 19-20	שפועל	_	_	_	_	_	_	_	SpaceAfter=No
 19	ש	ש	SCONJ	SCONJ	_	20	mark	_	_
-20	פועל	פעל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	18	acl:relcl	_	_
+20	פועל	פעל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=פ.ע.ל|VerbForm=Part|Voice=Act	18	acl:relcl	_	_
 21	,	,	PUNCT	PUNCT	_	20	punct	_	_
 22-23	מכוח	_	_	_	_	_	_	_	_
 22	מ	מ	ADP	ADP	_	23	case	_	_
@@ -12663,7 +12663,7 @@
 2-3	האוצר	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	אוצר	אוצר	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
-4	ימנה	מינה	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Fut	0	root	_	_
+4	ימנה	מינה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=3|Root=מ.נ.י|Tense=Fut	0	root	_	_
 5	עובד	עובד	NOUN	NOUN	Gender=Masc|Number=Sing	4	obj	_	_
 6-9	ממשרדו	_	_	_	_	_	_	_	_
 6	מ	מ	ADP	ADP	_	7	case	_	_
@@ -12685,9 +12685,9 @@
 1	ל	ל	ADP	ADP	_	2	case	_	_
 2	פקיד	פקיד	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 3	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	2	det	_	_
-4	יהיו	_	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
+4	יהיו	_	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	0	root	_	_
 5	סמכויות	סמכות	NOUN	NOUN	Gender=Fem|Number=Plur	4	nsubj	_	_
-6	לדרוש	דרש	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	5	acl	_	_
+6	לדרוש	דרש	VERB	VERB	HebBinyan=PAAL|Root=ד.ר.ש|VerbForm=Inf|Voice=Act	5	acl	_	_
 7	מידע	מידע	NOUN	NOUN	Gender=Masc|Number=Sing	6	obj	_	_
 8-9	לצורך	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	9	case	_	_
@@ -12733,7 +12733,7 @@
 4	קנסות	קנס	NOUN	NOUN	Gender=Masc|Number=Plur	16	nsubj	_	_
 5-6	שייגבו	_	_	_	_	_	_	_	SpaceAfter=No
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	ייגבו	נגבה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Fut|Voice=Mid	4	acl:relcl	_	_
+6	ייגבו	נגבה	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ג.ב.י|Tense=Fut|Voice=Mid	4	acl:relcl	_	_
 7	,	,	PUNCT	PUNCT	_	16	punct	_	_
 8	על	על	ADP	ADP	_	12	case	_	SpaceAfter=No
 9	-	-	PUNCT	PUNCT	_	8	fixed	_	SpaceAfter=No
@@ -12745,14 +12745,14 @@
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	מוצע	מוצע	ADJ	ADJ	Gender=Masc|Number=Sing	12	amod	_	_
 15	,	,	PUNCT	PUNCT	_	16	punct	_	_
-16	יועברו	הועבר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Fut|Voice=Pass	0	root	_	_
+16	יועברו	הועבר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=ע.ב.ר|Tense=Fut|Voice=Pass	0	root	_	_
 17-19	לגופים	_	_	_	_	_	_	_	_
 17	ל	ל	ADP	ADP	_	19	case	_	_
 18	ה_	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	גופים	גוף	NOUN	NOUN	Gender=Masc|Number=Plur	16	obl	_	_
 20-21	שעסקו	_	_	_	_	_	_	_	_
 20	ש	ש	SCONJ	SCONJ	_	21	mark	_	_
-21	עסקו	עסק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	19	acl:relcl	_	_
+21	עסקו	עסק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ס.ק|Tense=Past|Voice=Act	19	acl:relcl	_	_
 22-24	בגבייה	_	_	_	_	_	_	_	SpaceAfter=No
 22	ב	ב	ADP	ADP	_	24	case	_	_
 23	ה_	ה	DET	DET	PronType=Art	24	det:def	_	_
@@ -12760,10 +12760,10 @@
 25	,	,	PUNCT	PUNCT	_	16	punct	_	_
 26	כדי	כדי	ADP	ADP	_	30	case	_	_
 27-29	לעודדם	_	_	_	_	_	_	_	_
-27	לעודדם	_	VERB	VERB	VerbForm=Inf	30	dep	_	_
+27	לעודדם	_	VERB	VERB	HebBinyan=PIEL|Root=ע.ד.ד|VerbForm=Inf	30	dep	_	_
 28	את	את	ADP	ADP	Case=Acc	29	case	_	_
 29	_הם	הוא	PRON	PRON	Case=Acc|Gender=Masc|Number=Plur|Person=3|PronType=Prs	30	obj	_	_
-30	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	16	advcl	_	_
+30	להקים	הקים	VERB	VERB	HebBinyan=HIFIL|Root=ק.ו.מ|VerbForm=Inf|Voice=Act	16	advcl	_	_
 31	את	את	ADP	ADP	Case=Acc	32	case:acc	_	_
 32	מנגנון	מנגנון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	30	obj	_	_
 33-34	הגבייה	_	_	_	_	_	_	_	_
@@ -12774,7 +12774,7 @@
 36	דרוש	דרוש	ADJ	ADJ	Gender=Masc|Number=Sing	32	amod	_	_
 37-38	ולעסוק	_	_	_	_	_	_	_	_
 37	ו	ו	CCONJ	CCONJ	_	38	cc	_	_
-38	לעסוק	עסק	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	30	conj	_	_
+38	לעסוק	עסק	VERB	VERB	HebBinyan=PAAL|Root=ע.ס.ק|VerbForm=Inf|Voice=Act	30	conj	_	_
 39-40	בגביית	_	_	_	_	_	_	_	_
 39	ב	ב	ADP	ADP	_	40	case	_	_
 40	גביית	גבייה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	38	obl	_	_
@@ -12790,7 +12790,7 @@
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	1	compound:smixut	_	_
 4	תהיה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	5	cop	_	_
-5	כרוכה	כרך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	כרוכה	כרך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ר.כ|VerbForm=Part|Voice=Act	0	root	_	_
 6-7	במימון	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	מימון	מימון	NOUN	NOUN	Gender=Masc|Number=Sing	5	obl	_	_
@@ -12812,18 +12812,18 @@
 19	משרדים	משרד	NOUN	NOUN	Gender=Masc|Number=Plur	25	nsubj	_	_
 20-21	המופקדים	_	_	_	_	_	_	_	_
 20	ה	ה	SCONJ	SCONJ	_	21	mark	_	_
-21	מופקדים	הופקד	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	19	acl:relcl	_	_
+21	מופקדים	הופקד	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=פ.ק.ד|VerbForm=Part|Voice=Pass	19	acl:relcl	_	_
 22	על	על	ADP	ADP	_	24	case	_	_
 23-24	הגבייה	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	גבייה	גבייה	NOUN	NOUN	Gender=Fem|Number=Sing	21	obl	_	_
-25	יצטרכו	הצטרך	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Fut	15	conj	_	_
-26	להצטייד	הצטייד	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	25	xcomp	_	_
+25	יצטרכו	הצטרך	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=צ.ר.כ|Tense=Fut	15	conj	_	_
+26	להצטייד	הצטייד	VERB	VERB	HebBinyan=HITPAEL|Root=צ.י.ד|VerbForm=Inf	25	xcomp	_	_
 27-28	במכשור	_	_	_	_	_	_	_	_
 27	ב	ב	ADP	ADP	_	28	case	_	_
 28	מכשור	מכשור	NOUN	NOUN	Gender=Masc|Number=Sing	26	obl	_	_
 29	כדי	כדי	ADP	ADP	_	30	case	_	_
-30	לעמוד	עמד	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	26	advcl	_	_
+30	לעמוד	עמד	VERB	VERB	HebBinyan=PAAL|Root=ע.מ.ד|VerbForm=Inf|Voice=Act	26	advcl	_	_
 31-32	בקשר	_	_	_	_	_	_	_	_
 31	ב	ב	ADP	ADP	_	32	case	_	_
 32	קשר	קשר	NOUN	NOUN	Gender=Masc|Number=Sing	30	obl	_	_
@@ -12839,13 +12839,13 @@
 1-2	ואולם	_	_	_	_	_	_	_	_
 1	ו	ו	CCONJ	CCONJ	_	6	cc	_	_
 2	אולם	אולם	ADV	ADV	_	6	advmod	_	_
-3	מכיני	הכין	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	6	nsubj	_	_
+3	מכיני	הכין	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=כ.ו.נ|VerbForm=Part|Voice=Act	6	nsubj	_	_
 4-5	ההצעה	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	הצעה	הצעה	NOUN	NOUN	Gender=Fem|Number=Sing	3	compound:smixut	_	_
-6	מציינים	ציין	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+6	מציינים	ציין	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=צ.י.נ|VerbForm=Part|Voice=Act	0	root	_	_
 7	כי	כי	SCONJ	SCONJ	_	8	mark	_	_
-8	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	6	ccomp	_	_
+8	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ד.ב.ר|VerbForm=Part|Voice=Pass	6	ccomp	_	_
 9-10	בקנסות	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	קנסות	קנס	NOUN	NOUN	Gender=Masc|Number=Plur	8	obl	_	_
@@ -12856,7 +12856,7 @@
 14-15	שאינם	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
 15	אינם	אינו	AUX	AUX	Gender=Masc|Number=Plur|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	16	advmod	_	_
-16	נגבים	נגבה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Mid	10	acl:relcl	_	_
+16	נגבים	נגבה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Plur|Person=1,2,3|Root=ג.ב.י|VerbForm=Part|Voice=Mid	10	acl:relcl	_	_
 17	כלל	כלל	ADV	ADV	_	16	advmod	_	SpaceAfter=No
 18	.	.	PUNCT	PUNCT	_	6	punct	_	_
 
@@ -12869,7 +12869,7 @@
 4	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	2	nmod:poss	_	_
 5	,	,	PUNCT	PUNCT	_	7	punct	_	_
 6	לא	לא	ADV	ADV	Polarity=Neg	7	advmod	_	_
-7	יהיה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
+7	יהיה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	0	root	_	_
 8	צורך	צורך	NOUN	NOUN	Gender=Masc|Number=Sing	7	nsubj	_	_
 9-11	בשלב	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	11	case	_	_
@@ -12891,7 +12891,7 @@
 21	חוק	חוק	NOUN	NOUN	Gender=Masc|Number=Sing	19	compound:smixut	_	_
 22	,	,	PUNCT	PUNCT	_	7	punct	_	_
 23	שכן	שכן	SCONJ	SCONJ	_	24	mark	_	_
-24	יעסקו	עסק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Fut|Voice=Act	7	advcl	_	_
+24	יעסקו	עסק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ס.ק|Tense=Fut|Voice=Act	7	advcl	_	_
 25-26	בכך	_	_	_	_	_	_	_	_
 25	ב	ב	ADP	ADP	_	26	case	_	_
 26	כך	כך	PRON	PRON	Person=3|PronType=Dem	24	obl	_	_
@@ -12924,14 +12924,14 @@
 2	ניוקי	ניוקי	NOUN	NOUN	Gender=Masc|Number=Sing	21	nsubj	_	_
 3-4	שצופה	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	צופה	צופה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	2	acl:relcl	_	_
+4	צופה	צופה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=צ.פ.י|Tense=Past|Voice=Pass	2	acl:relcl	_	_
 5-6	בחמאה	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	חמאה	חמאה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
-7	מותכת	הותך	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	6	amod	_	_
+7	מותכת	הותך	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=נ.ת.כ|VerbForm=Part|Voice=Pass	6	amod	_	_
 8-9	והוגש	_	_	_	_	_	_	_	_
 8	ו	ו	CCONJ	CCONJ	_	9	cc	_	_
-9	הוגש	הוגש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	4	conj	_	_
+9	הוגש	הוגש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Pass	4	conj	_	_
 10-11	ברוטב	_	_	_	_	_	_	_	_
 10	ב	ב	ADP	ADP	_	11	case	_	_
 11	רוטב	רוטב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	9	obl	_	_
@@ -12965,7 +12965,7 @@
 11	רוטב	רוטב	NOUN	NOUN	Gender=Masc|Number=Sing	7	nmod	_	_
 12-13	המבוסס	_	_	_	_	_	_	_	_
 12	ה	ה	SCONJ	SCONJ	_	13	mark	_	_
-13	מבוסס	בוסס	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	11	acl:relcl	_	_
+13	מבוסס	בוסס	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ס.ס|VerbForm=Part	11	acl:relcl	_	_
 14	על	על	ADP	ADP	_	15	case	_	_
 15	ציר	ציר	NOUN	NOUN	Gender=Masc|Number=Sing	13	obl	_	_
 16	חום	חום	ADJ	ADJ	Gender=Masc|Number=Sing	15	amod	_	SpaceAfter=No
@@ -12979,13 +12979,13 @@
 23	עשבי	עשב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	15	conj	_	_
 24	מאכל	מאכל	NOUN	NOUN	Gender=Masc|Number=Sing	23	compound:smixut	_	_
 25	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	26	cop	_	_
-26	מאכזב	אכזב	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+26	מאכזב	אכזב	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=א.כ.ז.ב|VerbForm=Part|Voice=Act	0	root	_	_
 27	משום	משום	SCONJ	SCONJ	_	31	mark	_	_
 28-30	שהעגל	_	_	_	_	_	_	_	_
 28	ש	ש	SCONJ	SCONJ	_	27	fixed	_	_
 29	ה	ה	DET	DET	PronType=Art	30	det:def	_	_
 30	עגל	עגל	NOUN	NOUN	Gender=Masc|Number=Sing	31	nsubj	_	_
-31	בושל	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	26	advcl	_	_
+31	בושל	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ב.ש.ל|Tense=Past|Voice=Pass	26	advcl	_	_
 32	יתר	יתר	DET	DET	Definite=Cons	31	advmod	_	_
 33	על	על	ADP	ADP	_	32	fixed	_	_
 34-35	המידה	_	_	_	_	_	_	_	_
@@ -12995,7 +12995,7 @@
 36	ו	ו	CCONJ	CCONJ	_	39	cc	_	_
 37	ה	ה	DET	DET	PronType=Art	38	det:def	_	_
 38	רוטב	רוטב	NOUN	NOUN	Gender=Masc|Number=Sing	39	nsubj	_	_
-39	הוסמך	הוסמך	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	31	conj	_	SpaceAfter=No
+39	הוסמך	הוסמך	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ס.מ.כ|Tense=Past|Voice=Pass	31	conj	_	SpaceAfter=No
 40	,	,	PUNCT	PUNCT	_	39	punct	_	_
 41	ללא	ללא	ADP	ADP	_	42	case	_	_
 42	סיבה	סיבה	NOUN	NOUN	Gender=Fem|Number=Sing	39	obl	_	SpaceAfter=No
@@ -13017,10 +13017,10 @@
 7-8	שאחדות	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
 8	אחדות	אחדות	NOUN	NOUN	Gender=Fem|Number=Sing	9	nsubj	_	_
-9	איכזבו	אכזב	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	4	acl:relcl	_	_
+9	איכזבו	אכזב	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=א.כ.ז.ב|Tense=Past|Voice=Act	4	acl:relcl	_	_
 10	בהחלט	בהחלט	ADV	ADV	_	9	advmod	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	12	punct	_	_
-12	יגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+12	יגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ע|Tense=Fut|Voice=Act	0	root	_	_
 13-14	החשבון	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	חשבון	חשבון	NOUN	NOUN	Gender=Masc|Number=Sing	12	nsubj	_	_
@@ -13031,7 +13031,7 @@
 17	ל	ל	ADP	ADP	_	19	case	_	_
 18	70	70	NUM	NUM	_	19	nummod	_	_
 19	ש"ח	ש"ח	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	12	obl	_	_
-20	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	21	case	_	_
+20	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	21	case	_	_
 21	בירה	בירה	NOUN	NOUN	Gender=Fem|Number=Sing	19	nmod	_	_
 22-23	ואספרסו	_	_	_	_	_	_	_	SpaceAfter=No
 22	ו	ו	CCONJ	CCONJ	_	23	cc	_	_
@@ -13041,7 +13041,7 @@
 # sent_id = 6106
 # text = כדי לקבל תמורה מלאה לכספכם היכנסו רק כדי לטעום מנה אחת של ניוקי וסלט נדיב של חסילונים, שקדים, פטריות ועשבים טריים, הכל על מצע נאה של חסה.
 1	כדי	כדי	ADP	ADP	_	2	case	_	_
-2	לקבל	קיבל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	9	advcl	_	_
+2	לקבל	קיבל	VERB	VERB	HebBinyan=PIEL|Root=ק.ב.ל|VerbForm=Inf|Voice=Act	9	advcl	_	_
 3	תמורה	תמורה	NOUN	NOUN	Gender=Fem|Number=Sing	2	obj	_	_
 4	מלאה	מלא	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
 5-8	לכספכם	_	_	_	_	_	_	_	_
@@ -13049,10 +13049,10 @@
 6	כסף_	כסף	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 7	_של_	של	ADP	ADP	_	8	case:gen	_	_
 8	_אתם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=2|PronType=Prs	6	nmod:poss	_	_
-9	היכנסו	נכנס	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Mood=Imp|Number=Plur|Person=2|Voice=Mid	0	root	_	_
+9	היכנסו	נכנס	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Mood=Imp|Number=Plur|Person=2|Root=כ.נ.ס|Voice=Mid	0	root	_	_
 10	רק	רק	ADV	ADV	_	11	advmod	_	_
 11	כדי	כדי	ADP	ADP	_	12	case	_	_
-12	לטעום	טעם	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	9	advcl	_	_
+12	לטעום	טעם	VERB	VERB	HebBinyan=PAAL|Root=ט.ע.מ|VerbForm=Inf|Voice=Act	9	advcl	_	_
 13	מנה	מנה	NOUN	NOUN	Gender=Fem|Number=Sing	12	obj	_	_
 14	אחת	אחת	NUM	NUM	Gender=Fem|Number=Sing	13	nummod	_	_
 15	של	של	ADP	ADP	Case=Gen	16	case:gen	_	_
@@ -13089,7 +13089,7 @@
 4	,	,	PUNCT	PUNCT	_	3	punct	_	_
 5-6	המספיקות	_	_	_	_	_	_	_	_
 5	ה	ה	SCONJ	SCONJ	_	6	mark	_	_
-6	מספיקות	הספיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	3	acl:relcl	_	_
+6	מספיקות	הספיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ס.פ.ק|VerbForm=Part|Voice=Act	3	acl:relcl	_	_
 7-8	לארוחה	_	_	_	_	_	_	_	_
 7	ל	ל	ADP	ADP	_	8	case	_	_
 8	ארוחה	ארוחה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
@@ -13098,7 +13098,7 @@
 10	ל	ל	ADP	ADP	_	11	case	_	_
 11	שניים	שניים	NUM	NUM	Gender=Masc|Number=Plur	8	nmod	_	_
 12	,	,	PUNCT	PUNCT	_	13	punct	_	_
-13	יעלו	עלה	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut	0	root	_	_
+13	יעלו	עלה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ל.י|Tense=Fut	0	root	_	_
 14	רק	רק	ADV	ADV	_	16	det	_	_
 15	30	30	NUM	NUM	_	16	nummod	_	_
 16	ש"ח	ש"ח	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	13	obj	_	SpaceAfter=No
@@ -13118,7 +13118,7 @@
 # sent_id = 6109
 # text = היא נפתחה שנים אחדות לפני המסעדות האיטלקיות מן הגל החדש, ומגישים בה אוכל פשוט וחסר יומרות, נאמן במידה רבה לזה שאפשר למצוא בהרבה אוסטריות צנועות בכל רחבי איטליה.
 1	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	נפתחה	נפתח	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+2	נפתחה	נפתח	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=פ.ת.ח|Tense=Past|Voice=Mid	0	root	_	_
 3	שנים	שנה	NOUN	NOUN	Gender=Fem|Number=Plur	2	dep	_	_
 4	אחדות	אחדים	ADJ	ADJ	Gender=Fem|Number=Plur	3	amod	_	_
 5	לפני	לפני	ADP	ADP	_	7	case	_	_
@@ -13138,7 +13138,7 @@
 15	,	,	PUNCT	PUNCT	_	2	punct	_	_
 16-17	ומגישים	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
-17	מגישים	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	conj	_	_
+17	מגישים	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=נ.ג.ש|VerbForm=Part|Voice=Act	2	conj	_	_
 18-19	בה	_	_	_	_	_	_	_	_
 18	ב_	ב	ADP	ADP	_	19	case	_	_
 19	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	17	obl	_	_
@@ -13149,7 +13149,7 @@
 23	חסר	חסר	ADJ	ADJ	Definite=Cons|Gender=Masc|Number=Sing	21	conj	_	_
 24	יומרות	יומרה	NOUN	NOUN	Gender=Fem|Number=Plur	23	compound:smixut	_	SpaceAfter=No
 25	,	,	PUNCT	PUNCT	_	20	punct	_	_
-26	נאמן	נאמן	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	20	acl	_	_
+26	נאמן	נאמן	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=א.מ.נ|VerbForm=Part|Voice=Mid	20	acl	_	_
 27-28	במידה	_	_	_	_	_	_	_	_
 27	ב	ב	ADP	ADP	_	28	case	_	_
 28	מידה	מידה	NOUN	NOUN	Gender=Fem|Number=Sing	26	obl	_	_
@@ -13160,7 +13160,7 @@
 32-33	שאפשר	_	_	_	_	_	_	_	_
 32	ש	ש	SCONJ	SCONJ	_	33	mark	_	_
 33	אפשר	אפשר	AUX	AUX	VerbType=Mod	34	aux	_	_
-34	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	31	acl:relcl	_	_
+34	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|Root=מ.צ.א|VerbForm=Inf|Voice=Act	31	acl:relcl	_	_
 35-36	בהרבה	_	_	_	_	_	_	_	_
 35	ב	ב	ADP	ADP	_	37	case	_	_
 36	הרבה	הרבה	DET	DET	Definite=Cons	37	det	_	_
@@ -13235,7 +13235,7 @@
 20	ירקות	ירקות	NOUN	NOUN	Gender=Masc|Number=Plur	18	advmod	_	_
 21-22	ומתובלים	_	_	_	_	_	_	_	_
 21	ו	ו	CCONJ	CCONJ	_	22	cc	_	_
-22	מתובלים	תובל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	16	conj	_	_
+22	מתובלים	תובל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ת.ב.ל|VerbForm=Part|Voice=Pass	16	conj	_	_
 23-24	בצורה	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	צורה	צורה	NOUN	NOUN	Gender=Fem|Number=Sing	22	advmod	_	_
@@ -13243,7 +13243,7 @@
 26	,	,	PUNCT	PUNCT	_	29	punct	_	_
 27	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	29	nsubj	_	_
 28	תמיד	תמיד	ADV	ADV	_	29	advmod	_	_
-29	מהנים	מהנה	VERB	VERB	VerbForm=Part	1	conj	_	SpaceAfter=No
+29	מהנים	מהנה	VERB	VERB	HebBinyan=PIEL|Root=ה.נ.י|VerbForm=Part	1	conj	_	SpaceAfter=No
 30	.	.	PUNCT	PUNCT	_	1	punct	_	_
 
 # sent_id = 6112
@@ -13251,7 +13251,7 @@
 1-2	הניוקי	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	ניוקי	ניוקי	NOUN	NOUN	Gender=Masc|Number=Sing	3	nsubj	_	_
-3	מומלץ	הומלץ	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+3	מומלץ	הומלץ	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=מ.ל.צ|VerbForm=Part|Voice=Pass	0	root	_	_
 4	מאוד	מאוד	ADV	ADV	_	3	advmod	_	_
 5-6	ורוטב	_	_	_	_	_	_	_	_
 5	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
@@ -13264,12 +13264,12 @@
 10	טוב	טוב	ADJ	ADJ	Gender=Masc|Number=Sing	6	amod	_	_
 11-12	המצורף	_	_	_	_	_	_	_	_
 11	ה	ה	SCONJ	SCONJ	_	12	mark	_	_
-12	מצורף	צורף	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	6	acl:relcl	_	_
+12	מצורף	צורף	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=צ.ר.פ|VerbForm=Part|Voice=Pass	6	acl:relcl	_	_
 13-15	למנה	_	_	_	_	_	_	_	_
 13	ל	ל	ADP	ADP	_	15	case	_	_
 14	ה_	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	מנה	מנה	NOUN	NOUN	Gender=Fem|Number=Sing	12	obl	_	_
-16	עשוי	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	conj	_	_
+16	עשוי	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ע.ש.י|VerbForm=Part|Voice=Act	3	conj	_	_
 17-18	בסגנון	_	_	_	_	_	_	_	_
 17	ב	ב	ADP	ADP	_	18	case	_	_
 18	סגנון	סגנון	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	16	obl	_	_
@@ -13288,11 +13288,11 @@
 3	,	,	PUNCT	PUNCT	_	1	punct	_	_
 4-5	המומלצת	_	_	_	_	_	_	_	_
 4	ה	ה	SCONJ	SCONJ	_	5	mark	_	_
-5	מומלצת	הומלץ	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	1	acl:relcl	_	_
+5	מומלצת	הומלץ	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=מ.ל.צ|VerbForm=Part|Voice=Pass	1	acl:relcl	_	_
 6	אף	_	ADV	ADV	_	7	det	_	_
 7	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	9	punct	_	_
-9	נראית	נראה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+9	נראית	נראה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ר.א.י|VerbForm=Part|Voice=Mid	0	root	_	_
 10	כמו	כמו	ADP	ADP	_	11	case	_	_
 11	ערימה	ערימה	NOUN	NOUN	Gender=Fem|Number=Sing	9	obl	_	_
 12	של	של	ADP	ADP	Case=Gen	13	case:gen	_	_
@@ -13302,7 +13302,7 @@
 15	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
 16	עליה	עליה	ADP	ADP	_	17	case	_	_
 17	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	18	obl	_	_
-18	יצקו	יצק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	11	acl:relcl	_	_
+18	יצקו	יצק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.צ.ק|Tense=Past|Voice=Act	11	acl:relcl	_	_
 19	רוטב	רוטב	NOUN	NOUN	Gender=Masc|Number=Sing	18	obj	_	_
 20	טעים	טעים	ADJ	ADJ	Gender=Masc|Number=Sing	19	amod	_	_
 21	של	של	ADP	ADP	Case=Gen	22	case:gen	_	_
@@ -13358,13 +13358,13 @@
 4-5	הראשונה	_	_	_	_	_	_	_	_
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	3	amod	_	_
-6	טובלים	טבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+6	טובלים	טבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ט.ב.ל|VerbForm=Part|Voice=Act	0	root	_	_
 7	כתיתות	כתיתה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	6	obj	_	_
 8	עגל	עגל	NOUN	NOUN	Gender=Masc|Number=Sing	7	compound:smixut	_	_
 9-10	בקמח	_	_	_	_	_	_	_	_
 9	ב	ב	ADP	ADP	_	10	case	_	_
 10	קמח	קמח	NOUN	NOUN	Gender=Masc|Number=Sing	7	nmod	_	_
-11	מתובל	תובל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	10	acl	_	_
+11	מתובל	תובל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ת.ב.ל|VerbForm=Part|Voice=Pass	10	acl	_	_
 12-13	בעשבי	_	_	_	_	_	_	_	_
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	עשבי	עשב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	obl	_	_
@@ -13372,7 +13372,7 @@
 15-16	ואחר	_	_	_	_	_	_	_	_
 15	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
 16	אחר	_	ADV	ADV	_	17	advmod	_	_
-17	משחימים	השחים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	6	conj	_	_
+17	משחימים	השחים	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ש.ח.מ|VerbForm=Part|Voice=Act	6	conj	_	_
 18-19	אותן	_	_	_	_	_	_	_	_
 18	את_	את_	ADP	ADP	Case=Acc	19	case:acc	_	_
 19	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	17	obj	_	_
@@ -13457,7 +13457,7 @@
 21	,	,	PUNCT	PUNCT	_	18	punct	_	_
 22-23	המבוססת	_	_	_	_	_	_	_	_
 22	ה	ה	SCONJ	SCONJ	_	23	mark	_	_
-23	מבוססת	בוסס	VERB	VERB	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part	18	acl:relcl	_	_
+23	מבוססת	בוסס	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ס.ס|VerbForm=Part	18	acl:relcl	_	_
 24	על	על	ADP	ADP	_	25	case	_	_
 25	ביסקוויטים	ביסקוויט	NOUN	NOUN	Gender=Masc|Number=Plur	23	obl	_	_
 26	מרוסקים	מרוסק	ADJ	ADJ	Gender=Masc|Number=Plur	25	amod	_	SpaceAfter=No
@@ -13482,11 +13482,11 @@
 1	ארוחה	ארוחה	NOUN	NOUN	Gender=Fem|Number=Sing	7	nsubj	_	_
 2-3	המבוססת	_	_	_	_	_	_	_	_
 2	ה	ה	SCONJ	SCONJ	_	3	mark	_	_
-3	מבוססת	בוסס	VERB	VERB	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part	1	acl:relcl	_	_
+3	מבוססת	בוסס	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ס.ס|VerbForm=Part	1	acl:relcl	_	_
 4	על	על	ADP	ADP	_	5	case	_	_
 5	מנות	מנה	NOUN	NOUN	Gender=Fem|Number=Plur	3	obl	_	_
 6	אלה	אלה	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	5	det	_	_
-7	תגיע	הגיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+7	תגיע	הגיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ע|Tense=Fut|Voice=Act	0	root	_	_
 8-9	ל011	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	10	case	_	_
 9	110	110	NUM	NUM	_	10	nummod	_	_
@@ -13505,7 +13505,7 @@
 5-6	הבית	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	4	compound:smixut	_	_
-7	יוסיף	הוסיף	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+7	יוסיף	הוסיף	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.ס.פ|Tense=Fut|Voice=Act	0	root	_	_
 8	שמונה	שמונה	NUM	NUM	Gender=Masc|Number=Sing	9	nummod	_	_
 9	שקלים	שקל	NOUN	NOUN	Gender=Masc|Number=Plur	7	obj	_	_
 10-12	לחשבון	_	_	_	_	_	_	_	SpaceAfter=No
@@ -13548,7 +13548,7 @@
 23-24	שכדאי	_	_	_	_	_	_	_	_
 23	ש	ש	SCONJ	SCONJ	_	24	mark	_	_
 24	כדאי	כדאי	AUX	AUX	VerbType=Mod	25	aux	_	_
-25	לנסות	ניסה	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	22	acl:relcl	_	_
+25	לנסות	ניסה	VERB	VERB	HebBinyan=PIEL|Root=נ.ס.י|VerbForm=Inf|Voice=Act	22	acl:relcl	_	_
 26-27	אותו	_	_	_	_	_	_	_	_
 26	את_	את_	ADP	ADP	Case=Acc	27	case:acc	_	_
 27	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	25	obj	_	_
@@ -13568,7 +13568,7 @@
 4	ה	ה	DET	DET	PronType=Art	5	det:def	_	_
 5	בעלים	בעל	NOUN	NOUN	Gender=Masc|Number=Plur	1	appos	_	_
 6	של	של	ADP	ADP	Case=Gen	5	dep	_	_
-7	למדה	למד	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
+7	למדה	למד	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ל.מ.ד|Tense=Past	0	root	_	_
 8	בישול	בישול	NOUN	NOUN	Gender=Masc|Number=Sing	7	obj	_	_
 9	איטלקי	איטלקי	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
 10	משך	משך	ADP	ADP	_	11	case	_	_
@@ -13604,8 +13604,8 @@
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	כך	כך	PRON	PRON	Person=3|PronType=Dem	3	obl	_	_
 6	כדי	כדי	ADP	ADP	_	7	case	_	_
-7	ללמוד	למד	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	3	advcl	_	_
-8	להכין	הכין	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|VerbForm=Inf|Voice=Act	7	dep	_	_
+7	ללמוד	למד	VERB	VERB	HebBinyan=PAAL|Root=ל.מ.ד|VerbForm=Inf|Voice=Act	3	advcl	_	_
+8	להכין	הכין	VERB	VERB	HebBinyan=HIFIL|HebSource=ConvUncertainHead|Root=כ.ו.נ|VerbForm=Inf|Voice=Act	7	dep	_	_
 9	כמה	כמה	DET	DET	Definite=Cons	10	det	_	_
 10	מנות	מנה	NOUN	NOUN	Gender=Fem|Number=Plur	8	obj	_	_
 11	טובות	טוב	ADJ	ADJ	Gender=Fem|Number=Plur	10	amod	_	_
@@ -13624,7 +13624,7 @@
 21	כך	כך	PRON	PRON	Person=3|PronType=Dem	22	obl	_	_
 22	די	די	ADV	ADV	_	3	conj	_	_
 23	כדי	כדי	ADP	ADP	_	24	case	_	_
-24	לפתוח	פתח	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	22	advcl	_	_
+24	לפתוח	פתח	VERB	VERB	HebBinyan=PAAL|Root=פ.ת.ח|VerbForm=Inf|Voice=Act	22	advcl	_	_
 25	מסעדה	מסעדה	NOUN	NOUN	Gender=Fem|Number=Sing	24	obj	_	_
 26	איטלקית	איטלקי	ADJ	ADJ	Gender=Fem|Number=Sing	25	amod	_	SpaceAfter=No
 27	.	.	PUNCT	PUNCT	_	1	punct	_	_
@@ -13636,7 +13636,7 @@
 2	מרק	מרק	NOUN	NOUN	Gender=Masc|Number=Sing	14	nsubj	_	_
 3-4	שהופיע	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	הופיע	הופיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	acl:relcl	_	_
+4	הופיע	הופיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=י.פ.ע|Tense=Past|Voice=Act	2	acl:relcl	_	_
 5-7	בתפריט	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -13684,10 +13684,10 @@
 12	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
 13	ב_	ב	ADP	ADP	_	14	case	_	_
 14	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	obl	_	_
-15	נתקלתי	נתקל	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Sing|Person=1|Tense=Past|Voice=Mid	11	acl:relcl	_	_
+15	נתקלתי	נתקל	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Sing|Person=1|Root=ת.ק.ל|Tense=Past|Voice=Mid	11	acl:relcl	_	_
 16	אי	אי	ADV	ADV	Prefix=Yes	15	compound:affix	_	_
 17	פעם	פעם	ADV	ADV	_	16	fixed	_	_
-18	כלל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+18	כלל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=כ.ל.ל|Tense=Past|Voice=Act	0	root	_	_
 19	צירוף	צירוף	NOUN	NOUN	Gender=Masc|Number=Sing	18	obj	_	_
 20	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	19	det	_	_
 21	או	או	CCONJ	CCONJ	_	22	cc	_	_
@@ -13719,7 +13719,7 @@
 3	מ	מ	ADP	ADP	_	4	case	_	_
 4	אלה	_	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	2	nmod	_	_
 5	לא	לא	ADV	ADV	Polarity=Neg	6	advmod	_	_
-6	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+6	נמצא	נמצא	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=מ.צ.א|VerbForm=Part|Voice=Mid	0	root	_	_
 7-8	בגרסה	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	גרסה	גרסה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obl	_	_
@@ -13734,7 +13734,7 @@
 16-17	המזל	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	מזל	מזל	NOUN	NOUN	Gender=Masc|Number=Sing	15	compound:smixut	_	_
-18	שלטו	שלט	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	10	acl:relcl	_	_
+18	שלטו	שלט	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ש.ל.ט|Tense=Past	10	acl:relcl	_	_
 19-20	בה	_	_	_	_	_	_	_	_
 19	ב_	ב	ADP	ADP	_	20	case	_	_
 20	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	18	obl	_	_
@@ -13750,7 +13750,7 @@
 28	ש	ש	SCONJ	SCONJ	_	31	mark	_	_
 29	ב_	ב	ADP	ADP	_	30	case	_	_
 30	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	31	obl	_	_
-31	עשו	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	26	acl:relcl	_	_
+31	עשו	עשה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	26	acl:relcl	_	_
 32	שימוש	שימוש	NOUN	NOUN	Gender=Masc|Number=Sing	31	obj	_	_
 33-34	ביד	_	_	_	_	_	_	_	_
 33	ב	ב	ADP	ADP	_	34	case	_	_
@@ -13766,7 +13766,7 @@
 3	רוטולו	רוטולו	PROPN	PROPN	_	1	nmod:poss	_	_
 4	דה	דה	PROPN	PROPN	_	3	flat:name	_	_
 5	לזניה	לזניה	PROPN	PROPN	_	3	flat:name	_	_
-6	נעשתה	נעשה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+6	נעשתה	נעשה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Mid	0	root	_	_
 7	באמצעות	באמצעות	ADP	ADP	_	8	case	_	_
 8	קיפול	קיפול	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	6	obl	_	_
 9	איטריות	אטרייה	NOUN	NOUN	Gender=Fem|Number=Plur	8	compound:smixut	_	_
@@ -13779,7 +13779,7 @@
 15	מילוי	מילוי	NOUN	NOUN	Gender=Masc|Number=Sing	8	dep	_	_
 16	של	של	ADP	ADP	Case=Gen	17	case:gen	_	_
 17	פטריות	פטרייה	NOUN	NOUN	Gender=Fem|Number=Plur	15	nmod:poss	_	_
-18	מושחמות	הושחם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	17	amod	_	_
+18	מושחמות	הושחם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ש.ח.מ|VerbForm=Part|Voice=Pass	17	amod	_	_
 19-20	וגבינה	_	_	_	_	_	_	_	_
 19	ו	ו	CCONJ	CCONJ	_	20	cc	_	_
 20	גבינה	גבינה	NOUN	NOUN	Gender=Fem|Number=Sing	17	conj	_	_
@@ -13792,7 +13792,7 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	פסטה	פסטה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 3	היתה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	4	cop	_	_
-4	מבושלת	בושל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+4	מבושלת	בושל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ש.ל|VerbForm=Part|Voice=Pass	0	root	_	_
 5	היטב	היטב	ADV	ADV	_	4	advmod	_	_
 6-8	והמילוי	_	_	_	_	_	_	_	_
 6	ו	ו	CCONJ	CCONJ	_	10	cc	_	_
@@ -13805,7 +13805,7 @@
 13-14	המנה	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	מנה	מנה	NOUN	NOUN	Gender=Fem|Number=Sing	15	nsubj	_	_
-15	נהרסה	נהרס	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	4	conj	_	_
+15	נהרסה	נהרס	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ה.ר.ס|Tense=Past|Voice=Mid	4	conj	_	_
 16	על	על	ADP	ADP	_	18	case	_	_
 17	ידי	יד	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	16	fixed	_	_
 18	רוטב	רוטב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	15	obl	_	_
@@ -13819,7 +13819,7 @@
 
 # sent_id = 6129
 # text = הזמנו גם מנה של טלייריני אלה-מארינרה.
-1	הזמנו	הזמין	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Tense=Past|Voice=Act	0	root	_	_
+1	הזמנו	הזמין	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Root=ז.מ.נ|Tense=Past|Voice=Act	0	root	_	_
 2	גם	גם	ADV	ADV	_	1	advmod	_	_
 3	מנה	מנה	NOUN	NOUN	Gender=Fem|Number=Sing	1	obj	_	_
 4	של	של	ADP	ADP	Case=Gen	5	case:gen	_	_
@@ -13833,7 +13833,7 @@
 # text = במקום טלייריני קיבלנו ספגטיני, שהיה יכול להיות מתקבל על הדעת אלמלא בושלה הפסטה יתר על המידה עד שנעשתה רכרוכית.
 1	במקום	במקום	ADP	ADP	_	2	case	_	_
 2	טלייריני	טלייריני	PROPN	PROPN	_	3	obl	_	_
-3	קיבלנו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Tense=Past|Voice=Act	0	root	_	_
+3	קיבלנו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Root=ק.ב.ל|Tense=Past|Voice=Act	0	root	_	_
 4	ספגטיני	ספגטיני	PROPN	PROPN	_	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	4	punct	_	_
 6-7	שהיה	_	_	_	_	_	_	_	_
@@ -13841,13 +13841,13 @@
 7	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	8	cop	_	_
 8	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	9	aux	_	_
 9	להיות	היה	AUX	AUX	Polarity=Pos|VerbForm=Inf|VerbType=Cop	4	acl:relcl	_	_
-10	מתקבל	התקבל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	9	obl	_	_
+10	מתקבל	התקבל	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ק.ב.ל|VerbForm=Part	9	obl	_	_
 11	על	על	ADP	ADP	_	13	case	_	_
 12-13	הדעת	_	_	_	_	_	_	_	_
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	דעת	דעת	NOUN	NOUN	Gender=Fem|Number=Sing	10	advmod	_	_
 14	אלמלא	אלמלא	CCONJ	CCONJ	_	15	mark	_	_
-15	בושלה	בושל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	8	advcl	_	_
+15	בושלה	בושל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Root=ב.ש.ל|Tense=Past|Voice=Pass	8	advcl	_	_
 16-17	הפסטה	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
 17	פסטה	פסטה	NOUN	NOUN	Gender=Fem|Number=Sing	15	nsubj	_	_
@@ -13859,7 +13859,7 @@
 22	עד	עד	ADP	ADP	_	24	mark	_	_
 23-24	שנעשתה	_	_	_	_	_	_	_	_
 23	ש	ש	SCONJ	SCONJ	_	22	fixed	_	_
-24	נעשתה	נעשה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	15	advcl	_	_
+24	נעשתה	נעשה	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Mid	15	advcl	_	_
 25	רכרוכית	רכרוכי	ADJ	ADJ	Gender=Fem|Number=Sing	24	xcomp	_	SpaceAfter=No
 26	.	.	PUNCT	PUNCT	_	3	punct	_	_
 
@@ -13869,7 +13869,7 @@
 2	מה	מה	ADV	ADV	PronType=Int	13	nsubj	_	_
 3-4	שעשה	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	עשה	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	2	acl:relcl	_	_
+4	עשה	עשה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	2	acl:relcl	_	_
 5	את	את	ADP	ADP	Case=Acc	7	case:acc	_	_
 6-7	המנה	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -13902,9 +13902,9 @@
 13	רוטב	רוטב	NOUN	NOUN	Gender=Masc|Number=Sing	17	obl	_	_
 14-15	שקיבלנו	_	_	_	_	_	_	_	_
 14	ש	ש	SCONJ	SCONJ	_	15	mark	_	_
-15	קיבלנו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Tense=Past|Voice=Act	13	acl:relcl	_	_
+15	קיבלנו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Root=ק.ב.ל|Tense=Past|Voice=Act	13	acl:relcl	_	_
 16	לא	לא	ADV	ADV	Polarity=Neg	17	advmod	_	_
-17	היה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	3	conj	_	_
+17	היה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	3	conj	_	_
 18	שמץ	שמץ	NOUN	NOUN	Gender=Masc|Number=Sing	17	nsubj	_	_
 19	של	של	ADP	ADP	Case=Gen	20	case:gen	_	_
 20	שום	שום	NOUN	NOUN	Gender=Masc|Number=Sing	18	nmod:poss	_	SpaceAfter=No
@@ -13936,7 +13936,7 @@
 
 # sent_id = 6133
 # text = ידוע שלכל טבח יש יום רע, ועל כן חזרתי למסעדה בהזדמנות אחרת.
-1	ידוע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+1	ידוע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	0	root	_	_
 2-4	שלכל	_	_	_	_	_	_	_	_
 2	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
 3	ל	ל	ADP	ADP	_	5	case	_	_
@@ -13950,7 +13950,7 @@
 10	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
 11	על	על	ADP	ADP	_	13	advmod	_	_
 12	כן	כן	ADV	ADV	_	11	fixed	_	_
-13	חזרתי	חזר	VERB	VERB	Gender=Fem,Masc|Number=Sing|Person=1|Tense=Past	1	conj	_	_
+13	חזרתי	חזר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Sing|Person=1|Root=ח.ז.ר|Tense=Past	1	conj	_	_
 14-16	למסעדה	_	_	_	_	_	_	_	_
 14	ל	ל	ADP	ADP	_	16	case	_	_
 15	ה_	ה	DET	DET	PronType=Art	16	det:def	_	_
@@ -13989,7 +13989,7 @@
 4	נמוכים	נמוך	ADJ	ADJ	Gender=Masc|Number=Plur	0	root	_	_
 5	(	(	PUNCT	PUNCT	_	6	punct	_	SpaceAfter=No
 6	אפשר	אפשר	AUX	AUX	HebSource=ConvUncertainHead|VerbType=Mod	7	aux	_	_
-7	לקבל	קיבל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	4	dep	_	_
+7	לקבל	קיבל	VERB	VERB	HebBinyan=PIEL|Root=ק.ב.ל|VerbForm=Inf|Voice=Act	4	dep	_	_
 8	ארוחת	ארוחה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	7	obj	_	_
 9	ערב	ערב	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	_
 10	מלאה	מלאה	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
@@ -14008,7 +14008,7 @@
 21-22	האוכל	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	det:def	_	_
 22	אוכל	אוכל	NOUN	NOUN	Gender=Masc|Number=Sing	23	nsubj	_	_
-23	מאכזב	אכזב	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	4	conj	_	SpaceAfter=No
+23	מאכזב	אכזב	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=א.כ.ז.ב|VerbForm=Part|Voice=Act	4	conj	_	SpaceAfter=No
 24	.	.	PUNCT	PUNCT	_	4	punct	_	_
 
 # sent_id = 6136
@@ -14016,12 +14016,12 @@
 1-2	מאז	_	_	_	_	_	_	_	_
 1	מ	מ	ADP	ADP	_	3	case	_	_
 2	אז	אז	ADV	ADV	_	1	fixed	_	_
-3	נפתחה	נפתח	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	9	nmod	_	_
+3	נפתחה	נפתח	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=פ.ת.ח|Tense=Past|Voice=Mid	9	nmod	_	_
 4-5	בינואר	_	_	_	_	_	_	_	SpaceAfter=No
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	ינואר	ינואר	PROPN	PROPN	_	3	obl	_	_
 6	,	,	PUNCT	PUNCT	_	9	punct	_	_
-7	הפכה	הפך	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	9	aux	_	_
+7	הפכה	הפך	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ה.פ.כ|Tense=Past	9	aux	_	_
 8-9	למסעדה	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	9	case	_	_
 9	מסעדה	מסעדה	NOUN	NOUN	Gender=Fem|Number=Sing	0	root	_	_
@@ -14034,7 +14034,7 @@
 1-2	הארוחה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	ארוחה	ארוחה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	נפתחה	נפתח	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+3	נפתחה	נפתח	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=פ.ת.ח|Tense=Past|Voice=Mid	0	root	_	_
 4-5	בפונגי	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	פונגי	פונגי	PROPN	PROPN	_	3	obl	_	_
@@ -14045,7 +14045,7 @@
 10	פטריות	פטרייה	NOUN	NOUN	Gender=Fem|Number=Plur	5	appos	_	_
 11-12	המוגשות	_	_	_	_	_	_	_	_
 11	ה	ה	SCONJ	SCONJ	_	12	mark	_	_
-12	מוגשות	הוגש	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	10	acl:relcl	_	_
+12	מוגשות	הוגש	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=נ.ג.ש|VerbForm=Part|Voice=Pass	10	acl:relcl	_	_
 13-14	ברוטב	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	רוטב	רוטב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	obl	_	_
@@ -14060,7 +14060,7 @@
 2	פטריות	פטרייה	NOUN	NOUN	Gender=Fem|Number=Plur	6	nsubj	_	_
 3-4	המושחמות	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
-4	מושחמות	הושחם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	2	amod	_	_
+4	מושחמות	הושחם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ש.ח.מ|VerbForm=Part|Voice=Pass	2	amod	_	_
 5	היו	_	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	6	cop	_	_
 6	בסדר	בסדר	ADV	ADV	_	0	root	_	SpaceAfter=No
 7	,	,	PUNCT	PUNCT	_	6	punct	_	_
@@ -14074,7 +14074,7 @@
 14-15	ובלתי	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	16	cc	_	_
 15	בלתי	בלתי	ADV	ADV	Prefix=Yes	16	compound:affix	_	_
-16	מגרה	גירה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	13	conj	_	SpaceAfter=No
+16	מגרה	גירה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ג.ר.י|VerbForm=Part|Voice=Act	13	conj	_	SpaceAfter=No
 17	.	.	PUNCT	PUNCT	_	6	punct	_	_
 
 # sent_id = 6139
@@ -14088,7 +14088,7 @@
 5	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	1	amod	_	_
 6-7	שטעמנו	_	_	_	_	_	_	_	_
 6	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
-7	טעמנו	טעם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Past|Voice=Act	1	acl:relcl	_	_
+7	טעמנו	טעם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=ט.ע.מ|Tense=Past|Voice=Act	1	acl:relcl	_	_
 8	היתה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	9	cop	_	_
 9	ניוקי	ניוקי	NOUN	NOUN	Gender=Masc|Number=Sing	0	root	_	_
 10	אלה	אלה	PROPN	PROPN	_	9	flat:name	_	_
@@ -14111,7 +14111,7 @@
 11	,	,	PUNCT	PUNCT	_	10	punct	_	_
 12	אבל	אבל	CCONJ	CCONJ	_	14	cc	_	_
 13	הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	14	nsubj	_	_
-14	הושארו	הושאר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	10	conj	_	_
+14	הושארו	הושאר	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=ש.א.ר|Tense=Past|Voice=Pass	10	conj	_	_
 15-17	במים	_	_	_	_	_	_	_	_
 15	ב	ב	ADP	ADP	_	17	case	_	_
 16	ה_	ה	DET	DET	PronType=Art	17	det:def	_	_
@@ -14141,7 +14141,7 @@
 6	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	7	cop	_	_
 7	טעים	טעים	ADJ	ADJ	Gender=Masc|HebSource=ConvUncertainHead|Number=Sing	1	dep	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	9	punct	_	_
-9	נעדר	נעדר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	0	root	_	_
+9	נעדר	נעדר	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ע.ד.ר|VerbForm=Part|Voice=Mid	0	root	_	_
 10-11	ממנו	_	_	_	_	_	_	_	_
 10	ממנו	ממנו	ADP	ADP	_	11	case	_	_
 11	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	obl	_	_
@@ -14162,11 +14162,11 @@
 22	,	,	PUNCT	PUNCT	_	21	punct	_	_
 23-24	הנחשבת	_	_	_	_	_	_	_	_
 23	ה	ה	SCONJ	SCONJ	_	24	mark	_	_
-24	נחשבת	נחשב	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Mid	21	acl:relcl	_	_
+24	נחשבת	נחשב	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ח.ש.ב|VerbForm=Part|Voice=Mid	21	acl:relcl	_	_
 25-26	בעיני	_	_	_	_	_	_	_	_
 25	ב	ב	ADP	ADP	_	26	case	_	_
 26	עיני	עין	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	24	obl	_	_
-27	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	26	compound:smixut	_	_
+27	רבים	רב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ר.ב.י|VerbForm=Part|Voice=Act	26	compound:smixut	_	_
 28-30	לגבינה	_	_	_	_	_	_	_	_
 28	ל	ל	ADP	ADP	_	30	case	_	_
 29	ה_	ה	DET	DET	PronType=Art	30	det:def	_	_
@@ -14214,7 +14214,7 @@
 17	מנה	מנה	NOUN	NOUN	Gender=Fem|Number=Sing	29	nsubj	_	_
 18-19	שעשתה	_	_	_	_	_	_	_	_
 18	ש	ש	SCONJ	SCONJ	_	19	mark	_	_
-19	עשתה	עשה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	17	acl:relcl	_	_
+19	עשתה	עשה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ש.י|Tense=Past|Voice=Act	17	acl:relcl	_	_
 20	את	את	ADP	ADP	Case=Acc	21	case:acc	_	_
 21-23	דרכה	_	_	_	_	_	_	_	_
 21	דרך_	דרך	NOUN	NOUN	Definite=Def|Gender=Fem|Number=Sing	19	obj	_	_
@@ -14226,7 +14226,7 @@
 26	_של_	של	ADP	ADP	_	27	case:gen	_	_
 27	_אנחנו	הוא	PRON	PRON	Case=Gen|Gender=Fem,Masc|Number=Plur|Person=1|PronType=Prs	25	nmod:poss	_	_
 28	היתה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	29	cop	_	_
-29	שטוחה	שטח	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+29	שטוחה	שטח	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ש.ט.ח|VerbForm=Part|Voice=Act	0	root	_	_
 30-32	כלביבה	_	_	_	_	_	_	_	SpaceAfter=No
 30	כ	כ	ADP	ADP	_	32	case	_	_
 31	ה_	ה	DET	DET	PronType=Art	32	det:def	_	_
@@ -14235,7 +14235,7 @@
 
 # sent_id = 6144
 # text = חסרות לחלוטין היו השכבות האופייניות של רוטב בשר וגבינה העושות מנה זאת מפתה כל כך.
-1	חסרות	_	VERB	VERB	VerbForm=Part	0	root	_	_
+1	חסרות	_	VERB	VERB	HebBinyan=PAAL|Root=ח.ס.ר|VerbForm=Part	0	root	_	_
 2	לחלוטין	לחלוטין	ADV	ADV	_	1	advmod	_	_
 3	היו	_	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	1	cop	_	_
 4-5	השכבות	_	_	_	_	_	_	_	_
@@ -14252,7 +14252,7 @@
 12	גבינה	גבינה	NOUN	NOUN	Gender=Fem|Number=Sing	10	conj	_	_
 13-14	העושות	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	mark	_	_
-14	עושות	עשה	VERB	VERB	VerbForm=Part	5	acl:relcl	_	_
+14	עושות	עשה	VERB	VERB	HebBinyan=PAAL|Root=ע.ש.י|VerbForm=Part	5	acl:relcl	_	_
 15	מנה	מנה	NOUN	NOUN	Gender=Fem|Number=Sing	14	obj	_	_
 16	זאת	זאת	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Dem	15	det	_	_
 17	מפתה	מפתה	ADJ	ADJ	Gender=Fem|HebSource=ConvUncertainHead|Number=Sing	14	dep	_	_
@@ -14266,12 +14266,12 @@
 1	ו	ו	CCONJ	CCONJ	_	19	cc	_	_
 2	כאילו	כאילו	ADV	ADV	_	3	advmod	_	_
 3	כדי	כדי	ADP	ADP	_	4	case	_	_
-4	להוסיף	הוסיף	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	9	advcl	_	_
+4	להוסיף	הוסיף	VERB	VERB	HebBinyan=HIFIL|Root=י.ס.פ|VerbForm=Inf|Voice=Act	9	advcl	_	_
 5	חטא	חטא	NOUN	NOUN	Gender=Masc|Number=Sing	4	obj	_	_
 6	על	על	ADP	ADP	_	7	case	_	_
 7	פשע	פשע	NOUN	NOUN	Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	9	punct	_	_
-9	חוממה	חומם	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+9	חוממה	חומם	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Root=ח.מ.מ|Tense=Past|Voice=Pass	0	root	_	_
 10-11	הלזניה	_	_	_	_	_	_	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	לזניה	לזניה	PROPN	PROPN	_	9	dep	_	_
@@ -14287,7 +14287,7 @@
 19	ו	ו	CCONJ	CCONJ	_	22	cc	_	_
 20	ב	ב	ADP	ADP	_	21	case	_	_
 21	כך	כך	PRON	PRON	Person=3|PronType=Dem	22	obl	_	_
-22	הפכו	הפך	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	9	conj	_	_
+22	הפכו	הפך	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ה.פ.כ|Tense=Past	9	conj	_	_
 23	את	את	ADP	ADP	Case=Acc	24	case:acc	_	_
 24	קרום	קרום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	22	obj	_	_
 25-26	הגבינה	_	_	_	_	_	_	_	_
@@ -14301,7 +14301,7 @@
 30	משהו	משהו	NOUN	NOUN	Gender=Masc|Number=Sing	22	obl	_	_
 31-32	שדומה	_	_	_	_	_	_	_	_
 31	ש	ש	SCONJ	SCONJ	_	32	mark	_	_
-32	דומה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	30	acl:relcl	_	_
+32	דומה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ד.מ.י|VerbForm=Part|Voice=Act	30	acl:relcl	_	_
 33-34	לגומי	_	_	_	_	_	_	_	SpaceAfter=No
 33	ל	ל	ADP	ADP	_	34	case	_	_
 34	גומי	גומי	NOUN	NOUN	Gender=Masc|Number=Sing	32	obl	_	_
@@ -14321,7 +14321,7 @@
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	טאראגון	טאראגון	PROPN	PROPN	_	6	nmod	_	_
 9	,	,	PUNCT	PUNCT	_	10	punct	_	_
-10	שיפרה	שיפר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+10	שיפרה	שיפר	VERB	VERB	Gender=Fem|HebBinyan=PIEL|Number=Sing|Person=3|Root=ש.פ.ר|Tense=Past|Voice=Act	0	root	_	_
 11	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 12-13	המצב	_	_	_	_	_	_	_	SpaceAfter=No
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
@@ -14336,7 +14336,7 @@
 3	,	,	PUNCT	PUNCT	_	2	punct	_	_
 4-5	שהושחם	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	הושחם	הושחם	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	2	acl:relcl	_	_
+5	הושחם	הושחם	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ש.ח.מ|Tense=Past|Voice=Pass	2	acl:relcl	_	_
 6-7	בתערובת	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	תערובת	תערובת	NOUN	NOUN	Gender=Fem|Number=Sing	5	obl	_	_
@@ -14349,7 +14349,7 @@
 12	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
 13	אחר	אחר	ADP	ADP	_	14	case	_	_
 14	כך	כך	PRON	PRON	Person=3|PronType=Dem	15	obl	_	_
-15	נצלה	נצלה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	5	conj	_	_
+15	נצלה	נצלה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=צ.ל.י|Tense=Past|Voice=Mid	5	conj	_	_
 16	עם	עם	ADP	ADP	_	17	case	_	_
 17	ירקות	ירקות	NOUN	NOUN	Gender=Masc|Number=Plur	15	obl	_	SpaceAfter=No
 18	,	,	PUNCT	PUNCT	_	17	punct	_	_
@@ -14375,7 +14375,7 @@
 34	ש	ש	SCONJ	SCONJ	_	36	mark	_	_
 35	הייתי	_	AUX	AUX	Gender=Fem,Masc|Number=Sing|Person=1|Polarity=Pos|Tense=Past|VerbType=Cop	36	cop	_	_
 36	מוכן	מוכן	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbType=Mod	37	aux	_	_
-37	להתעלם	התעלם	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	26	obl	_	_
+37	להתעלם	התעלם	VERB	VERB	HebBinyan=HITPAEL|Root=ע.ל.מ|VerbForm=Inf	26	obl	_	_
 38-40	מהכמות	_	_	_	_	_	_	_	_
 38	מ	מ	ADP	ADP	_	40	case	_	_
 39	ה	ה	DET	DET	PronType=Art	40	det:def	_	_
@@ -14389,7 +14389,7 @@
 46	בישול	בישול	NOUN	NOUN	Gender=Masc|Number=Sing	45	compound:smixut	_	_
 47-48	שנותרה	_	_	_	_	_	_	_	_
 47	ש	ש	SCONJ	SCONJ	_	48	mark	_	_
-48	נותרה	נותר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	40	acl:relcl	_	_
+48	נותרה	נותר	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.ת.ר|Tense=Past|Voice=Mid	40	acl:relcl	_	_
 49	על	על	ADP	ADP	_	51	case	_	_
 50-51	הצלחת	_	_	_	_	_	_	_	SpaceAfter=No
 50	ה	ה	DET	DET	PronType=Art	51	det:def	_	_
@@ -14403,7 +14403,7 @@
 2	טירמיסו	טירמיסו	NOUN	NOUN	Gender=Masc|Number=Sing	8	nsubj	_	_
 3-4	שקיבלנו	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	קיבלנו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Tense=Past|Voice=Act	2	acl:relcl	_	_
+4	קיבלנו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Root=ק.ב.ל|Tense=Past|Voice=Act	2	acl:relcl	_	_
 5-6	לקינוח	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	קינוח	קינוח	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
@@ -14427,18 +14427,18 @@
 10	שניים	שניים	NUM	NUM	Gender=Masc|Number=Plur	8	nmod	_	_
 11-12	המבוססת	_	_	_	_	_	_	_	_
 11	ה	ה	SCONJ	SCONJ	_	12	mark	_	_
-12	מבוססת	בוסס	VERB	VERB	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part	8	acl:relcl	_	_
+12	מבוססת	בוסס	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ס.ס|VerbForm=Part	8	acl:relcl	_	_
 13	על	על	ADP	ADP	_	15	case	_	_
 14-15	המנות	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	מנות	מנה	NOUN	NOUN	Gender=Fem|Number=Plur	12	obl	_	_
 16	הללו	הללו	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	15	det	_	_
-17	תעלה	עלה	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Fut	0	root	_	_
+17	תעלה	עלה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ל.י|Tense=Fut	0	root	_	_
 18-19	כ051	_	_	_	_	_	_	_	_
 18	כ	כ	ADP	ADP	_	20	det	_	_
 19	150	150	NUM	NUM	_	20	nummod	_	_
 20	ש"ח	ש"ח	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	17	obj	_	_
-21	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	22	case	_	_
+21	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	22	case	_	_
 22	שירות	שירות	NOUN	NOUN	Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
 23	.	.	PUNCT	PUNCT	_	17	punct	_	_
 
@@ -14449,7 +14449,7 @@
 2	מחיר	מחיר	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 3	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	2	det	_	_
 4	אפשר	אפשר	AUX	AUX	VerbType=Mod	5	aux	_	_
-5	לצפות	ציפה	VERB	VERB	VerbForm=Inf	0	root	_	_
+5	לצפות	ציפה	VERB	VERB	HebBinyan=PIEL|Root=צ.פ.י|VerbForm=Inf	0	root	_	_
 6-7	למשהו	_	_	_	_	_	_	_	_
 6	ל	ל	ADP	ADP	_	7	case	_	_
 7	משהו	משהו	NOUN	NOUN	Gender=Masc|Number=Sing	5	obl	_	_
@@ -14459,7 +14459,7 @@
 
 # sent_id = 6151
 # text = מעוצבת כביסטרו שתפריטו כולל, בין היתר, מנות איטלקיות פשוטות וטובות.
-1	מעוצבת	עוצב	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+1	מעוצבת	עוצב	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ע.צ.ב|VerbForm=Part|Voice=Pass	0	root	_	_
 2-3	כביסטרו	_	_	_	_	_	_	_	_
 2	כ	כ	ADP	ADP	_	3	case	_	_
 3	ביסטרו	ביסטרו	NOUN	NOUN	_	1	obl	_	_
@@ -14468,7 +14468,7 @@
 5	תפריט_	תפריט	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
 6	_של_	של	ADP	ADP	_	7	case:gen	_	_
 7	_הוא	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nmod:poss	_	_
-8	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	acl:relcl	_	SpaceAfter=No
+8	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	3	acl:relcl	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	8	punct	_	_
 10	בין	בין	ADP	ADP	_	12	case	_	_
 11-12	היתר	_	_	_	_	_	_	_	SpaceAfter=No
@@ -14496,7 +14496,7 @@
 6	ש	ש	SCONJ	SCONJ	_	9	mark	_	_
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	עין	עין	NOUN	NOUN	Gender=Fem|Number=Sing	9	nsubj	_	_
-9	קולטת	קלט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	3	acl:relcl	_	_
+9	קולטת	קלט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ק.ל.ט|VerbForm=Part|Voice=Act	3	acl:relcl	_	_
 10	הוא	הוא	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|VerbForm=Part|VerbType=Cop	11	cop	_	_
 11	שולחן	שולחן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	0	root	_	_
 12	אנטיפסטו	אנטיפסטו	PROPN	PROPN	_	11	compound:smixut	_	_
@@ -14513,7 +14513,7 @@
 22	סוגי	סוג	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	18	conj	_	_
 23	הרינג	הרינג	NOUN	NOUN	Gender=Masc|Number=Sing	22	compound:smixut	_	SpaceAfter=No
 24	,	,	PUNCT	PUNCT	_	18	punct	_	_
-25	מתאבנים	התאבן	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	18	conj	_	_
+25	מתאבנים	התאבן	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=_|VerbForm=Part	18	conj	_	_
 26	קרים	קר	ADJ	ADJ	Gender=Masc|Number=Plur	25	amod	_	_
 27	אחרים	אחר	ADJ	ADJ	Gender=Masc|Number=Plur	25	amod	_	_
 28-29	ותצוגה	_	_	_	_	_	_	_	_
@@ -14528,7 +14528,7 @@
 # text = אפשר בקלות להרכיב ארוחה מן הדברים הללו לבדם, אבל החלטנו ללכת על ארוחה קלה שכולה פסטה.
 1	אפשר	אפשר	AUX	AUX	VerbType=Mod	3	aux	_	_
 2	בקלות	_	ADV	ADV	_	1	advmod	_	_
-3	להרכיב	הרכיב	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	0	root	_	_
+3	להרכיב	הרכיב	VERB	VERB	HebBinyan=HIFIL|Root=ר.כ.ב|VerbForm=Inf|Voice=Act	0	root	_	_
 4	ארוחה	ארוחה	NOUN	NOUN	Gender=Fem|Number=Sing	3	obj	_	_
 5	מן	מן	ADP	ADP	_	7	case	_	_
 6-7	הדברים	_	_	_	_	_	_	_	_
@@ -14538,8 +14538,8 @@
 9	לבדם	לבד	ADV	ADV	_	7	advmod	_	SpaceAfter=No
 10	,	,	PUNCT	PUNCT	_	1	punct	_	_
 11	אבל	אבל	CCONJ	CCONJ	_	12	cc	_	_
-12	החלטנו	החליט	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Tense=Past|Voice=Act	1	conj	_	_
-13	ללכת	הלך	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	12	xcomp	_	_
+12	החלטנו	החליט	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Root=ח.ל.ט|Tense=Past|Voice=Act	1	conj	_	_
+13	ללכת	הלך	VERB	VERB	HebBinyan=PAAL|Root=ה.ל.כ|VerbForm=Inf|Voice=Act	12	xcomp	_	_
 14	על	על	ADP	ADP	_	15	case	_	_
 15	ארוחה	ארוחה	NOUN	NOUN	Gender=Fem|Number=Sing	13	obl	_	_
 16	קלה	קל	ADJ	ADJ	Gender=Fem|Number=Sing	15	amod	_	_
@@ -14559,7 +14559,7 @@
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	ירוק	ירוק	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
 5	,	,	PUNCT	PUNCT	_	2	punct	_	_
-6	ממולא	מולא	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	2	acl	_	_
+6	ממולא	מולא	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=מ.ל.א|VerbForm=Part|Voice=Pass	2	acl	_	_
 7-8	בבלוטות	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	בלוטות	בלוטה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	6	obl	_	_
@@ -14568,11 +14568,11 @@
 10	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
 11	על_	על	ADP	ADP	_	12	case	_	_
 12	_הן	הוא	PRON	PRON	Gender=Fem|Number=Plur|Person=3|PronType=Prs	13	obl	_	_
-13	היזו	_	VERB	VERB	_	8	acl:relcl	_	_
+13	היזו	_	VERB	VERB	HebBinyan=HIFIL|Root=נ.ז.י	8	acl:relcl	_	_
 14	יין	יין	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	13	obj	_	_
 15	שרי	שרי	NOUN	NOUN	Gender=Masc|Number=Sing	14	compound:smixut	_	SpaceAfter=No
 16	,	,	PUNCT	PUNCT	_	17	punct	_	_
-17	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	0	root	_	_
+17	הגיע	הגיע	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ע|Tense=Past|Voice=Act	0	root	_	_
 18	עם	עם	ADP	ADP	_	19	case	_	_
 19	רוטב	רוטב	NOUN	NOUN	Gender=Masc|Number=Sing	17	obl	_	_
 20	של	של	ADP	ADP	Case=Gen	21	case:gen	_	_
@@ -14587,7 +14587,7 @@
 27	למרות	למרות	ADP	ADP	_	29	mark	_	_
 28-29	שהיה	_	_	_	_	_	_	_	_
 28	ש	ש	SCONJ	SCONJ	_	27	fixed	_	_
-29	היה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	36	advcl	_	_
+29	היה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	36	advcl	_	_
 30-31	בו	_	_	_	_	_	_	_	_
 30	ב_	ב	ADP	ADP	_	31	case	_	_
 31	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	29	obl	_	_
@@ -14608,7 +14608,7 @@
 4	,	,	PUNCT	PUNCT	_	3	punct	_	_
 5-6	שהוגשו	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
-6	הוגשו	הוגש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	3	acl:relcl	_	_
+6	הוגשו	הוגש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Pass	3	acl:relcl	_	_
 7	עם	עם	ADP	ADP	_	8	case	_	_
 8	רוטב	רוטב	NOUN	NOUN	Gender=Masc|Number=Sing	6	obl	_	_
 9	דומה	דומה	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
@@ -14624,7 +14624,7 @@
 # sent_id = 6156
 # text = מכאן המשכנו ללזניה, מנה רבת שכבות עם אטריות מבושלות היטב, רוטב בולונז, רוטב בשמל וגבינת פרמזן.
 1	מכאן	מכאן	ADV	ADV	_	2	advmod	_	_
-2	המשכנו	המשיך	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Tense=Past|Voice=Act	0	root	_	_
+2	המשכנו	המשיך	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Root=מ.ש.כ|Tense=Past|Voice=Act	0	root	_	_
 3-4	ללזניה	_	_	_	_	_	_	_	SpaceAfter=No
 3	ל	ל	ADP	ADP	_	4	case	_	_
 4	לזניה	לזניה	PROPN	PROPN	_	2	obl	_	_
@@ -14634,7 +14634,7 @@
 8	שכבות	שכבה	NOUN	NOUN	Gender=Fem|Number=Plur	7	compound:smixut	_	_
 9	עם	עם	ADP	ADP	_	10	case	_	_
 10	אטריות	אטרייה	NOUN	NOUN	Gender=Fem|Number=Plur	6	nmod	_	_
-11	מבושלות	בושל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	10	amod	_	_
+11	מבושלות	בושל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ב.ש.ל|VerbForm=Part|Voice=Pass	10	amod	_	_
 12	היטב	היטב	ADV	ADV	_	11	advmod	_	SpaceAfter=No
 13	,	,	PUNCT	PUNCT	_	10	punct	_	_
 14	רוטב	רוטב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	10	conj	_	_
@@ -14650,7 +14650,7 @@
 
 # sent_id = 6157
 # text = ניסינו גם פטוציני אלפרדו, אותה מנה רומאית קלאסית שבה הפסטה מכוסה ברוטב של חמאה, שמנת חמוצה וגבינה.
-1	ניסינו	ניסה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Tense=Past|Voice=Act	0	root	_	_
+1	ניסינו	ניסה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Root=נ.ס.י|Tense=Past|Voice=Act	0	root	_	_
 2	גם	גם	ADV	ADV	_	1	advmod	_	_
 3	פטוציני	פטוציני	PROPN	PROPN	_	1	obj	_	_
 4	אלפרדו	אלפרדו	PROPN	PROPN	_	3	flat:name	_	SpaceAfter=No
@@ -14666,7 +14666,7 @@
 13-14	הפסטה	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	פסטה	פסטה	NOUN	NOUN	Gender=Fem|Number=Sing	15	nsubj	_	_
-15	מכוסה	כוסה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	7	acl:relcl	_	_
+15	מכוסה	כוסה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=כ.ס.י|VerbForm=Part|Voice=Pass	7	acl:relcl	_	_
 16-17	ברוטב	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	רוטב	רוטב	NOUN	NOUN	Gender=Masc|Number=Sing	15	obl	_	_
@@ -14686,7 +14686,7 @@
 2-3	המנות	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	מנות	מנה	NOUN	NOUN	Gender=Fem|Number=Plur	4	nsubj	_	_
-4	עמדו	עמד	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	0	root	_	_
+4	עמדו	עמד	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ע.מ.ד|Tense=Past	0	root	_	_
 5-6	בהצלחה	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	הצלחה	הצלחה	NOUN	NOUN	Gender=Fem|Number=Sing	4	obl	_	_
@@ -14708,10 +14708,10 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	סך	סך	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obl	_	_
 3	הכל	הכיל	NOUN	NOUN	_	2	compound:smixut	_	_
-4	היה	_	VERB	VERB	Gender=Masc|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Tense=Past	0	root	_	_
+4	היה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebExistential=True|Number=Sing|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Past	0	root	_	_
 5	שם	שם	ADV	ADV	_	4	advmod	_	_
 6	מזון	מזון	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
-7	מספיק	הספיק	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	6	acl	_	_
+7	מספיק	הספיק	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ס.פ.ק|VerbForm=Part|Voice=Act	6	acl	_	_
 8-9	לארבעה	_	_	_	_	_	_	_	_
 8	ל	ל	ADP	ADP	_	10	case	_	_
 9	ארבעה	ארבעה	NUM	NUM	Gender=Masc|Number=Sing	10	nummod	_	_
@@ -14721,7 +14721,7 @@
 12	ה	ה	DET	DET	PronType=Art	13	det:def	_	_
 13	חשבון	חשבון	NOUN	NOUN	Gender=Masc|Number=Sing	27	nsubj	_	_
 14	,	,	PUNCT	PUNCT	_	16	punct	_	_
-15	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	16	case	_	_
+15	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	16	case	_	_
 16	קנקן	קנקן	NOUN	NOUN	Gender=Masc|Number=Sing	13	appos	_	_
 17	גדול	גדול	ADJ	ADJ	Gender=Masc|Number=Sing	16	amod	_	_
 18	של	של	ADP	ADP	Case=Gen	19	case:gen	_	_
@@ -14762,7 +14762,7 @@
 13	,	,	PUNCT	PUNCT	_	11	punct	_	_
 14-15	המוגבל	_	_	_	_	_	_	_	_
 14	ה	ה	SCONJ	SCONJ	_	15	mark	_	_
-15	מוגבל	הוגבל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	11	acl:relcl	_	_
+15	מוגבל	הוגבל	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ג.ב.ל|VerbForm=Part|Voice=Pass	11	acl:relcl	_	_
 16-17	בכוונה	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	כוונה	כוונה	NOUN	NOUN	Gender=Fem|Number=Sing	15	obl	_	_
@@ -14787,7 +14787,7 @@
 35	סביר	סביר	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
 36-37	ונע	_	_	_	_	_	_	_	_
 36	ו	ו	CCONJ	CCONJ	_	37	cc	_	_
-37	נע	נע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	35	conj	_	_
+37	נע	נע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=נ.ו.ע|VerbForm=Part|Voice=Act	35	conj	_	_
 38-39	מ21	_	_	_	_	_	_	_	_
 38	מ	מ	ADP	ADP	_	39	case	_	_
 39	12	12	NUM	NUM	_	37	obl	_	_
@@ -14800,7 +14800,7 @@
 # text = בהחלט שווה לנסות.
 1	בהחלט	בהחלט	ADV	ADV	_	2	advmod	_	_
 2	שווה	שווה	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
-3	לנסות	ניסה	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	2	xcomp	_	SpaceAfter=No
+3	לנסות	ניסה	VERB	VERB	HebBinyan=PIEL|Root=נ.ס.י|VerbForm=Inf|Voice=Act	2	xcomp	_	SpaceAfter=No
 4	.	.	PUNCT	PUNCT	_	2	punct	_	_
 
 # sent_id = 6162
@@ -14832,12 +14832,12 @@
 21-23	והמזמינים	_	_	_	_	_	_	_	_
 21	ו	ו	CCONJ	CCONJ	_	23	cc	_	_
 22	ה	ה	DET	DET	PronType=Art	23	det:def	_	_
-23	מזמינים	הזמין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	20	conj	_	_
+23	מזמינים	הזמין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ז.מ.נ|VerbForm=Part|Voice=Act	20	conj	_	_
 24-25	שהייתם	_	_	_	_	_	_	_	_
 24	ש	ש	SCONJ	SCONJ	_	26	mark	_	_
 25	הייתם	היה	AUX	AUX	Gender=Masc|Number=Plur|Person=2|Polarity=Pos|Tense=Past|VerbType=Cop	26	cop	_	_
-26	מצפים	ציפה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	18	acl:relcl	_	_
-27	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|VerbForm=Inf|Voice=Act	26	xcomp	_	_
+26	מצפים	ציפה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=צ.פ.י|VerbForm=Part|Voice=Act	18	acl:relcl	_	_
+27	למצוא	מצא	VERB	VERB	HebBinyan=PAAL|Root=מ.צ.א|VerbForm=Inf|Voice=Act	26	xcomp	_	_
 28	בין	בין	ADP	ADP	_	29	case	_	_
 29	גבעות	גבעה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Plur	27	obl	_	_
 30	טוסקאנה	טוסקאנה	PROPN	PROPN	_	29	compound:smixut	_	SpaceAfter=No
@@ -14849,7 +14849,7 @@
 2	,	,	PUNCT	PUNCT	_	1	punct	_	_
 3-4	שרכש	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	רכש	רכש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	1	acl:relcl	_	_
+4	רכש	רכש	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ר.כ.ש|Tense=Past|Voice=Act	1	acl:relcl	_	_
 5-6	לעצמו	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	עצמו	עצמו	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	4	obl	_	_
@@ -14864,8 +14864,8 @@
 12	ב	ב	ADP	ADP	_	13	case	_	_
 13	יפו	יפו	PROPN	PROPN	_	9	nmod	_	_
 14	,	,	PUNCT	PUNCT	_	15	punct	_	_
-15	ממונה	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
-16	כאן	כאן	VERB	VERB	HebSource=ConvUncertainHead|VerbForm=Part	15	dep	_	_
+15	ממונה	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=מ.נ.י|VerbForm=Part|Voice=Pass	0	root	_	_
+16	כאן	כאן	VERB	VERB	HebBinyan=_|HebSource=ConvUncertainHead|Root=_|VerbForm=Part	15	dep	_	_
 17	על	על	ADP	ADP	_	19	case	_	_
 18-19	המטבח	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
@@ -14875,11 +14875,11 @@
 21	איש	איש	NOUN	NOUN	Gender=Masc|Number=Sing	23	nsubj	_	_
 22	אינו	אינו	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	23	advmod	_	_
 23	יכול	_	AUX	AUX	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	24	aux	_	_
-24	להתלונן	התלונן	VERB	VERB	HebBinyan=HITPAEL|VerbForm=Inf	15	conj	_	_
+24	להתלונן	התלונן	VERB	VERB	HebBinyan=HITPAEL|Root=ל.ו.נ|VerbForm=Inf	15	conj	_	_
 25-27	שהאוכל	_	_	_	_	_	_	_	_
 25	ש	ש	SCONJ	SCONJ	_	29	mark	_	_
 26	ה	ה	DET	DET	PronType=Art	27	det:def	_	_
-27	אוכל	אכל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	29	nsubj	_	_
+27	אוכל	אכל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=א.כ.ל|VerbForm=Part|Voice=Act	29	nsubj	_	_
 28	אינו	אינו	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	29	advmod	_	_
 29	איטלקי	איטלקי	ADJ	ADJ	Gender=Masc|Number=Sing	24	xcomp	_	_
 30	אותנטי	אותנטי	ADJ	ADJ	Gender=Masc|Number=Sing	29	dep	_	SpaceAfter=No
@@ -14894,18 +14894,18 @@
 3	ש	ש	SCONJ	SCONJ	_	6	mark	_	_
 4	ב_	ב	ADP	ADP	_	5	case	_	_
 5	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	obl	_	_
-6	פתחנו	פתח	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=1|Tense=Past	2	acl:relcl	_	_
+6	פתחנו	פתח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=פ.ת.ח|Tense=Past	2	acl:relcl	_	_
 7	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	8	cop	_	_
 8	מצוין	מצוין	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 9	,	,	PUNCT	PUNCT	_	8	punct	_	_
-10	מבושל	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	8	conj	_	_
+10	מבושל	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ש.ל|VerbForm=Part|Voice=Pass	8	conj	_	_
 11-12	בצורה	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	צורה	צורה	NOUN	NOUN	Gender=Fem|Number=Sing	10	obl	_	_
 13	מושלמת	מושלם	ADJ	ADJ	Gender=Fem|Number=Sing	12	amod	_	_
 14-15	ומוגש	_	_	_	_	_	_	_	_
 14	ו	ו	CCONJ	CCONJ	_	15	cc	_	_
-15	מוגש	הוגש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	8	conj	_	_
+15	מוגש	הוגש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=נ.ג.ש|VerbForm=Part|Voice=Pass	8	conj	_	_
 16-17	ברוטב	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	רוטב	רוטב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	15	obl	_	_
@@ -14933,7 +14933,7 @@
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	מינסטרונה	מינסטרונה	PROPN	PROPN	_	1	compound:smixut	_	_
 4	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	5	cop	_	_
-5	מספק	סיפק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+5	מספק	סיפק	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ס.פ.ק|VerbForm=Part|Voice=Act	0	root	_	_
 6	לא	לא	ADV	ADV	Polarity=Neg	7	advmod	_	_
 7	פחות	פחות	ADV	ADV	_	5	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	PUNCT	_	5	punct	_	_
@@ -14946,16 +14946,16 @@
 3-4	העשיר	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	עשיר	עשיר	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-5	התמזג	התמזג	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+5	התמזג	התמזג	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=מ.ז.ג|Tense=Past	0	root	_	_
 6	היטב	היטב	ADV	ADV	_	5	advmod	_	_
 7-8	בירקות	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	ירקות	ירקות	NOUN	NOUN	Gender=Masc|Number=Plur	5	obl	_	_
-9	מבושלים	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	8	amod	_	_
+9	מבושלים	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ב.ש.ל|VerbForm=Part|Voice=Pass	8	amod	_	_
 10-12	והמתובלים	_	_	_	_	_	_	_	SpaceAfter=No
 10	ו	ו	CCONJ	CCONJ	HebSource=ConvUncertainHead	8	dep	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
-12	מתובלים	תובל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	8	amod	_	_
+12	מתובלים	תובל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ת.ב.ל|VerbForm=Part|Voice=Pass	8	amod	_	_
 13	.	.	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 6167
@@ -14974,7 +14974,7 @@
 11-12	העוף	_	_	_	_	_	_	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	עוף	עוף	NOUN	NOUN	Gender=Masc|Number=Sing	9	nmod:poss	_	_
-13	מבושל	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	4	advcl	_	_
+13	מבושל	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ש.ל|VerbForm=Part|Voice=Pass	4	advcl	_	_
 14	בדיוק	בדיוק	ADV	ADV	_	15	advmod	_	_
 15	עד	עד	ADP	ADP	_	18	case	_	_
 16-18	לנקודה	_	_	_	_	_	_	_	_
@@ -15009,7 +15009,7 @@
 8	עגל	עגל	NOUN	NOUN	Gender=Masc|Number=Sing	5	nmod	_	_
 9-10	שבושלו	_	_	_	_	_	_	_	_
 9	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
-10	בושלו	בושל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	5	acl:relcl	_	_
+10	בושלו	בושל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=ב.ש.ל|Tense=Past|Voice=Pass	5	acl:relcl	_	_
 11-12	ביין	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	יין	יין	NOUN	NOUN	Gender=Masc|Number=Sing	10	obl	_	_
@@ -15034,7 +15034,7 @@
 1-2	המנה	_	_	_	_	_	_	_	_
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	מנה	מנה	NOUN	NOUN	Gender=Fem|Number=Sing	3	nsubj	_	_
-3	הוגשה	הוגש	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+3	הוגשה	הוגש	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Pass	0	root	_	_
 4-6	ברוטב	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	6	case	_	_
 5	ה_	ה	DET	DET	PronType=Art	6	det:def	_	_
@@ -15043,10 +15043,10 @@
 7	ש	ש	SCONJ	SCONJ	_	10	mark	_	_
 8	ב_	ב	ADP	ADP	_	9	case	_	_
 9	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obl	_	_
-10	בושלה	בושל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	6	acl:relcl	_	_
+10	בושלה	בושל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=3|Root=ב.ש.ל|Tense=Past|Voice=Pass	6	acl:relcl	_	_
 11-12	והצדיקה	_	_	_	_	_	_	_	_
 11	ו	ו	CCONJ	CCONJ	_	12	cc	_	_
-12	הצדיקה	הצדיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	3	conj	_	_
+12	הצדיקה	הצדיק	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=צ.ד.ק|Tense=Past|Voice=Act	3	conj	_	_
 13	את	את	ADP	ADP	Case=Acc	15	case:acc	_	_
 14-15	המוניטין	_	_	_	_	_	_	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
@@ -15075,7 +15075,7 @@
 1	ה	ה	DET	DET	PronType=Art	2	det:def	_	_
 2	ארוחה	ארוחה	NOUN	NOUN	Gender=Fem|Number=Sing	12	nsubj	_	_
 3	,	,	PUNCT	PUNCT	_	5	punct	_	_
-4	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	5	case	_	_
+4	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	5	case	_	_
 5	פאי	_	NOUN	NOUN	Definite=Cons	2	appos	_	_
 6-7	הלימון	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -15085,7 +15085,7 @@
 9	קינוח	קינוח	NOUN	NOUN	Gender=Masc|Number=Sing	5	nmod	_	_
 10	,	,	PUNCT	PUNCT	_	5	punct	_	_
 11	היתה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	12	cop	_	_
-12	משביעת	השביע	VERB	VERB	Definite=Cons|Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+12	משביעת	השביע	VERB	VERB	Definite=Cons|Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ש.ב.ע|VerbForm=Part|Voice=Act	0	root	_	_
 13	רצון	רצון	NOUN	NOUN	Gender=Masc|Number=Sing	12	compound:smixut	_	SpaceAfter=No
 14	,	,	PUNCT	PUNCT	_	12	punct	_	_
 15	אך	אך	CCONJ	CCONJ	_	19	cc	_	_
@@ -15102,7 +15102,7 @@
 # sent_id = 6171
 # text = כאשר הגענו, באחת אחר הצהריים, עדיין לא נערכו השולחנות כראוי והמלצר היחיד שנראה בשטח לא ידע לענות על אף אחת משאלותינו.
 1	כאשר	כאשר	SCONJ	SCONJ	_	2	mark	_	_
-2	הגענו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Tense=Past|Voice=Act	12	advcl	_	SpaceAfter=No
+2	הגענו	הגיע	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=1|Root=נ.ג.ע|Tense=Past|Voice=Act	12	advcl	_	SpaceAfter=No
 3	,	,	PUNCT	PUNCT	_	12	punct	_	_
 4-5	באחת	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
@@ -15114,7 +15114,7 @@
 9	,	,	PUNCT	PUNCT	_	12	punct	_	_
 10	עדיין	עדיין	ADV	ADV	_	11	advmod	_	_
 11	לא	לא	ADV	ADV	Polarity=Neg	12	advmod	_	_
-12	נערכו	נערך	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+12	נערכו	נערך	VERB	VERB	Gender=Fem,Masc|HebBinyan=NIFAL|Number=Plur|Person=3|Root=ע.ר.כ|Tense=Past|Voice=Mid	0	root	_	_
 13-14	השולחנות	_	_	_	_	_	_	_	_
 13	ה	ה	DET	DET	PronType=Art	14	det:def	_	_
 14	שולחנות	שולחן	NOUN	NOUN	Gender=Masc|Number=Plur	12	nsubj	_	_
@@ -15131,14 +15131,14 @@
 22	יחיד	יחיד	ADJ	ADJ	Gender=Masc|Number=Sing	20	amod	_	_
 23-24	שנראה	_	_	_	_	_	_	_	_
 23	ש	ש	SCONJ	SCONJ	_	24	mark	_	_
-24	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	20	acl:relcl	_	_
+24	נראה	נראה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=3|Root=ר.א.י|Tense=Past|Voice=Mid	20	acl:relcl	_	_
 25-27	בשטח	_	_	_	_	_	_	_	_
 25	ב	ב	ADP	ADP	_	27	case	_	_
 26	ה_	ה	DET	DET	PronType=Art	27	det:def	_	_
 27	שטח	שטח	NOUN	NOUN	Gender=Masc|Number=Sing	24	obl	_	_
 28	לא	לא	ADV	ADV	Polarity=Neg	29	advmod	_	_
-29	ידע	ידע	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	12	conj	_	_
-30	לענות	ענה	VERB	VERB	VerbForm=Inf	29	xcomp	_	_
+29	ידע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=י.ד.ע|Tense=Past	12	conj	_	_
+30	לענות	ענה	VERB	VERB	HebBinyan=PAAL|Root=ע.נ.י|VerbForm=Inf	29	xcomp	_	_
 31	על	על	ADP	ADP	_	33	case	_	_
 32	אף	אף	DET	DET	Definite=Cons	33	det	_	_
 33	אחת	אחת	NUM	NUM	Gender=Fem|Number=Sing	30	obl	_	_
@@ -15156,7 +15156,7 @@
 4	,	,	PUNCT	PUNCT	_	1	punct	_	_
 5-6	המבוססת	_	_	_	_	_	_	_	_
 5	ה	ה	SCONJ	SCONJ	_	6	mark	_	_
-6	מבוססת	בוסס	VERB	VERB	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part	1	acl:relcl	_	_
+6	מבוססת	בוסס	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ס.ס|VerbForm=Part	1	acl:relcl	_	_
 7	על	על	ADP	ADP	_	8	case	_	_
 8	מנות	מנה	NOUN	NOUN	Gender=Fem|Number=Plur	6	obl	_	_
 9	דומות	דומה	ADJ	ADJ	Gender=Fem|Number=Plur	8	amod	_	_
@@ -15170,7 +15170,7 @@
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
 16	בית	בית	NOUN	NOUN	Gender=Masc|Number=Sing	14	compound:smixut	_	_
 17	,	,	PUNCT	PUNCT	_	18	punct	_	_
-18	תגיע	הגיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Fut|Voice=Act	0	root	_	_
+18	תגיע	הגיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Sing|Person=3|Root=נ.ג.ע|Tense=Fut|Voice=Act	0	root	_	_
 19-21	לכ001	_	_	_	_	_	_	_	_
 19	ל	ל	ADP	ADP	_	22	case	_	_
 20	כ	כ	ADP	ADP	_	22	case	_	_
@@ -15191,11 +15191,11 @@
 2	,	,	PUNCT	PUNCT	_	1	punct	_	_
 3-4	החושבים	_	_	_	_	_	_	_	_
 3	ה	ה	SCONJ	SCONJ	_	4	mark	_	_
-4	חושבים	חשב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	1	ccomp	_	_
+4	חושבים	חשב	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ח.ש.ב|VerbForm=Part|Voice=Act	1	ccomp	_	_
 5-6	שהם	_	_	_	_	_	_	_	_
 5	ש	ש	SCONJ	SCONJ	_	7	mark	_	_
 6	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	7	nsubj	_	_
-7	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	4	ccomp	_	_
+7	יודעים	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	4	ccomp	_	_
 8	די	די	ADV	ADV	_	7	advmod	_	_
 9-10	והותר	_	_	_	_	_	_	_	_
 9	ו	ו	CCONJ	CCONJ	_	8	fixed	_	_
@@ -15210,7 +15210,7 @@
 16-17	ומסוגלים	_	_	_	_	_	_	_	_
 16	ו	ו	CCONJ	CCONJ	_	17	cc	_	_
 17	מסוגלים	מסוגל	AUX	AUX	Gender=Masc|Number=Plur|Person=1,2,3|VerbType=Mod	18	aux	_	_
-18	להשכיל	השכיל	VERB	VERB	HebBinyan=HIFIL|VerbForm=Inf|Voice=Act	7	conj	_	_
+18	להשכיל	השכיל	VERB	VERB	HebBinyan=HIFIL|Root=ש.כ.ל|VerbForm=Inf|Voice=Act	7	conj	_	_
 19	את	את	ADP	ADP	Case=Acc	20	case:acc	_	_
 20-22	לקוחותיהם	_	_	_	_	_	_	_	SpaceAfter=No
 20	לקוח_	לקוח	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	18	obj	_	_
@@ -15239,7 +15239,7 @@
 13	אביב	אביב	NOUN	NOUN	Gender=Masc|Number=Sing	11	flat:name	_	_
 14	יכולה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part|VerbType=Mod	16	aux	_	_
 15	רק	רק	ADV	ADV	_	14	advmod	_	_
-16	לשפר	שיפר	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	0	root	_	_
+16	לשפר	שיפר	VERB	VERB	HebBinyan=PIEL|Root=ש.פ.ר|VerbForm=Inf|Voice=Act	0	root	_	_
 17	את	את	ADP	ADP	Case=Acc	19	case:acc	_	_
 18-19	המצב	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
@@ -15253,7 +15253,7 @@
 25-26	מאז	_	_	_	_	_	_	_	_
 25	מ	מ	ADP	ADP	_	27	case	_	_
 26	אז	אז	ADV	ADV	_	25	fixed	_	_
-27	שלטה	שלט	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	37	obl	_	_
+27	שלטה	שלט	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ש.ל.ט|Tense=Past	37	obl	_	_
 28	משפחת	משפחה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	27	nsubj	_	_
 29	מדיצי	מדיצי	PROPN	PROPN	_	28	compound:smixut	_	_
 30-31	בפירנצה	_	_	_	_	_	_	_	_
@@ -15265,7 +15265,7 @@
 34	אזור	אזור	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	31	conj	_	_
 35	טוסקאנה	טוסקאנה	PROPN	PROPN	_	34	compound:smixut	_	SpaceAfter=No
 36	,	,	PUNCT	PUNCT	_	37	punct	_	_
-37	הצטיינו	הצטיין	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Tense=Past	14	advcl	_	_
+37	הצטיינו	הצטיין	VERB	VERB	Gender=Fem,Masc|HebBinyan=HITPAEL|Number=Plur|Person=3|Root=צ.י.נ|Tense=Past	14	advcl	_	_
 38-39	האיטלקים	_	_	_	_	_	_	_	_
 38	ה	ה	DET	DET	PronType=Art	39	det:def	_	_
 39	איטלקים	איטלקי	ADJ	ADJ	Gender=Masc|Number=Plur	37	nsubj	_	_
@@ -15301,7 +15301,7 @@
 9	אנשים	איש	NOUN	NOUN	Gender=Masc|Number=Plur	18	obl	_	_
 10-11	שפתחו	_	_	_	_	_	_	_	_
 10	ש	ש	SCONJ	SCONJ	_	11	mark	_	_
-11	פתחו	פתח	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Past	9	acl:relcl	_	_
+11	פתחו	פתח	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=פ.ת.ח|Tense=Past	9	acl:relcl	_	_
 12	את	את	ADP	ADP	Case=Acc	13	case:acc	_	_
 13	בתי	בית	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	11	obj	_	_
 14-15	האוכל	_	_	_	_	_	_	_	_
@@ -15325,7 +15325,7 @@
 28-29	שהם	_	_	_	_	_	_	_	_
 28	ש	ש	SCONJ	SCONJ	_	30	mark	_	_
 29	הם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Prs	30	nsubj	_	_
-30	מחקים	חיקה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	27	acl:relcl	_	SpaceAfter=No
+30	מחקים	חיקה	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Plur|Person=1,2,3|Root=ח.ק.י|VerbForm=Part|Voice=Act	27	acl:relcl	_	SpaceAfter=No
 31	.	.	PUNCT	PUNCT	_	18	punct	_	_
 
 # sent_id = 6176
@@ -15335,10 +15335,10 @@
 2	ביקורות	ביקורת	NOUN	NOUN	Gender=Fem|Number=Plur	6	nsubj	_	_
 3-4	המופיעות	_	_	_	_	_	_	_	_
 3	ה	ה	SCONJ	SCONJ	_	4	mark	_	_
-4	מופיעות	הופיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	2	acl:relcl	_	_
+4	מופיעות	הופיע	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=י.פ.ע|VerbForm=Part|Voice=Act	2	acl:relcl	_	_
 5	להלן	להלן	ADV	ADV	_	4	advmod	_	_
 6	עשויות	עשוי	AUX	AUX	Gender=Fem|Number=Plur|Person=1,2,3|VerbType=Mod	7	aux	_	_
-7	לשמש	שימש	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	0	root	_	_
+7	לשמש	שימש	VERB	VERB	HebBinyan=PIEL|Root=ש.מ.ש|VerbForm=Inf|Voice=Act	0	root	_	_
 8	מדריך	מדריך	NOUN	NOUN	Gender=Masc|Number=Sing	7	obl	_	_
 9-10	לאוכל	_	_	_	_	_	_	_	_
 9	ל	ל	ADP	ADP	_	10	case	_	_
@@ -15360,7 +15360,7 @@
 1	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
 2	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Dem	3	advmod	_	_
 3	עתה	עתה	ADV	ADV	_	4	advmod	_	_
-4	חגגה	חגג	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	16	advcl	_	_
+4	חגגה	חגג	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ג.ג|Tense=Past|Voice=Act	16	advcl	_	_
 5	את	את	ADP	ADP	Case=Acc	6	case:acc	_	_
 6	יום	יום	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	obj	_	_
 7-8	ההולדת	_	_	_	_	_	_	_	_
@@ -15375,7 +15375,7 @@
 13	_של_	של	ADP	ADP	_	14	case:gen	_	_
 14	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	12	nmod:poss	_	_
 15	,	,	PUNCT	PUNCT	_	16	punct	_	_
-16	רואה	ראה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	0	root	_	_
+16	רואה	ראה	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ר.א.י|VerbForm=Part|Voice=Act	0	root	_	_
 17	עצמה	עצמו	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	16	obj	_	_
 18-19	כחלוצת	_	_	_	_	_	_	_	_
 18	כ	כ	ADP	ADP	_	19	case	_	_
@@ -15399,7 +15399,7 @@
 # text = אמנם היא מצטיינת באווירה מקסימה, אך יש כאלה הסבורים שזו אחת המסעדות המוערכות יתר על המידה.
 1	אמנם	אמנם	ADV	ADV	_	3	advmod	_	_
 2	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
-3	מצטיינת	הצטיין	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	0	root	_	_
+3	מצטיינת	הצטיין	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=צ.י.נ|VerbForm=Part	0	root	_	_
 4-5	באווירה	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	אווירה	אווירה	NOUN	NOUN	Gender=Fem|Number=Sing	3	obl	_	_
@@ -15423,7 +15423,7 @@
 19	מסעדות	מסעדה	NOUN	NOUN	Gender=Fem|Number=Plur	14	ccomp	_	_
 20-21	המוערכות	_	_	_	_	_	_	_	_
 20	ה	ה	DET	DET	PronType=Art	21	det:def	_	_
-21	מוערכות	הוערך	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	19	amod	_	_
+21	מוערכות	הוערך	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ע.ר.כ|VerbForm=Part|Voice=Pass	19	amod	_	_
 22	יתר	יתר	NOUN	NOUN	Gender=Masc|Number=Sing	21	advmod	_	_
 23	על	על	ADP	ADP	_	22	fixed	_	_
 24-25	המידה	_	_	_	_	_	_	_	SpaceAfter=No
@@ -15441,7 +15441,7 @@
 5	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
 6	ב_	ב	ADP	ADP	_	7	case	_	_
 7	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	obl	_	_
-8	שורים	שור	VERB	VERB	VerbForm=Part	3	acl:relcl	_	_
+8	שורים	שור	VERB	VERB	HebBinyan=PAAL|Root=ש.ר.י|VerbForm=Part	3	acl:relcl	_	_
 9	פרוסות	פרוסה	NOUN	NOUN	Gender=Fem|Number=Plur	8	obj	_	_
 10	דקיקות	דקיק	ADJ	ADJ	Gender=Fem|Number=Plur	9	amod	_	_
 11	של	של	ADP	ADP	Case=Gen	12	case:gen	_	_
@@ -15453,7 +15453,7 @@
 16	מרינדה	מרינדה	NOUN	NOUN	Gender=Fem|Number=Sing	12	nmod	_	_
 17-18	ומגישים	_	_	_	_	_	_	_	_
 17	ו	ו	CCONJ	CCONJ	_	18	cc	_	_
-18	מגישים	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	8	conj	_	_
+18	מגישים	הגיש	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=נ.ג.ש|VerbForm=Part|Voice=Act	8	conj	_	_
 19-20	אותו	_	_	_	_	_	_	_	_
 19	את_	את_	ADP	ADP	Case=Acc	20	case:acc	_	_
 20	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	obj	_	_
@@ -15489,7 +15489,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	ביקור	ביקור	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 3	אחר	אחר	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-4	הוטבע	הוטבע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	הוטבע	הוטבע	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ט.ב.ע|Tense=Past|Voice=Pass	0	root	_	_
 5	ממש	ממש	ADV	ADV	_	4	advmod	_	_
 6-7	הבשר	_	_	_	_	_	_	_	_
 6	ה	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -15501,7 +15501,7 @@
 11	מה	מה	ADV	ADV	PronType=Int	4	advmod	_	_
 12-13	שגזל	_	_	_	_	_	_	_	_
 12	ש	ש	SCONJ	SCONJ	_	13	mark	_	_
-13	גזל	גזל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	11	acl:relcl	_	_
+13	גזל	גזל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ג.ז.ל|Tense=Past|Voice=Act	11	acl:relcl	_	_
 14	מן	מן	ADP	ADP	_	16	case	_	_
 15-16	הבשר	_	_	_	_	_	_	_	_
 15	ה	ה	DET	DET	PronType=Art	16	det:def	_	_
@@ -15530,11 +15530,11 @@
 6	אינסאלאטה	אינסאלאטה	PROPN	PROPN	_	5	flat:name	_	_
 7	פרגו	פרג	PROPN	PROPN	_	6	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	9	punct	_	_
-9	נוספה	נוסף	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Tense=Past|Voice=Mid	0	root	_	_
+9	נוספה	נוסף	VERB	VERB	Gender=Fem|HebBinyan=NIFAL|Number=Sing|Person=3|Root=י.ס.פ|Tense=Past|Voice=Mid	0	root	_	_
 10-11	לחסילונים	_	_	_	_	_	_	_	_
 10	ל	ל	ADP	ADP	_	11	case	_	_
 11	חסילונים	חסילון	NOUN	NOUN	Gender=Masc|Number=Plur	9	obl	_	_
-12	מורתחים	הורתח	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	11	amod	_	_
+12	מורתחים	הורתח	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Plur|Person=1,2,3|Root=ר.ת.ח|VerbForm=Part|Voice=Pass	11	amod	_	_
 13	תערובת	תערובת	NOUN	NOUN	Gender=Fem|Number=Sing	9	nsubj	_	_
 14	של	של	ADP	ADP	Case=Gen	15	case:gen	_	_
 15	חסה	חסה	NOUN	NOUN	Gender=Fem|Number=Sing	13	nmod:poss	_	_
@@ -15570,7 +15570,7 @@
 10	ש	ש	SCONJ	SCONJ	_	9	fixed	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	חסילונים	חסילון	NOUN	NOUN	Gender=Masc|Number=Plur	13	nsubj	_	_
-13	בושלו	בושל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	20	advcl	_	_
+13	בושלו	בושל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=ב.ש.ל|Tense=Past|Voice=Pass	20	advcl	_	_
 14	יתר	יתר	NOUN	NOUN	Gender=Masc|Number=Sing	13	advmod	_	_
 15	על	על	ADP	ADP	_	14	fixed	_	_
 16-17	המידה	_	_	_	_	_	_	_	_
@@ -15603,7 +15603,7 @@
 # sent_id = 6185
 # text = הוא הוגש בסגנון פלורנטיני, ללא פסטה, ותובל קלות בעשבי תיבול.
 1	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	הוגש	הוגש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+2	הוגש	הוגש	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Pass	0	root	_	_
 3-4	בסגנון	_	_	_	_	_	_	_	_
 3	ב	ב	ADP	ADP	_	4	case	_	_
 4	סגנון	סגנון	NOUN	NOUN	Gender=Masc|Number=Sing	2	obl	_	_
@@ -15614,7 +15614,7 @@
 9	,	,	PUNCT	PUNCT	_	2	punct	_	_
 10-11	ותובל	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
-11	תובל	תובל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	2	conj	_	_
+11	תובל	תובל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ת.ב.ל|Tense=Past|Voice=Pass	2	conj	_	_
 12	קלות	קלות	ADV	ADV	_	11	advmod	_	_
 13-14	בעשבי	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	14	case	_	_
@@ -15624,7 +15624,7 @@
 
 # sent_id = 6186
 # text = בחרנו בשתי מנות פסטה: פטוציני ברוטב עגבניות ואחרת עם פסטו.
-1	בחרנו	בחר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Tense=Past|Voice=Act	0	root	_	_
+1	בחרנו	בחר	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=1|Root=ב.ח.ר|Tense=Past|Voice=Act	0	root	_	_
 2-3	בשתי	_	_	_	_	_	_	_	_
 2	ב	ב	ADP	ADP	_	4	case	_	_
 3	שתי	שתי	NUM	NUM	Definite=Cons|Gender=Fem|Number=Plur	4	nummod	_	_
@@ -15653,7 +15653,7 @@
 5	טובות	טוב	ADJ	ADJ	Gender=Fem|Number=Plur	0	root	_	_
 6	אבל	אבל	CCONJ	CCONJ	_	8	cc	_	_
 7	לא	לא	ADV	ADV	Polarity=Neg	8	advmod	_	_
-8	מסעירות	הסעיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	5	conj	_	SpaceAfter=No
+8	מסעירות	הסעיר	VERB	VERB	Gender=Fem|HebBinyan=HIFIL|Number=Plur|Person=1,2,3|Root=ס.ע.ר|VerbForm=Part|Voice=Act	5	conj	_	SpaceAfter=No
 9	.	.	PUNCT	PUNCT	_	5	punct	_	_
 
 # sent_id = 6188
@@ -15678,7 +15678,7 @@
 14	ב	ב	ADP	ADP	_	15	case	_	_
 15	פרגו	פרג	PROPN	PROPN	_	17	obl	_	_
 16	לא	לא	ADV	ADV	Polarity=Neg	17	advmod	_	_
-17	שומרים	שמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Act	12	acl:relcl	_	_
+17	שומרים	שמר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Plur|Person=1,2,3|Root=ש.מ.ר|VerbForm=Part|Voice=Act	12	acl:relcl	_	_
 18	על	על	ADP	ADP	_	19	case	_	_
 19	רמה	רמה	NOUN	NOUN	Gender=Fem|Number=Sing	17	obl	_	_
 20	אחידה	אחיד	ADJ	ADJ	Gender=Fem|Number=Sing	19	amod	_	_
@@ -15687,7 +15687,7 @@
 23-24	והיא	_	_	_	_	_	_	_	_
 23	ו	ו	CCONJ	CCONJ	_	25	cc	_	_
 24	היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	25	nsubj	_	_
-25	משתנה	_	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|VerbForm=Part	17	conj	_	_
+25	משתנה	_	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=1,2,3|Root=ש.נ.י|VerbForm=Part	17	conj	_	_
 26-27	מביקור	_	_	_	_	_	_	_	_
 26	מ	מ	ADP	ADP	_	27	case	_	_
 27	ביקור	ביקור	NOUN	NOUN	Gender=Masc|Number=Sing	25	obl	_	_
@@ -15719,7 +15719,7 @@
 3	דקות	דק	ADJ	ADJ	Gender=Fem|Number=Plur	2	amod	_	_
 4	של	של	ADP	ADP	Case=Gen	5	case:gen	_	_
 5	עגל	עגל	NOUN	NOUN	Gender=Masc|Number=Sing	2	nmod	_	_
-6	בזקו	בזק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+6	בזקו	בזק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=ב.ז.ק|Tense=Past|Voice=Act	0	root	_	_
 7	מרווה	מרווה	NOUN	NOUN	Gender=Fem|Number=Sing	6	obj	_	SpaceAfter=No
 8	,	,	PUNCT	PUNCT	_	7	punct	_	_
 9	פלפל	פלפל	NOUN	NOUN	Gender=Masc|Number=Sing	7	conj	_	_
@@ -15729,7 +15729,7 @@
 12-13	ואחר	_	_	_	_	_	_	_	_
 12	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 13	אחר	_	ADV	ADV	_	14	advmod	_	_
-14	גילגלו	גלגל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Tense=Past|Voice=Act	6	conj	_	_
+14	גילגלו	גלגל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=3|Root=ג.ל.ג.ל|Tense=Past|Voice=Act	6	conj	_	_
 15-16	מסביבן	_	_	_	_	_	_	_	_
 15	מ	מ	ADP	ADP	_	16	case	_	_
 16	סביבן	_	NOUN	NOUN	_	14	obl	_	_
@@ -15745,7 +15745,7 @@
 # text = כל זה הושחם במהירות בחמאה והיה רך וטעים.
 1	כל	כול	DET	DET	Definite=Cons	2	det	_	_
 2	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
-3	הושחם	הושחם	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+3	הושחם	הושחם	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ש.ח.מ|Tense=Past|Voice=Pass	0	root	_	_
 4-5	במהירות	_	_	_	_	_	_	_	_
 4	ב	ב	ADP	ADP	_	5	case	_	_
 5	מהירות	מהירות	NOUN	NOUN	Gender=Fem|Number=Sing	3	obl	_	_
@@ -15767,7 +15767,7 @@
 1	ב	ב	ADP	ADP	_	2	case	_	_
 2	ביקור	ביקור	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
 3	אחר	אחר	ADJ	ADJ	Gender=Masc|Number=Sing	2	amod	_	_
-4	בושל	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+4	בושל	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ב.ש.ל|Tense=Past|Voice=Pass	0	root	_	_
 5-6	העגל	_	_	_	_	_	_	_	_
 5	ה	ה	DET	DET	PronType=Art	6	det:def	_	_
 6	עגל	עגל	NOUN	NOUN	Gender=Masc|Number=Sing	4	nsubj	_	_
@@ -15784,7 +15784,7 @@
 14	ש	ש	SCONJ	SCONJ	_	17	mark	_	_
 15	ב_	ב	ADP	ADP	_	16	case	_	_
 16	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	obl	_	_
-17	הוגשה	הוגש	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	13	acl:relcl	_	_
+17	הוגשה	הוגש	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Pass	13	acl:relcl	_	_
 18-19	המנה	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
 19	מנה	מנה	NOUN	NOUN	Gender=Fem|Number=Sing	17	nsubj	_	_
@@ -15800,13 +15800,13 @@
 1-2	לקינוח	_	_	_	_	_	_	_	_
 1	ל	ל	ADP	ADP	_	2	case	_	_
 2	קינוח	קינוח	NOUN	NOUN	Gender=Masc|Number=Sing	3	obl	_	_
-3	קיבלנו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Tense=Past|Voice=Act	0	root	_	_
+3	קיבלנו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Root=ק.ב.ל|Tense=Past|Voice=Act	0	root	_	_
 4	פיניאטה	פיניאטה	PROPN	PROPN	_	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	PUNCT	_	4	punct	_	_
 6	תערובת	תערובת	NOUN	NOUN	Gender=Fem|Number=Sing	4	appos	_	_
 7-8	המבוססת	_	_	_	_	_	_	_	_
 7	ה	ה	SCONJ	SCONJ	_	8	mark	_	_
-8	מבוססת	בוסס	VERB	VERB	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part	6	acl:relcl	_	_
+8	מבוססת	בוסס	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ס.ס|VerbForm=Part	6	acl:relcl	_	_
 9	על	על	ADP	ADP	_	10	case	_	_
 10	חמאה	חמאה	NOUN	NOUN	Gender=Fem|Number=Sing	8	obl	_	SpaceAfter=No
 11	,	,	PUNCT	PUNCT	_	10	punct	_	_
@@ -15848,12 +15848,12 @@
 6	קצפת	קצפת	NOUN	NOUN	Gender=Fem|Number=Sing	12	nsubj	_	_
 7-8	שהוגשה	_	_	_	_	_	_	_	_
 7	ש	ש	SCONJ	SCONJ	_	8	mark	_	_
-8	הוגשה	הוגש	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	6	acl:relcl	_	_
+8	הוגשה	הוגש	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Pass	6	acl:relcl	_	_
 9	עם	עם	ADP	ADP	_	11	case	_	_
 10-11	הקינוח	_	_	_	_	_	_	_	_
 10	ה	ה	DET	DET	PronType=Art	11	det:def	_	_
 11	קינוח	קינוח	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	_
-12	הותזה	הותז	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	0	root	_	_
+12	הותזה	הותז	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=נ.ת.ז|Tense=Past|Voice=Pass	0	root	_	_
 13-14	מבקבוק	_	_	_	_	_	_	_	_
 13	מ	מ	ADP	ADP	_	14	case	_	_
 14	בקבוק	בקבוק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	12	obl	_	_
@@ -15872,7 +15872,7 @@
 7	זה	זה	PRON	PRON	Gender=Masc|Number=Sing|Person=3	9	nsubj	_	_
 8	בלתי	בלתי	ADV	ADV	Prefix=Yes	9	compound:affix	_	_
 9	הגיוני	הגיוני	ADJ	ADJ	Gender=Masc|Number=Sing	0	root	_	_
-10	לצפות	ציפה	VERB	VERB	HebSource=ConvUncertainHead|VerbForm=Inf	9	dep	_	_
+10	לצפות	ציפה	VERB	VERB	HebBinyan=PIEL|HebSource=ConvUncertainHead|Root=צ.פ.י|VerbForm=Inf	9	dep	_	_
 11-12	לקצפת	_	_	_	_	_	_	_	_
 11	ל	ל	ADP	ADP	_	12	case	_	_
 12	קצפת	קצפת	NOUN	NOUN	Gender=Fem|Number=Sing	10	obl	_	_
@@ -15891,7 +15891,7 @@
 4	מנות	מנה	NOUN	NOUN	Gender=Fem|Number=Plur	18	obl	_	_
 5	הללו	הללו	PRON	PRON	Gender=Masc|Number=Plur|Person=3|PronType=Dem	4	det	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	8	punct	_	_
-7	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	8	case	_	_
+7	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	8	case	_	_
 8	בקבוק	בקבוק	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	4	appos	_	_
 9	יין	יין	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	_
 10	אדום	אדום	ADJ	ADJ	Gender=Masc|Number=Sing	8	amod	_	_
@@ -15903,7 +15903,7 @@
 15	שנת	שנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	11	nmod	_	_
 16	1987	1987	NUM	NUM	_	15	compound:smixut	_	SpaceAfter=No
 17	,	,	PUNCT	PUNCT	_	18	punct	_	_
-18	תסתכם	הסתכם	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Fut	0	root	_	_
+18	תסתכם	הסתכם	VERB	VERB	Gender=Fem|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ס.כ.מ|Tense=Fut	0	root	_	_
 19	ארוחת	ארוחה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	18	nsubj	_	_
 20	ערב	ערב	NOUN	NOUN	Gender=Masc|Number=Sing	19	compound:smixut	_	_
 21-22	לשניים	_	_	_	_	_	_	_	_
@@ -15955,7 +15955,7 @@
 19	_של_	של	ADP	ADP	_	20	case:gen	_	_
 20	_היא	הוא	PRON	PRON	Case=Gen|Gender=Fem|Number=Sing|Person=3|PronType=Prs	18	nmod:poss	_	_
 21	אינו	אינו	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Neg|VerbForm=Part|VerbType=Cop	22	advmod	_	_
-22	עולה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	16	dep	_	_
+22	עולה	_	VERB	VERB	Gender=Masc|HebBinyan=PAAL|HebSource=ConvUncertainHead|Number=Sing|Person=1,2,3|Root=ע.ל.י|VerbForm=Part|Voice=Act	16	dep	_	_
 23	על	על	ADP	ADP	_	25	case	_	_
 24	18	18	NUM	NUM	_	25	nummod	_	_
 25	חודשים	חודש	NOUN	NOUN	Gender=Masc|Number=Plur	22	obl	_	SpaceAfter=No
@@ -15970,7 +15970,7 @@
 4	רפי	רפי	PROPN	PROPN	_	2	appos	_	_
 5	אדר	אדר	PROPN	PROPN	_	4	flat:name	_	SpaceAfter=No
 6	,	,	PUNCT	PUNCT	_	7	punct	_	_
-7	התגורר	התגורר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+7	התגורר	התגורר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ג.ו.ר|Tense=Past	0	root	_	_
 8	זמן	זמן	NOUN	NOUN	Gender=Masc|Number=Sing	7	dep	_	_
 9	מה	מה	ADV	ADV	HebSource=ConvUncertainLabel|PronType=Int	8	nmod	_	_
 10-11	באיטליה	_	_	_	_	_	_	_	_
@@ -15979,7 +15979,7 @@
 12-13	והוא	_	_	_	_	_	_	_	_
 12	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 13	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
-14	מכנה	_	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	7	conj	_	_
+14	מכנה	_	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=כ.נ.י|VerbForm=Part|Voice=Act	7	conj	_	_
 15	את	את	ADP	ADP	Case=Acc	17	case:acc	_	_
 16-17	המקום	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
@@ -15990,7 +15990,7 @@
 20	,	,	PUNCT	PUNCT	_	17	punct	_	_
 21-22	המעוצב	_	_	_	_	_	_	_	_
 21	ה	ה	SCONJ	SCONJ	_	22	mark	_	_
-22	מעוצב	עוצב	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	17	acl:relcl	_	_
+22	מעוצב	עוצב	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ע.צ.ב|VerbForm=Part|Voice=Pass	17	acl:relcl	_	_
 23-24	בפשטות	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	פשטות	פשטות	NOUN	NOUN	Gender=Fem|Number=Sing	22	obl	_	_
@@ -16007,41 +16007,41 @@
 33	ו	ו	CCONJ	CCONJ	_	36	cc	_	_
 34	ב	ב	ADP	ADP	_	35	case	_	_
 35	כך	כך	PRON	PRON	Person=3|PronType=Dem	36	obl	_	_
-36	מפגין	הפגין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	7	conj	_	_
+36	מפגין	הפגין	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=פ.ג.נ|VerbForm=Part|Voice=Act	7	conj	_	_
 37	חוסר	חוסר	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	36	obj	_	_
 38	יומרות	יומרה	NOUN	NOUN	Gender=Fem|Number=Plur	37	compound:smixut	_	_
-39	מעורר	עורר	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	37	amod	_	_
+39	מעורר	עורר	VERB	VERB	Definite=Cons|Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ע.ו.ר|VerbForm=Part|Voice=Act	37	amod	_	_
 40	הערכה	הערכה	NOUN	NOUN	Gender=Fem|Number=Sing	39	compound:smixut	_	SpaceAfter=No
 41	.	.	PUNCT	PUNCT	_	7	punct	_	_
 
 # sent_id = 6200
 # text = פטריות ממולאות גדולות, מצופות יפה בפירורי לחם מתובלים ומטוגנות בטיגון עמוק, היו מבושלות בצורה מושלמת כולל הפסטו שבו מולאו.
 1	פטריות	פטרייה	NOUN	NOUN	Gender=Fem|Number=Plur	18	nsubj	_	_
-2	ממולאות	מולא	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	1	amod	_	_
+2	ממולאות	מולא	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=מ.ל.א|VerbForm=Part|Voice=Pass	1	amod	_	_
 3	גדולות	גדול	ADJ	ADJ	Gender=Fem|Number=Plur	1	amod	_	SpaceAfter=No
 4	,	,	PUNCT	PUNCT	_	1	punct	_	_
-5	מצופות	צופה	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	1	acl:relcl	_	_
+5	מצופות	צופה	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=צ.פ.י|VerbForm=Part|Voice=Pass	1	acl:relcl	_	_
 6	יפה	יפה	ADV	ADV	_	5	advmod	_	_
 7-8	בפירורי	_	_	_	_	_	_	_	_
 7	ב	ב	ADP	ADP	_	8	case	_	_
 8	פירורי	פירור	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	5	obl	_	_
 9	לחם	לחם	NOUN	NOUN	Gender=Masc|Number=Sing	8	compound:smixut	_	_
-10	מתובלים	תובל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	8	amod	_	_
+10	מתובלים	תובל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ת.ב.ל|VerbForm=Part|Voice=Pass	8	amod	_	_
 11-12	ומטוגנות	_	_	_	_	_	_	_	_
 11	ו	ו	CCONJ	CCONJ	_	12	cc	_	_
-12	מטוגנות	טוגן	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	5	conj	_	_
+12	מטוגנות	טוגן	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ט.ג.נ|VerbForm=Part|Voice=Pass	5	conj	_	_
 13-14	בטיגון	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	טיגון	טיגון	NOUN	NOUN	Gender=Masc|Number=Sing	12	obl	_	_
 15	עמוק	עמוק	ADJ	ADJ	Gender=Masc|Number=Sing	14	amod	_	SpaceAfter=No
 16	,	,	PUNCT	PUNCT	_	18	punct	_	_
 17	היו	_	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	18	cop	_	_
-18	מבושלות	בושל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+18	מבושלות	בושל	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ב.ש.ל|VerbForm=Part|Voice=Pass	0	root	_	_
 19-20	בצורה	_	_	_	_	_	_	_	_
 19	ב	ב	ADP	ADP	_	20	case	_	_
 20	צורה	צורה	NOUN	NOUN	Gender=Fem|Number=Sing	18	obl	_	_
 21	מושלמת	מושלם	ADJ	ADJ	Gender=Fem|Number=Sing	20	amod	_	_
-22	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	24	case	_	_
+22	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	24	case	_	_
 23-24	הפסטו	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
 24	פסטו	פסטו	NOUN	NOUN	Gender=Masc|Number=Sing	18	obl	_	_
@@ -16049,7 +16049,7 @@
 25	ש	ש	SCONJ	SCONJ	_	28	mark	_	_
 26	ב_	ב	ADP	ADP	_	27	case	_	_
 27	_הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	28	obl	_	_
-28	מולאו	מולא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	24	acl:relcl	_	SpaceAfter=No
+28	מולאו	מולא	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Number=Plur|Person=3|Root=מ.ל.א|Tense=Past|Voice=Pass	24	acl:relcl	_	SpaceAfter=No
 29	.	.	PUNCT	PUNCT	_	18	punct	_	_
 
 # sent_id = 6201
@@ -16073,7 +16073,7 @@
 12	שמנת	שמנת	NOUN	NOUN	Gender=Fem|Number=Sing	10	compound:smixut	_	_
 13-14	שיצקו	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
-14	יצקו	יצק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Tense=Past|Voice=Act	10	acl:relcl	_	_
+14	יצקו	יצק	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Plur|Person=3|Root=י.צ.ק|Tense=Past|Voice=Act	10	acl:relcl	_	_
 15	על	על	ADP	ADP	_	17	case	_	_
 16-17	הפטריות	_	_	_	_	_	_	_	_
 16	ה	ה	DET	DET	PronType=Art	17	det:def	_	_
@@ -16138,14 +16138,14 @@
 10-11	ופטריות	_	_	_	_	_	_	_	_
 10	ו	ו	CCONJ	CCONJ	_	11	cc	_	_
 11	פטריות	פטרייה	NOUN	NOUN	Gender=Fem|Number=Plur	9	conj	_	_
-12	הוכיחו	הוכיח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+12	הוכיחו	הוכיח	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=י.כ.ח|Tense=Past|Voice=Act	0	root	_	_
 13-15	שהטבח	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	16	mark	_	_
 14	ה	ה	DET	DET	PronType=Art	15	det:def	_	_
 15	טבח	טבח	NOUN	NOUN	Gender=Masc|Number=Sing	16	nsubj	_	_
-16	יודע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	12	ccomp	_	_
+16	יודע	ידע	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=י.ד.ע|VerbForm=Part|Voice=Act	12	ccomp	_	_
 17	כיצד	כיצד	ADV	ADV	PronType=Int	18	advmod	_	_
-18	לטפל	טיפל	VERB	VERB	HebBinyan=PIEL|VerbForm=Inf|Voice=Act	16	xcomp	_	_
+18	לטפל	טיפל	VERB	VERB	HebBinyan=PIEL|Root=ט.פ.ל|VerbForm=Inf|Voice=Act	16	xcomp	_	_
 19-21	בפסטה	_	_	_	_	_	_	_	SpaceAfter=No
 19	ב	ב	ADP	ADP	_	21	case	_	_
 20	ה_	ה	DET	DET	PronType=Art	21	det:def	_	_
@@ -16158,7 +16158,7 @@
 2-3	המנות	_	_	_	_	_	_	_	_
 2	ה	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	מנות	מנה	NOUN	NOUN	Gender=Fem|Number=Plur	4	nsubj	_	_
-4	לוו	לווה	VERB	VERB	Gender=Fem,Masc|Mood=Imp|Number=Plur|Person=2	0	root	_	_
+4	לוו	לווה	VERB	VERB	Gender=Fem,Masc|HebBinyan=PUAL|Mood=Imp|Number=Plur|Person=2|Root=ל.ו.י	0	root	_	_
 5-6	ברוטב	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	6	case	_	_
 6	רוטב	רוטב	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
@@ -16169,7 +16169,7 @@
 10	נעים	נעים	ADJ	ADJ	Gender=Masc|Number=Sing	6	acl:relcl	_	_
 11	אמנם	אמנם	ADV	ADV	_	10	advmod	_	_
 12	אך	אך	CCONJ	CCONJ	_	13	cc	_	_
-13	סבל	סבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	conj	_	_
+13	סבל	סבל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ס.ב.ל|Tense=Past|Voice=Act	10	conj	_	_
 14-15	משימוש	_	_	_	_	_	_	_	_
 14	מ	מ	ADP	ADP	_	15	case	_	_
 15	שימוש	שימוש	NOUN	NOUN	Gender=Masc|Number=Sing	13	obl	_	_
@@ -16212,7 +16212,7 @@
 24	רגיל	רגיל	ADJ	ADJ	Gender=Masc|Number=Sing	21	advmod	_	_
 25	,	,	PUNCT	PUNCT	_	27	punct	_	_
 26	הוא	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=3|PronType=Prs	27	nsubj	_	_
-27	הלם	הלם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	conj	_	SpaceAfter=No
+27	הלם	הלם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ה.ל.מ|Tense=Past|Voice=Act	10	conj	_	SpaceAfter=No
 28	,	,	PUNCT	PUNCT	_	27	punct	_	_
 29-30	באופן	_	_	_	_	_	_	_	_
 29	ב	ב	ADP	ADP	_	30	case	_	_
@@ -16233,7 +16233,7 @@
 2	טירמיס	טירמיס	PROPN	PROPN	_	8	nsubj	_	_
 3-4	שקיבלנו	_	_	_	_	_	_	_	_
 3	ש	ש	SCONJ	SCONJ	_	4	mark	_	_
-4	קיבלנו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Tense=Past|Voice=Act	2	acl:relcl	_	_
+4	קיבלנו	קיבל	VERB	VERB	Gender=Fem,Masc|HebBinyan=PIEL|Number=Plur|Person=1|Root=ק.ב.ל|Tense=Past|Voice=Act	2	acl:relcl	_	_
 5-6	לקינוח	_	_	_	_	_	_	_	_
 5	ל	ל	ADP	ADP	_	6	case	_	_
 6	קינוח	קינוח	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
@@ -16251,7 +16251,7 @@
 16	ביותר	ביותר	ADV	ADV	_	15	advmod	_	_
 17-18	שטעמתי	_	_	_	_	_	_	_	_
 17	ש	ש	SCONJ	SCONJ	_	18	mark	_	_
-18	טעמתי	טעם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Sing|Person=1|Tense=Past|Voice=Act	13	acl:relcl	_	_
+18	טעמתי	טעם	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|Number=Sing|Person=1|Root=ט.ע.מ|Tense=Past|Voice=Act	13	acl:relcl	_	_
 19-20	מחוץ	_	_	_	_	_	_	_	_
 19	מ	מ	ADP	ADP	_	22	case	_	_
 20	חוץ	חוץ	NOUN	NOUN	Gender=Masc|Number=Sing	19	fixed	_	_
@@ -16262,7 +16262,7 @@
 
 # sent_id = 6207
 # text = כולל קנקן של חצי ליטר של יין הבית (אשקלון אדום) וקפה לסיום ארוחת ערב המבוססת על המנות הללו המחיר יהיה כ631 ש"ח, כולל דמי שירות בסך 5 ש"ח, סעיף מעליב בהתחשב במחיר.
-1	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	2	case	_	_
+1	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	2	case	_	_
 2	קנקן	קנקן	NOUN	NOUN	Gender=Masc|Number=Sing	31	nmod	_	_
 3	של	של	ADP	ADP	Case=Gen	4	case:gen	_	_
 4	חצי	חץ	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	2	nmod:poss	_	_
@@ -16286,7 +16286,7 @@
 19	ערב	ערב	NOUN	NOUN	Gender=Masc|Number=Sing	18	compound:smixut	_	_
 20-21	המבוססת	_	_	_	_	_	_	_	_
 20	ה	ה	SCONJ	SCONJ	_	21	mark	_	_
-21	מבוססת	בוסס	VERB	VERB	Gender=Fem|Number=Sing|Person=1,2,3|VerbForm=Part	18	acl:relcl	_	_
+21	מבוססת	בוסס	VERB	VERB	Gender=Fem|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ב.ס.ס|VerbForm=Part	18	acl:relcl	_	_
 22	על	על	ADP	ADP	_	24	case	_	_
 23-24	המנות	_	_	_	_	_	_	_	_
 23	ה	ה	DET	DET	PronType=Art	24	det:def	_	_
@@ -16301,7 +16301,7 @@
 30	136	136	NUM	NUM	_	31	nummod	_	_
 31	ש"ח	ש"ח	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 32	,	,	PUNCT	PUNCT	_	31	punct	_	_
-33	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	34	case	_	_
+33	כולל	כלל	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=כ.ל.ל|VerbForm=Part|Voice=Act	34	case	_	_
 34	דמי	_	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	31	nmod	_	_
 35	שירות	שירות	NOUN	NOUN	Gender=Masc|Number=Sing	34	compound:smixut	_	_
 36-37	בסך	_	_	_	_	_	_	_	_
@@ -16311,7 +16311,7 @@
 39	ש"ח	ש"ח	NOUN	NOUN	Abbr=Yes|Gender=Masc|Number=Sing	37	compound:smixut	_	SpaceAfter=No
 40	,	,	PUNCT	PUNCT	_	41	punct	_	_
 41	סעיף	סעיף	NOUN	NOUN	Gender=Masc|Number=Sing	34	appos	_	_
-42	מעליב	העליב	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	41	amod	_	_
+42	מעליב	העליב	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=1,2,3|Root=ע.ל.ב|VerbForm=Part|Voice=Act	41	amod	_	_
 43	בהתחשב	התחשב	ADP	ADP	_	46	case	_	_
 44-46	במחיר	_	_	_	_	_	_	_	SpaceAfter=No
 44	ב	ב	ADP	ADP	_	43	fixed	_	_
@@ -16332,7 +16332,7 @@
 7	ה	ה	DET	DET	PronType=Art	8	det:def	_	_
 8	טבח	טבח	NOUN	NOUN	Gender=Masc|Number=Sing	5	conj	_	_
 9	של	של	ADP	ADP	Case=Gen	5	dep	_	_
-10	התגורר	התגורר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Tense=Past	0	root	_	_
+10	התגורר	התגורר	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Sing|Person=3|Root=ג.ו.ר|Tense=Past	0	root	_	_
 11-12	ברומא	_	_	_	_	_	_	_	_
 11	ב	ב	ADP	ADP	_	12	case	_	_
 12	רומא	רומא	PROPN	PROPN	_	10	obl	_	_
@@ -16357,7 +16357,7 @@
 26	מקומיים	מקומי	ADJ	ADJ	Gender=Masc|Number=Plur	20	amod	_	_
 27-28	שעבר	_	_	_	_	_	_	_	_
 27	ש	ש	SCONJ	SCONJ	_	28	mark	_	_
-28	עבר	עבר	VERB	VERB	Gender=Masc|Number=Sing|Person=3|Tense=Past	20	acl:relcl	_	_
+28	עבר	עבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ע.ב.ר|Tense=Past	20	acl:relcl	_	_
 29	חניכה	חניכה	NOUN	NOUN	Gender=Fem|Number=Sing	28	obj	_	_
 30	קולינארית	_	ADJ	ADJ	_	29	amod	_	_
 31-32	באיטליה	_	_	_	_	_	_	_	SpaceAfter=No
@@ -16367,7 +16367,7 @@
 
 # sent_id = 6209
 # text = יהיו אשר יהיו המעלות והחסרונות של האוכל במסעדה שלו, היא איטלקית לעילא.
-1	יהיו	_	VERB	VERB	Gender=Fem,Masc|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Tense=Fut	0	root	_	_
+1	יהיו	_	VERB	VERB	Gender=Fem,Masc|HebBinyan=PAAL|HebExistential=True|Number=Plur|Person=3|Polarity=Pos|Root=ה.י.י|Tense=Fut	0	root	_	_
 2	אשר	אשר	SCONJ	SCONJ	_	3	mark	_	_
 3	יהיו	_	AUX	AUX	Gender=Fem,Masc|Number=Plur|Person=3|Polarity=Pos|Tense=Fut|VerbType=Cop	1	advcl	_	_
 4-5	המעלות	_	_	_	_	_	_	_	_
@@ -16401,7 +16401,7 @@
 3	פרושוטו	פרושוטו	PROPN	PROPN	_	1	compound:smixut	_	_
 4-5	שהוגשו	_	_	_	_	_	_	_	_
 4	ש	ש	SCONJ	SCONJ	_	5	mark	_	_
-5	הוגשו	הוגש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Tense=Past|Voice=Pass	1	acl:relcl	_	_
+5	הוגשו	הוגש	VERB	VERB	Gender=Fem,Masc|HebBinyan=HUFAL|Number=Plur|Person=3|Root=נ.ג.ש|Tense=Past|Voice=Pass	1	acl:relcl	_	_
 6-7	במנת	_	_	_	_	_	_	_	_
 6	ב	ב	ADP	ADP	_	7	case	_	_
 7	מנת	מנה	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	1	nmod	_	_
@@ -16421,7 +16421,7 @@
 18	,	,	PUNCT	PUNCT	HebSource=ConvUncertainHead	17	dep	_	_
 19-20	שנצלה	_	_	_	_	_	_	_	_
 19	ש	ש	SCONJ	SCONJ	_	20	mark	_	_
-20	נצלה	נצלה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Tense=Past|Voice=Mid	17	dep	_	_
+20	נצלה	נצלה	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|HebSource=ConvUncertainHead|Number=Sing|Person=3|Root=צ.ל.י|Tense=Past|Voice=Mid	17	dep	_	_
 21-22	בגריל	_	_	_	_	_	_	_	_
 21	ב	ב	ADP	ADP	_	22	case	_	_
 22	גריל	גריל	NOUN	NOUN	Gender=Masc|Number=Sing	20	obl	_	_
@@ -16429,17 +16429,17 @@
 23	ו	ו	CCONJ	CCONJ	_	26	cc	_	_
 24	אחר	אחר	ADP	ADP	_	25	case	_	_
 25	כך	כך	PRON	PRON	Person=3|PronType=Dem	26	obl	_	_
-26	טוגן	טוגן	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Tense=Past|Voice=Pass	20	conj	_	SpaceAfter=No
+26	טוגן	טוגן	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=3|Root=ט.ג.נ|Tense=Past|Voice=Pass	20	conj	_	SpaceAfter=No
 27	,	,	PUNCT	PUNCT	_	29	punct	_	_
 28	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	29	cop	_	_
-29	ספוג	ספג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	13	conj	_	_
+29	ספוג	ספג	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=ס.פ.ג|VerbForm=Part|Voice=Act	13	conj	_	_
 30-31	בשמן	_	_	_	_	_	_	_	_
 30	ב	ב	ADP	ADP	_	31	case	_	_
 31	שמן	שמן	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Sing	29	obl	_	_
 32	זית	זית	NOUN	NOUN	Gender=Fem|Number=Sing	31	compound:smixut	_	_
 33-34	שפגם	_	_	_	_	_	_	_	_
 33	ש	ש	SCONJ	SCONJ	_	34	mark	_	_
-34	פגם	פגם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	31	acl:relcl	_	_
+34	פגם	פגם	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=פ.ג.מ|Tense=Past|Voice=Act	31	acl:relcl	_	_
 35-38	בטעמו	_	_	_	_	_	_	_	SpaceAfter=No
 35	ב	ב	ADP	ADP	_	36	case	_	_
 36	טעם_	טעם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	34	obl	_	_
@@ -16475,7 +16475,7 @@
 19	עשבי	עשב	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	16	conj	_	_
 20	תיבול	תיבול	NOUN	NOUN	Gender=Masc|Number=Sing	19	compound:smixut	_	_
 21	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	22	cop	_	_
-22	משפר	שיפר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	9	conj	_	_
+22	משפר	שיפר	VERB	VERB	Gender=Masc|HebBinyan=PIEL|Number=Sing|Person=1,2,3|Root=ש.פ.ר|VerbForm=Part|Voice=Act	9	conj	_	_
 23	את	את	ADP	ADP	Case=Acc	24	case:acc	_	_
 24-26	טעמה	_	_	_	_	_	_	_	SpaceAfter=No
 24	טעם_	טעם	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Sing	22	obj	_	_
@@ -16492,7 +16492,7 @@
 4	מאכלי	מאכל	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	2	nmod:poss	_	_
 5	ים	ים	NOUN	NOUN	Gender=Masc|Number=Sing	4	compound:smixut	_	_
 6	היה	_	AUX	AUX	Gender=Masc|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	7	cop	_	_
-7	מורכב	הורכב	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	0	root	_	_
+7	מורכב	הורכב	VERB	VERB	Gender=Masc|HebBinyan=HUFAL|Number=Sing|Person=1,2,3|Root=ר.כ.ב|VerbForm=Part|Voice=Pass	0	root	_	_
 8	בעיקר	בעיקר	ADV	ADV	_	10	advmod	_	_
 9-10	מזרועות	_	_	_	_	_	_	_	_
 9	מ	מ	ADP	ADP	_	10	case	_	_
@@ -16502,7 +16502,7 @@
 12	ו	ו	CCONJ	CCONJ	_	14	cc	_	_
 13	מ	מ	ADP	ADP	_	14	case	_	_
 14	חסילונים	חסילון	NOUN	NOUN	Gender=Masc|Number=Plur	10	conj	_	_
-15	מבושלים	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|VerbForm=Part|Voice=Pass	14	acl	_	_
+15	מבושלים	בושל	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Plur|Person=1,2,3|Root=ב.ש.ל|VerbForm=Part|Voice=Pass	14	acl	_	_
 16-17	ביין	_	_	_	_	_	_	_	_
 16	ב	ב	ADP	ADP	_	17	case	_	_
 17	יין	יין	NOUN	NOUN	Gender=Masc|Number=Sing	15	obl	_	_
@@ -16527,7 +16527,7 @@
 5	היתה	_	AUX	AUX	Gender=Fem|Number=Sing|Person=3|Polarity=Pos|Tense=Past|VerbType=Cop	6	cop	_	_
 6	טעימה	טעים	ADJ	ADJ	Gender=Fem|Number=Sing	8	advcl	_	SpaceAfter=No
 7	,	,	PUNCT	PUNCT	_	8	punct	_	_
-8	חסרה	חסר	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
+8	חסרה	חסר	VERB	VERB	Gender=Fem|HebBinyan=PAAL|Number=Sing|Person=3|Root=ח.ס.ר|Tense=Past	0	root	_	_
 9-10	בה	_	_	_	_	_	_	_	_
 9	ב_	ב	ADP	ADP	_	10	case	_	_
 10	_היא	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3|PronType=Prs	8	obl	_	_
@@ -16545,7 +16545,7 @@
 20	קורנית	קורנית	NOUN	NOUN	Gender=Fem|Number=Sing	18	nmod:poss	_	_
 21-22	האופייניים	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	mark	_	_
-22	אופייניים	אופייני	VERB	VERB	VerbForm=Part	12	acl:relcl	_	_
+22	אופייניים	אופייני	VERB	VERB	HebBinyan=_|Root=_|VerbForm=Part	12	acl:relcl	_	_
 23-24	בדרך	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	דרך	דרך	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	22	advmod	_	_
@@ -16573,7 +16573,7 @@
 1	הורה_	הורה	NOUN	NOUN	Definite=Def|Gender=Masc|Number=Plur	4	nsubj	_	_
 2	_של_	של	ADP	ADP	_	3	case:gen	_	_
 3	_הם	הוא	PRON	PRON	Case=Gen|Gender=Masc|Number=Plur|Person=3|PronType=Prs	1	nmod:poss	_	_
-4	האמינו	האמין	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	0	root	_	_
+4	האמינו	האמין	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=א.מ.נ|Tense=Past|Voice=Act	0	root	_	_
 5-7	ברפואה	_	_	_	_	_	_	_	_
 5	ב	ב	ADP	ADP	_	7	case	_	_
 6	ה_	ה	DET	DET	PronType=Art	7	det:def	_	_
@@ -16585,7 +16585,7 @@
 10	ו	ו	CCONJ	CCONJ	_	13	cc	_	_
 11	ה	ה	DET	DET	PronType=Art	12	det:def	_	_
 12	רופאים	רופא	NOUN	NOUN	Gender=Masc|Number=Plur	13	nsubj	_	_
-13	המליצו	המליץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Tense=Past|Voice=Act	4	conj	_	_
+13	המליצו	המליץ	VERB	VERB	Gender=Fem,Masc|HebBinyan=HIFIL|Number=Plur|Person=3|Root=מ.ל.צ|Tense=Past|Voice=Act	4	conj	_	_
 14	על	על	ADP	ADP	_	15	case	_	_
 15	פאראצטמול	פאראצטמול	PROPN	PROPN	_	13	obl	_	SpaceAfter=No
 16	,	,	PUNCT	PUNCT	_	15	punct	_	_

--- a/he_htb-ud-test.conllu
+++ b/he_htb-ud-test.conllu
@@ -4767,7 +4767,7 @@
 9	ה	ה	DET	DET	PronType=Art	10	det:def	_	_
 10	נדון	נדון	VERB	VERB	Gender=Masc|HebBinyan=NIFAL|Number=Sing|Person=1,2,3|Root=ד.ו.נ|VerbForm=Part|Voice=Mid	8	amod	_	_
 11	"	"	PUNCT	PUNCT	_	12	punct	_	SpaceAfter=No
-12	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Pass	3	ccomp	_	_
+12	מדובר	דובר	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=ד.ב.ר|VerbForm=Part|Voice=Pass	3	ccomp	_	_
 13-14	בתובענה	_	_	_	_	_	_	_	_
 13	ב	ב	ADP	ADP	_	14	case	_	_
 14	תובענה	תובענה	NOUN	NOUN	Gender=Fem|Number=Sing	12	obl	_	_
@@ -9233,7 +9233,7 @@
 23	"	"	PUNCT	PUNCT	_	25	punct	_	SpaceAfter=No
 24-25	משראה	_	_	_	_	_	_	_	SpaceAfter=No
 24	מש	מש	SCONJ	SCONJ	Case=Tem	25	mark	_	_
-25	ראה	ראה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Tense=Past|Voice=Act	15	advcl	_	_
+25	ראה	ראה	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=3|Root=ר.א.י|Tense=Past|Voice=Act	15	advcl	_	_
 26	"	"	PUNCT	PUNCT	_	25	punct	_	_
 27-28	שיש	_	_	_	_	_	_	_	_
 27	ש	ש	SCONJ	SCONJ	_	28	mark	_	_
@@ -10159,7 +10159,7 @@
 12	(	(	PUNCT	PUNCT	_	14	punct	_	SpaceAfter=No
 13-14	שהחל	_	_	_	_	_	_	_	_
 13	ש	ש	SCONJ	SCONJ	_	14	mark	_	_
-14	החל	החל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Tense=Past|Voice=Act	10	appos	_	_
+14	החל	החל	VERB	VERB	Gender=Masc|HebBinyan=HIFIL|Number=Sing|Person=3|Root=ח.ל.ל|Tense=Past|Voice=Act	10	appos	_	_
 15	להוציא	הוציא	VERB	VERB	HebBinyan=HIFIL|Root=י.צ.א|VerbForm=Inf|Voice=Act	14	xcomp	_	_
 16-18	לאור	_	_	_	_	_	_	_	_
 16	ל	ל	ADP	ADP	_	18	case	_	_

--- a/he_htb-ud-test.conllu
+++ b/he_htb-ud-test.conllu
@@ -8592,7 +8592,7 @@
 3-4	הראשונה	_	_	_	_	_	_	_	_
 3	ה	ה	DET	DET	PronType=Art	4	det:def	_	_
 4	ראשונה	_	ADJ	ADJ	Gender=Fem|Number=Sing	2	amod	_	_
-5	תוקם	הוקם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ק.ו.ם|Tense=Fut|Voice=Pass	0	root	_	_
+5	תוקם	הוקם	VERB	VERB	Gender=Fem|HebBinyan=HUFAL|Number=Sing|Person=3|Root=ק.ו.מ|Tense=Fut|Voice=Pass	0	root	_	_
 6	באמצעות	באמצעות	ADP	ADP	_	7	case	_	_
 7	איחוד	איחוד	NOUN	NOUN	Gender=Masc|Number=Sing	5	obl	_	_
 8	מנהלי	מנהלי	ADJ	ADJ	Gender=Masc|Number=Sing	7	amod	_	_

--- a/he_htb-ud-test.conllu
+++ b/he_htb-ud-test.conllu
@@ -10300,7 +10300,7 @@
 1	ב	ב	ADP	ADP	_	3	case	_	_
 2	ה_	ה	DET	DET	PronType=Art	3	det:def	_	_
 3	המשך	המשך	NOUN	NOUN	Gender=Masc|Number=Sing	4	obl	_	_
-4	ישנה	_	VERB	VERB	Gender=Fem|HebBinyan=_|Number=Sing|Person=3|Root=_|Tense=Past	0	root	_	_
+4	ישנה	_	VERB	VERB	Gender=Fem|Number=Sing|Person=3|Tense=Past	0	root	_	_
 5	אנציקלופדיה	אנציקלופדיה	NOUN	NOUN	Gender=Fem|Number=Sing	4	nsubj	_	_
 6	זעירה	זעיר	ADJ	ADJ	Gender=Fem|Number=Sing	5	amod	_	_
 7-8	המפרטת	_	_	_	_	_	_	_	_
@@ -11626,7 +11626,7 @@
 54	ה	ה	DET	DET	PronType=Art	55	det:def	_	_
 55	מקוריות	מקורי	ADJ	ADJ	Gender=Fem|Number=Plur	50	conj	_	_
 56	מבני	מבנה	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	48	nsubj	_	_
-57	צבור	צבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|Root=_|VerbForm=Part|Voice=Act	56	compound:smixut	_	SpaceAfter=No
+57	צבור	צבר	VERB	VERB	Gender=Masc|HebBinyan=PAAL|Number=Sing|Person=1,2,3|VerbForm=Part|Voice=Act	56	compound:smixut	_	SpaceAfter=No
 58	.	.	PUNCT	PUNCT	_	34	punct	_	_
 
 # sent_id = 6070
@@ -14513,7 +14513,7 @@
 22	סוגי	סוג	NOUN	NOUN	Definite=Cons|Gender=Masc|Number=Plur	18	conj	_	_
 23	הרינג	הרינג	NOUN	NOUN	Gender=Masc|Number=Sing	22	compound:smixut	_	SpaceAfter=No
 24	,	,	PUNCT	PUNCT	_	18	punct	_	_
-25	מתאבנים	התאבן	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|Root=_|VerbForm=Part	18	conj	_	_
+25	מתאבנים	התאבן	VERB	VERB	Gender=Masc|HebBinyan=HITPAEL|Number=Plur|Person=1,2,3|VerbForm=Part	18	conj	_	_
 26	קרים	קר	ADJ	ADJ	Gender=Masc|Number=Plur	25	amod	_	_
 27	אחרים	אחר	ADJ	ADJ	Gender=Masc|Number=Plur	25	amod	_	_
 28-29	ותצוגה	_	_	_	_	_	_	_	_
@@ -14865,7 +14865,7 @@
 13	יפו	יפו	PROPN	PROPN	_	9	nmod	_	_
 14	,	,	PUNCT	PUNCT	_	15	punct	_	_
 15	ממונה	מונה	VERB	VERB	Gender=Masc|HebBinyan=PUAL|Number=Sing|Person=1,2,3|Root=מ.נ.י|VerbForm=Part|Voice=Pass	0	root	_	_
-16	כאן	כאן	VERB	VERB	HebBinyan=_|HebSource=ConvUncertainHead|Root=_|VerbForm=Part	15	dep	_	_
+16	כאן	כאן	VERB	VERB	HebSource=ConvUncertainHead|VerbForm=Part	15	dep	_	_
 17	על	על	ADP	ADP	_	19	case	_	_
 18-19	המטבח	_	_	_	_	_	_	_	_
 18	ה	ה	DET	DET	PronType=Art	19	det:def	_	_
@@ -16545,7 +16545,7 @@
 20	קורנית	קורנית	NOUN	NOUN	Gender=Fem|Number=Sing	18	nmod:poss	_	_
 21-22	האופייניים	_	_	_	_	_	_	_	_
 21	ה	ה	DET	DET	PronType=Art	22	mark	_	_
-22	אופייניים	אופייני	VERB	VERB	HebBinyan=_|Root=_|VerbForm=Part	12	acl:relcl	_	_
+22	אופייניים	אופייני	VERB	VERB	VerbForm=Part	12	acl:relcl	_	_
 23-24	בדרך	_	_	_	_	_	_	_	_
 23	ב	ב	ADP	ADP	_	24	case	_	_
 24	דרך	דרך	NOUN	NOUN	Definite=Cons|Gender=Fem|Number=Sing	22	advmod	_	_


### PR DESCRIPTION
Contributed by Sara Gershuni saragershuni@gmail.com

Roots are added to `feats` in the form of `|Root=א.כ.ל`.
Sin is represented as the character pair `שׂ`.

Some verbs are invalid (many instances of יש, אין, for example). Those are left unchanged.
The `HebBinyan` of some verbs is analyzed incorrectly. Those are left unchanged. Some are missing, and they are updated.